### PR TITLE
Large code documentation update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,3 +70,22 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  docs:
+    name: docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Install minimal stable with rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+          override: true
+
+      - name: Run cargo doc on release profile
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --lib -r

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to this library
+We want to make contributing to this project as easy and transparent as
+possible.
+
+## Pull Requests
+We actively welcome your pull requests.
+
+1. Fork the repo and create your branch from `main`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes.
+5. If you haven't already, complete the Contributor License Agreement ("CLA").
+
+## Issues
+We use GitHub issues to track public bugs. Please ensure your description is
+clear and has sufficient instructions to be able to reproduce the issue.
+
+## License
+By contributing to `ractor`, you agree that your contributions will be
+licensed under the LICENSE file in the root directory of this source tree.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # ractor
 
-A Rust actor framework.
+A pure-Rust actor framework. Inspired from [Erlang's `gen_server`](https://www.erlang.org/doc/man/gen_server.html), with the speed + performance of Rust!
 
 ## About
 
-Ractor tries to solve the problem of building and maintaing an Erlang-like actor framework in Rust. It gives
-a set of generic primitives and helps automate the supervision tree. It's built *heavily* on `tokio` which is a
+`ractor` tries to solve the problem of building and maintaing an Erlang-like actor framework in Rust. It gives
+a set of generic primitives and helps automate the supervision tree and management of our actors along with the traditional actor message processing logic. It's built *heavily* on `tokio` which is a
 hard requirement for `ractor`. 
+
+`ractor` is a modern actor framework written in 100% rust with NO `unsafe` code. 
 
 ## Installation
 
@@ -16,3 +18,102 @@ Install `ractor` by adding the following to your Cargo.toml dependencies
 [dependencies]
 ractor = "0.1"
 ```
+
+## Working with Actors
+
+Actors in `ractor` are very lightweight and can be treated as thread-safe. Each actor will only call one of it's handler functions at a time, and they will
+never be executed in parallel. Following the actor model leads to microservices with well-defined state and processing logic.
+
+An example `ping-pong` actor might be the following
+
+```rust
+use ractor::{Actor, ActorCell, ActorHandler};
+
+/// [PingPong] is a basic actor that will print
+/// ping..pong.. repeatedly until some exit
+/// condition is met (a counter hits 10). Then
+/// it will exit
+pub struct PingPong;
+
+/// This is the types of message [PingPong] supports
+#[derive(Debug, Clone)]
+pub enum Message {
+    Ping,
+    Pong,
+}
+
+impl Message {
+    // retrieve the next message in the sequence
+    fn next(&self) -> Self {
+        match self {
+            Self::Ping => Self::Pong,
+            Self::Pong => Self::Ping,
+        }
+    }
+    // print out this message
+    fn print(&self) {
+        match self {
+            Self::Ping => print!("ping.."),
+            Self::Pong => print!("pong.."),
+        }
+    }
+}
+
+// the implementation of our actor's "logic"
+#[async_trait::async_trait]
+impl ActorHandler for PingPong {
+    // An actor has a message type
+    type Msg = Message;
+    // and (optionally) internal state
+    type State = u8;
+
+    // Initially we need to create our state, and potentially
+    // start some internal processing (by posting a message for
+    // example)
+    async fn pre_start(&self, myself: ActorCell) -> Self::State {
+        // startup the event processing
+        self.send_message(myself, Message::Ping).unwrap();
+        0u8
+    }
+
+    // This is our main message handler
+    async fn handle(
+        &self,
+        myself: ActorCell,
+        message: Self::Msg,
+        state: &Self::State,
+    ) -> Option<Self::State> {
+        if *state < 10u8 {
+            message.print();
+            self.send_message(myself, message.next()).unwrap();
+            Some(*state + 1)
+        } else {
+            myself.stop();
+            // don't send another message, rather stop the agent after 10 iterations
+            None
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let (_, actor_handle) = Actor::spawn(None, PingPong).await.expect("Failed to start actor");
+    actor_handle.await.expect("Actor failed to exit cleanly");
+}
+```
+
+which will output
+
+```bash
+$ cargo run
+ping..pong..ping..pong..ping..pong..ping..pong..ping..pong..
+$ 
+```
+
+## Contributors
+
+The original authors of `ractor` are Sean Lawlor (@slawlor), Dillon George (@dillonrg), and Evan Au (@afterdusk). To learn more about contributing to `ractor` please see [CONTRIBUTING.md](https://github.com/slawlor/ractor/blob/main/CONTRIBUTING.md)
+
+## License
+
+This project is licensed under [MIT](https://github.com/slawlor/ractor/blob/main/LICENSE).

--- a/ractor-repl/src/main.rs
+++ b/ractor-repl/src/main.rs
@@ -5,11 +5,13 @@
 
 mod ping_pong;
 
+use ractor::Actor;
+
 // MAIN //
 #[tokio::main]
 async fn main() {
-    let actor_handler = ping_pong::PingPong;
-    let (the_actor, ports) = ractor::Actor::new(None, actor_handler);
-    let (_actor_ref, actor_handle) = the_actor.start(ports, None).await.unwrap();
-    actor_handle.await.unwrap();
+    let (_, actor_handle) = Actor::spawn(None, ping_pong::PingPong)
+        .await
+        .expect("Failed to start actor");
+    actor_handle.await.expect("Actor failed to exit cleanly");
 }

--- a/ractor/src/actor/supervision.rs
+++ b/ractor/src/actor/supervision.rs
@@ -4,6 +4,12 @@
 // LICENSE-MIT file in the root directory of this source tree.
 
 //! Supervision management logic
+//!
+//! Supervision is a special notion of "ownership" over actors by a parent (supervisor).
+//! Supervisors are responsible for the lifecycle of a child actor such that they get notified
+//! when a child actor starts, stops, or panics (when possible). The supervisor can then decide
+//! how to handle the event. Should it restart the actor, leave it dead, potentially die itself
+//! notifying the supervisor's supervisor? That's up to the implementation of the [super::ActorHandler]
 
 use std::sync::Arc;
 

--- a/ractor/src/actor/tests/mod.rs
+++ b/ractor/src/actor/tests/mod.rs
@@ -24,8 +24,6 @@ async fn test_panic_on_start_captured() {
         }
     }
 
-    let (actor, ports) = Actor::new(None, TestActor);
-    let actor_output = actor.start(ports, None).await;
-
+    let actor_output = Actor::spawn(None, TestActor).await;
     assert!(matches!(actor_output, Err(SpawnErr::StartupPanic(_))));
 }

--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -69,17 +69,13 @@ async fn test_supervision_panic_in_post_startup() {
 
     let flag = Arc::new(AtomicU64::new(0));
 
-    let (supervisor, supervisor_ports) = Actor::new(None, Supervisor { flag: flag.clone() });
-    let (supervisor_ref, s_handle) = supervisor
-        .start(supervisor_ports, None)
+    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() })
         .await
         .expect("Supervisor panicked on startup");
 
     let supervisor_tree = supervisor_ref.get_tree();
 
-    let (child, child_ports) = Actor::new(None, Child);
-    let (child_ref, c_handle) = child
-        .start(child_ports, Some(supervisor_ref))
+    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, supervisor_ref)
         .await
         .expect("Child panicked on startup");
 
@@ -147,17 +143,13 @@ async fn test_supervision_panic_in_handle() {
 
     let flag = Arc::new(AtomicU64::new(0));
 
-    let (supervisor, supervisor_ports) = Actor::new(None, Supervisor { flag: flag.clone() });
-    let (supervisor_ref, s_handle) = supervisor
-        .start(supervisor_ports, None)
+    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() })
         .await
         .expect("Supervisor panicked on startup");
 
     let supervisor_tree = supervisor_ref.get_tree();
 
-    let (child, child_ports) = Actor::new(None, Child);
-    let (child_ref, c_handle) = child
-        .start(child_ports, Some(supervisor_ref))
+    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, supervisor_ref)
         .await
         .expect("Child panicked on startup");
 
@@ -232,17 +224,13 @@ async fn test_supervision_panic_in_post_stop() {
 
     let flag = Arc::new(AtomicU64::new(0));
 
-    let (supervisor, supervisor_ports) = Actor::new(None, Supervisor { flag: flag.clone() });
-    let (supervisor_ref, s_handle) = supervisor
-        .start(supervisor_ports, None)
+    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() })
         .await
         .expect("Supervisor panicked on startup");
 
     let supervisor_tree = supervisor_ref.get_tree();
 
-    let (child, child_ports) = Actor::new(None, Child);
-    let (child_ref, c_handle) = child
-        .start(child_ports, Some(supervisor_ref))
+    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, supervisor_ref)
         .await
         .expect("Child panicked on startup");
 
@@ -339,18 +327,14 @@ async fn test_supervision_panic_in_supervisor_handle() {
 
     let supervisor_tree = supervisor_ref.get_tree();
 
-    let (midpoint, midpoint_ports) = Actor::new(None, Midpoint);
-    let (midpoint_ref, m_handle) = midpoint
-        .start(midpoint_ports, Some(supervisor_ref))
+    let (midpoint_ref, m_handle) = Actor::spawn_linked(None, Midpoint, supervisor_ref)
         .await
         .expect("Midpoint actor failed to startup");
 
     let midpoint_tree = midpoint_ref.get_tree();
     let midpoint_ref_clone = midpoint_ref.clone();
 
-    let (child, child_ports) = Actor::new(None, Child);
-    let (child_ref, c_handle) = child
-        .start(child_ports, Some(midpoint_ref))
+    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, midpoint_ref)
         .await
         .expect("Child panicked on startup");
 
@@ -408,17 +392,13 @@ async fn test_killing_a_supervisor_terminates_children() {
         }
     }
 
-    let (supervisor, supervisor_ports) = Actor::new(None, Supervisor);
-    let (supervisor_ref, s_handle) = supervisor
-        .start(supervisor_ports, None)
+    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor)
         .await
         .expect("Supervisor panicked on startup");
 
     let supervisor_tree = supervisor_ref.get_tree();
 
-    let (child, child_ports) = Actor::new(None, Child);
-    let (child_ref, c_handle) = child
-        .start(child_ports, Some(supervisor_ref.clone()))
+    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, supervisor_ref.clone())
         .await
         .expect("Child panicked on startup");
 

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -3,8 +3,120 @@
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree.
 
-//! An actor framework for Rust
+//! `ractor`: A pure-Rust actor framework. Inspired from [Erlang's `gen_server`](https://www.erlang.org/doc/man/gen_server.html),
+//! with the speed + performance of Rust!
+//!
+//! ## Installation
+//!
+//! Install `ractor` by adding the following to your Cargo.toml dependencies
+//!
+//! ```toml
+//! [dependencies]
+//! ractor = "0.1"
+//! ```
+//!
+//! ## Getting started
+//!
+//! An example "ping-pong" actor might be the following
+//!
+//! ```rust
+//! use ractor::{Actor, ActorCell, ActorHandler};
+//!
+//! /// [PingPong] is a basic actor that will print
+//! /// ping..pong.. repeatedly until some exit
+//! /// condition is met (a counter hits 10). Then
+//! /// it will exit
+//! pub struct PingPong;
+//!
+//! /// This is the types of message [PingPong] supports
+//! #[derive(Debug, Clone)]
+//! pub enum Message {
+//!     Ping,
+//!     Pong,
+//! }
+//!
+//! impl Message {
+//!     // retrieve the next message in the sequence
+//!     fn next(&self) -> Self {
+//!         match self {
+//!             Self::Ping => Self::Pong,
+//!             Self::Pong => Self::Ping,
+//!         }
+//!     }
+//!     // print out this message
+//!     fn print(&self) {
+//!         match self {
+//!             Self::Ping => print!("ping.."),
+//!             Self::Pong => print!("pong.."),
+//!         }
+//!     }
+//! }
+//!
+//! // the implementation of our actor's "logic"
+//! #[async_trait::async_trait]
+//! impl ActorHandler for PingPong {
+//!     // An actor has a message type
+//!     type Msg = Message;
+//!     // and (optionally) internal state
+//!     type State = u8;
+//!
+//!     // Initially we need to create our state, and potentially
+//!     // start some internal processing (by posting a message for
+//!     // example)
+//!     async fn pre_start(&self, myself: ActorCell) -> Self::State {
+//!         // startup the event processing
+//!         self.send_message(myself, Message::Ping).unwrap();
+//!         0u8
+//!     }
+//!
+//!     // This is our main message handler
+//!     async fn handle(
+//!         &self,
+//!         myself: ActorCell,
+//!         message: Self::Msg,
+//!         state: &Self::State,
+//!     ) -> Option<Self::State> {
+//!         if *state < 10u8 {
+//!             message.print();
+//!             self.send_message(myself, message.next()).unwrap();
+//!             Some(*state + 1)
+//!         } else {
+//!             myself.stop();
+//!             // don't send another message, rather stop the agent after 10 iterations
+//!             None
+//!         }
+//!     }
+//! }
+//!
+//! async fn run() {
+//!     let (_, actor_handle) = Actor::spawn(None, PingPong).await.expect("Failed to start actor");
+//!     actor_handle.await.expect("Actor failed to exit cleanly");
+//! }
+//! ```
+//!
+//! which will output
+//!
+//! ```bash
+//! $ cargo run
+//! ping..pong..ping..pong..ping..pong..ping..pong..ping..pong..
+//! $
+//! ```
+//!
+//! ## Supervision
+//!
+//! Actors in `ractor` also support supervision. This is done by "linking" actors together in a supervisor-child relationship.
+//! A supervisor is "responsible" for the child actor, and as such is notified when the actor starts, stops, and fails (panics).
+//!
+//! Supervision is presently left to the implementor, but you can see a suite of supervision tests in `crate::actor::tests::supervisor`
+//! for examples on the supported functionality.
+//!
+//! NOTE: panic's in `pre_start` of an actor will cause failures to spawn, rather than supervision notified failurs as the actor hasn't "linked"
+//! to its supervisor yet. However failures in `post_start`, `handle`, `handle_supervisor_evt`, `post_stop` will notify the supervisor should a failure
+//! occur. See [crate::ActorHandler] documentation for more information
 
+#![deny(warnings)]
+#![warn(unused_imports)]
+#![warn(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(unused_crate_dependencies)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/ractor/src/port/mod.rs
+++ b/ractor/src/port/mod.rs
@@ -12,14 +12,14 @@ use crate::MessagingErr;
 
 // ============ Input Ports ============ //
 
-/// A bounded imput port (alias of [mpsc::Sender])
+/// A bounded-depth message port (alias of [mpsc::Sender])
 pub(crate) type BoundedInputPort<TMsg> = mpsc::Sender<TMsg>;
-/// A bounded imput port (alias of [mpsc::Receiver])
+/// A bounded-depth message port's receiver (alias of [mpsc::Receiver])
 pub(crate) type BoundedInputPortReceiver<TMsg> = mpsc::Receiver<TMsg>;
 
-/// An import-port (alias of [mpsc::UnboundedSender])
+/// An unbounded message port (alias of [mpsc::UnboundedSender])
 pub type InputPort<TMsg> = mpsc::UnboundedSender<TMsg>;
-/// An input port's receiver (alias of [mpsc::UnboundedReceiver])
+/// An unbounded message port's receiver (alias of [mpsc::UnboundedReceiver])
 pub(crate) type InputPortReceiver<TMsg> = mpsc::UnboundedReceiver<TMsg>;
 
 // ============ Output Ports ============ //
@@ -29,19 +29,27 @@ pub(crate) type InputPortReceiver<TMsg> = mpsc::UnboundedReceiver<TMsg>;
 
 // ============ Rpc (one-use) Ports ============ //
 
-/// A RPC's reply port. Wrapper of [tokio::sync::oneshot::Sender] with a consistent
-/// error type
+/// A remote procedure call's reply port. Wrapper of [tokio::sync::oneshot::Sender] with a
+/// consistent error type
 pub struct RpcReplyPort<TMsg> {
     port: oneshot::Sender<TMsg>,
 }
 
 impl<TMsg> RpcReplyPort<TMsg> {
     /// Send a message to the Rpc reply port. This consumes the port
+    ///
+    /// * `msg` - The message to send
+    ///
+    /// Returns [Ok(())] if the message send was successful, [Err(MessagingErr)] otherwise
     pub fn send(self, msg: TMsg) -> Result<(), MessagingErr> {
         self.port.send(msg).map_err(|_| MessagingErr::ChannelClosed)
     }
 
     /// Determine if the port is closed (i.e. the receiver has been dropped)
+    ///
+    /// Returns [true] if the receiver has been dropped and the channel is
+    /// closed, this means sends will fail, [false] if channel is open and
+    /// receiving messages
     pub fn is_closed(&self) -> bool {
         self.port.is_closed()
     }

--- a/ractor/src/rpc/mod.rs
+++ b/ractor/src/rpc/mod.rs
@@ -18,6 +18,11 @@ mod tests;
 
 /// Sends an asynchronous request to the specified actor, ignoring if the
 /// actor is alive or healthy and simply returns immediately
+///
+/// * `actor` - A reference to the [ActorCell] to communicate with
+/// * `msg` - The message to send to the actor
+///
+/// Returns [Ok(())] upon successful send, [Err(MessagingErr)] otherwise
 pub fn cast<TActor, TMsg>(actor: &ActorCell, msg: TMsg) -> Result<(), MessagingErr>
 where
     TActor: ActorHandler<Msg = TMsg>,
@@ -28,6 +33,14 @@ where
 
 /// Sends an asynchronous request to the specified actor, building a one-time
 /// use reply channel and awaiting the result with the specified timeout
+///
+/// * `actor` - A reference to the [ActorCell] to communicate with
+/// * `msg_builder` - The [FnOnce] to construct the message
+/// * `timeout_option` - An optional [Duration] which represents the amount of
+/// time until the operation times out
+///
+/// Returns [Ok(CallResult)] upon successful initial sending with the reply from
+/// the [crate::Actor], [Err(MessagingErr)] if the initial send operation failed
 pub async fn call<TActor, TMsg, TReply, TMsgBuilder>(
     actor: &ActorCell,
     msg_builder: TMsgBuilder,
@@ -59,6 +72,14 @@ where
 /// Send a message asynchronously to another actor, waiting in a new task for the reply
 /// and then forwaring the reply to a followup-actor. If this [CallResult] from the first
 /// actor is not success, the forward is not sent.
+///
+/// * `actor` - A reference to the [ActorCell] to communicate with
+/// * `msg_builder` - The [FnOnce] to construct the message
+/// * `response_forward` - The [ActorCell] to forward the message to
+/// * `forward_mapping` - The [FnOnce] which maps the response from the `actor` [ActorCell]'s reply message
+/// type to the `response_forward` [ActorCell]'s message type
+/// * `timeout_option` - An optional [Duration] which represents the amount of
+/// time until the operation times out
 ///
 /// Returns: A [JoinHandle<CallResult<()>>] which can be awaited to see if the
 /// forward was successful or ignored

--- a/ractor/src/rpc/tests.rs
+++ b/ractor/src/rpc/tests.rs
@@ -40,16 +40,14 @@ async fn test_rpc_cast() {
         }
     }
 
-    let (actor, ports) = Actor::new(
+    let (actor_ref, handle) = Actor::spawn(
         None,
         TestActor {
             counter: counter.clone(),
         },
-    );
-    let (actor_ref, handle) = actor
-        .start(ports, None)
-        .await
-        .expect("Failed to start test actor");
+    )
+    .await
+    .expect("Failed to start test actor");
 
     rpc::cast::<TestActor, _>(&actor_ref, ()).expect("Failed to send message");
     actor_ref
@@ -102,9 +100,7 @@ async fn test_rpc_call() {
         }
     }
 
-    let (actor, ports) = Actor::new(None, TestActor);
-    let (actor_ref, handle) = actor
-        .start(ports, None)
+    let (actor_ref, handle) = Actor::spawn(None, TestActor)
         .await
         .expect("Failed to start test actor");
 
@@ -198,22 +194,18 @@ async fn test_rpc_call_forwarding() {
         }
     }
 
-    let (worker, ports) = Actor::new(None, Worker);
-    let (worker_ref, worker_handle) = worker
-        .start(ports, None)
+    let (worker_ref, worker_handle) = Actor::spawn(None, Worker)
         .await
         .expect("Failed to start worker actor");
 
-    let (forwarder, ports) = Actor::new(
+    let (forwarder_ref, forwarder_handle) = Actor::spawn(
         None,
         Forwarder {
             counter: counter.clone(),
         },
-    );
-    let (forwarder_ref, forwarder_handle) = forwarder
-        .start(ports, None)
-        .await
-        .expect("Failed to start forwarder actor");
+    )
+    .await
+    .expect("Failed to start forwarder actor");
 
     let forward_handle = rpc::call_and_forward::<Worker, Forwarder, _, _, _, _, _>(
         &worker_ref,

--- a/ractor/src/time/mod.rs
+++ b/ractor/src/time/mod.rs
@@ -13,7 +13,14 @@ use crate::{ActorCell, ActorHandler, Message, MessagingErr, ACTIVE_STATES};
 mod tests;
 
 /// Sends a message to a given actor repeatedly after a specifid time
-/// using the provided message generation function
+/// using the provided message generation function. The task will exit
+/// once the channel is closed (meaning the underlying [crate::Actor]
+/// has terminated)
+///
+/// * `period` - The [Duration] representing the period for the send interval
+/// * `actor` - The [ActorCell] representing the [crate::Actor] to communicate with
+/// * `msg` - The [Fn] message builder which is called to generate a message for each send
+/// operation
 ///
 /// Returns: The [JoinHandle] which represents the backgrounded work (can be ignored to
 /// "fire and forget")
@@ -35,10 +42,17 @@ where
     })
 }
 
-/// Sends a message after a given period to the specified actor.
+/// Sends a message after a given period to the specified actor. The task terminates
+/// once the send has completed
 ///
-/// Returns: The [JoinHandle] which represents the backgrounded work. Awaiting the handle
-/// will yield the result of the send operation. Can be safely ignored to "fire and forget"
+/// * `period` - The [Duration] representing the time to delay before sending
+/// * `actor` - The [ActorCell] representing the [crate::Actor] to communicate with
+/// * `msg` - The [Fn] message builder which is called to generate a message for the send
+/// operation
+///
+/// Returns: The [JoinHandle<Result<(), MessagingErr>>] which represents the backgrounded work.
+/// Awaiting the handle will yield the result of the send operation. Can be safely ignored to
+/// "fire and forget"
 pub fn send_after<TActor, TMsg, F>(
     period: Duration,
     actor: ActorCell,
@@ -56,6 +70,9 @@ where
 }
 
 /// Sends the [crate::Signal::Exit] signal to the actor after a specified duration
+///
+/// * `period` - The [Duration] representing the time to delay before sending
+/// * `actor` - The [ActorCell] representing the [crate::Actor] to exit after the duration
 ///
 /// Returns: The [JoinHandle] which denotes the backgrounded operation. To cancel the
 /// exit operation, you can abort the handle to cancel the work.


### PR DESCRIPTION
Includes struct, trait, and function documentation with inputs + outputs documented. Additionally I've changed the visibility of `Actor::new` and `Actor::start` in favor of `spawn` and `spawn_linked`.

This is because we can now hide the usage of `ActorPortSet` outside of `ractor`

Blocked on #6 and a rebase