### PR TITLE
Make the stop port separate from signal port so we don't cancel async work on graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ impl ActorHandler for PingPong {
             self.send_message(myself, message.next()).unwrap();
             Some(*state + 1)
         } else {
-            myself.stop();
+            myself.stop(None);
             // don't send another message, rather stop the agent after 10 iterations
             None
         }
@@ -109,6 +109,21 @@ $ cargo run
 ping..pong..ping..pong..ping..pong..ping..pong..ping..pong..
 $ 
 ```
+
+## Messaging actors
+
+The means of communication between actors is that they pass messages to each other. A developer can define any message type which is `Send + 'static` and it
+will be supported by `ractor`. There are 4 concurrent message types, which are listened to in priority. They are
+
+1. Signals: Signals are the highest-priority of all and will interrupt the actor wherever processing currently is (this includes terminating async work). There
+is only 1 signal today, which is `Signal::Kill`, and it immediately terminates all work. This includes message processing or supervision event processing.
+2. Stop: There is also a pre-defined stop signal. You can give a "stop reason" if you want, but it's optional. Stop is a graceful exit, meaning currently executing async
+work will complete, and on the next message processing iteration Stop will take prioritity over future supervision events or regular messages. It will **not** terminate
+currently executing work, regardless of the provided reason.
+3. SupervisionEvent: Supervision events are messages from child actors to their supervisors in the event of their startup, death, and/or unhandled panic. Supervision events
+are how an actor's supervisor(s) are notified of events of their children and can handle lifetime events for them.
+4. Messages: Regular, user-defined, messages are the last channel of communication to actors. They are the lowest priority of the 4 message types and denote general actor work. The first 
+3 messages types (signals, stop, supervision) are generally quiet unless it's a lifecycle event for the actor, but this channel is the "work" channel doing what your actor wants to do!
 
 ## Contributors
 

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -13,3 +13,6 @@ readme = "../README.md"
 async-trait = "0.1"
 dashmap = "5"
 tokio = { version = "1.23", features = ["rt", "time", "sync", "macros"]}
+
+[dev-dependencies]
+tokio = { version = "1.23", features = ["rt", "time", "sync", "macros", "rt-multi-thread"] }

--- a/ractor/examples/counter.rs
+++ b/ractor/examples/counter.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! A basic counting agent. Demonstrates remote procedure calls to interact
+//! with the agent externally and safely acquire the "count"
+//!
+//! Execute with
+//!
+//! ```text
+//! cargo run --example counter
+//! ```
+
+extern crate ractor;
+
+use ractor::{rpc, Actor, ActorCell, ActorHandler, RpcReplyPort};
+use tokio::time::Duration;
+
+struct Counter;
+
+#[derive(Clone)]
+struct CounterState {
+    count: i64,
+}
+
+enum CounterMessage {
+    Increment(i64),
+    Decrement(i64),
+    Retrieve(RpcReplyPort<i64>),
+}
+
+#[async_trait::async_trait]
+impl ActorHandler for Counter {
+    type Msg = CounterMessage;
+
+    type State = CounterState;
+
+    async fn pre_start(&self, _myself: ActorCell) -> Self::State {
+        // create the initial state
+        CounterState { count: 0 }
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorCell,
+        message: Self::Msg,
+        state: &Self::State,
+    ) -> Option<Self::State> {
+        match message {
+            CounterMessage::Increment(how_much) => Some(CounterState {
+                count: state.count + how_much,
+            }),
+            CounterMessage::Decrement(how_much) => Some(CounterState {
+                count: state.count - how_much,
+            }),
+            CounterMessage::Retrieve(reply_port) => {
+                if !reply_port.is_closed() {
+                    reply_port.send(state.count).unwrap();
+                }
+                None
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let (actor, handle) = Actor::spawn(None, Counter)
+        .await
+        .expect("Failed to start actor!");
+
+    // +5 +10 -5 a few times, printing the value via RPC
+    for _i in 0..4 {
+        actor
+            .send_message::<Counter>(CounterMessage::Increment(5))
+            .expect("Failed to send message");
+        actor
+            .send_message::<Counter>(CounterMessage::Increment(10))
+            .expect("Failed to send message");
+        actor
+            .send_message::<Counter>(CounterMessage::Decrement(5))
+            .expect("Failed to send message");
+
+        let rpc_result = rpc::call::<Counter, _, _>(
+            &actor,
+            CounterMessage::Retrieve,
+            Some(Duration::from_millis(10)),
+        )
+        .await
+        .expect("Failed to send RPC");
+
+        println!(
+            "Count is: {}",
+            rpc_result.expect("RPC failed to reply successfully")
+        );
+    }
+
+    actor.stop(None);
+    handle.await.expect("Actor failed to exit cleanly");
+}

--- a/ractor/src/actor/messages.rs
+++ b/ractor/src/actor/messages.rs
@@ -93,6 +93,14 @@ impl Debug for BoxedMessage {
     }
 }
 
+/// Messages to stop an actor
+pub(crate) enum StopMessage {
+    // Normal stop
+    Stop,
+    /// Stop with a reason
+    Reason(String),
+}
+
 /// A supervision event from the supervision tree
 #[derive(Debug)]
 pub enum SupervisionEvent {
@@ -135,6 +143,6 @@ impl SupervisionEvent {
 /// A signal message which takes priority above all else
 #[derive(Clone, Debug)]
 pub enum Signal {
-    /// Exit, cancelling all async work immediately
-    Exit,
+    /// Terminate the agent, cancelling all async work immediately
+    Kill,
 }

--- a/ractor/src/actor/supervision.rs
+++ b/ractor/src/actor/supervision.rs
@@ -76,13 +76,12 @@ impl SupervisionTree {
     }
 
     /// Send a notification to all supervisors
-    pub fn notify_supervisors<TActor, TState>(&self, evt: SupervisionEvent)
+    pub fn notify_supervisors<TActor>(&self, evt: SupervisionEvent)
     where
-        TActor: ActorHandler<State = TState>,
-        TState: crate::State,
+        TActor: ActorHandler,
     {
         for kvp in self.parents.iter() {
-            let evt_clone = evt.duplicate::<TState>().unwrap();
+            let evt_clone = evt.duplicate::<TActor::State>().unwrap();
             let _ = kvp.value().send_supervisor_evt(evt_clone);
         }
     }

--- a/ractor/src/actor/tests/mod.rs
+++ b/ractor/src/actor/tests/mod.rs
@@ -5,7 +5,14 @@
 
 //! General tests, more logic-specific tests are contained in sub-modules
 
-use crate::{Actor, ActorHandler, SpawnErr};
+use std::sync::{
+    atomic::{AtomicU8, Ordering},
+    Arc,
+};
+
+use tokio::time::Duration;
+
+use crate::{Actor, ActorCell, ActorHandler, ActorStatus, SpawnErr, SupervisionEvent};
 
 mod supervisor;
 
@@ -26,4 +33,197 @@ async fn test_panic_on_start_captured() {
 
     let actor_output = Actor::spawn(None, TestActor).await;
     assert!(matches!(actor_output, Err(SpawnErr::StartupPanic(_))));
+}
+
+#[tokio::test]
+async fn test_stop_higher_priority_over_messages() {
+    let message_counter = Arc::new(AtomicU8::new(0u8));
+
+    struct TestActor {
+        counter: Arc<AtomicU8>,
+    }
+
+    #[async_trait::async_trait]
+    impl ActorHandler for TestActor {
+        type Msg = ();
+
+        type State = ();
+
+        async fn pre_start(&self, _this_actor: crate::ActorCell) -> Self::State {}
+
+        async fn handle(
+            &self,
+            _myself: ActorCell,
+            _message: Self::Msg,
+            _state: &Self::State,
+        ) -> Option<Self::State> {
+            self.counter.fetch_add(1, Ordering::Relaxed);
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            None
+        }
+    }
+
+    let (actor, handle) = Actor::spawn(
+        None,
+        TestActor {
+            counter: message_counter.clone(),
+        },
+    )
+    .await
+    .expect("Actor failed to start");
+
+    // pump 10 messages on the queue
+    for _i in 0..10 {
+        actor
+            .send_message::<TestActor>(())
+            .expect("Failed to send message to actor");
+    }
+
+    // give some time to process the first message and start sleeping
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // followed by the "stop" signal
+    actor.stop(None);
+
+    // current async work should complete, so we're still "running" sleeping
+    // on the first message
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    assert_eq!(ActorStatus::Running, actor.get_status());
+    assert!(!handle.is_finished());
+
+    // now wait enough time for the first iteration to complete
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    println!("Counter: {}", message_counter.load(Ordering::Relaxed));
+
+    // actor should have "stopped"
+    assert_eq!(ActorStatus::Stopped, actor.get_status());
+    assert!(handle.is_finished());
+    // counter should have bumped only a single time
+    assert_eq!(1, message_counter.load(Ordering::Relaxed));
+}
+
+#[tokio::test]
+async fn test_kill_terminates_work() {
+    struct TestActor;
+
+    #[async_trait::async_trait]
+    impl ActorHandler for TestActor {
+        type Msg = ();
+
+        type State = ();
+
+        async fn pre_start(&self, _this_actor: crate::ActorCell) -> Self::State {}
+
+        async fn handle(
+            &self,
+            _myself: ActorCell,
+            _message: Self::Msg,
+            _state: &Self::State,
+        ) -> Option<Self::State> {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            None
+        }
+    }
+
+    let (actor, handle) = Actor::spawn(None, TestActor)
+        .await
+        .expect("Actor failed to start");
+
+    actor
+        .send_message::<TestActor>(())
+        .expect("Failed to send message to actor");
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    actor.kill();
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    assert_eq!(ActorStatus::Stopped, actor.get_status());
+    assert!(handle.is_finished());
+}
+
+#[tokio::test]
+async fn test_stop_does_not_terminate_async_work() {
+    struct TestActor;
+
+    #[async_trait::async_trait]
+    impl ActorHandler for TestActor {
+        type Msg = ();
+
+        type State = ();
+
+        async fn pre_start(&self, _this_actor: crate::ActorCell) -> Self::State {}
+
+        async fn handle(
+            &self,
+            _myself: ActorCell,
+            _message: Self::Msg,
+            _state: &Self::State,
+        ) -> Option<Self::State> {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            None
+        }
+    }
+
+    let (actor, handle) = Actor::spawn(None, TestActor)
+        .await
+        .expect("Actor failed to start");
+
+    // send a work message followed by a stop message
+    actor
+        .send_message::<TestActor>(())
+        .expect("Failed to send message to actor");
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    actor.stop(None);
+
+    // async work should complete, so we're still "running" sleeping
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    assert_eq!(ActorStatus::Running, actor.get_status());
+    assert!(!handle.is_finished());
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // now enouch time has passed, so we have proceesed the next message, which is stop
+    // so we should be dead now
+    assert_eq!(ActorStatus::Stopped, actor.get_status());
+    assert!(handle.is_finished());
+}
+
+#[tokio::test]
+async fn test_kill_terminates_supervision_work() {
+    struct TestActor;
+
+    #[async_trait::async_trait]
+    impl ActorHandler for TestActor {
+        type Msg = ();
+
+        type State = ();
+
+        async fn pre_start(&self, _this_actor: crate::ActorCell) -> Self::State {}
+
+        async fn handle_supervisor_evt(
+            &self,
+            _myself: ActorCell,
+            _message: SupervisionEvent,
+            _state: &Self::State,
+        ) -> Option<Self::State> {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            None
+        }
+    }
+
+    let (actor, handle) = Actor::spawn(None, TestActor)
+        .await
+        .expect("Actor failed to start");
+
+    // send some dummy event to cause the supervision stuff to hang
+    actor
+        .send_supervisor_evt(SupervisionEvent::ActorStarted(actor.clone()))
+        .expect("Failed to send message to actor");
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    actor.kill();
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    assert_eq!(ActorStatus::Stopped, actor.get_status());
+    assert!(handle.is_finished());
 }

--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -60,7 +60,7 @@ async fn test_supervision_panic_in_post_startup() {
             // check that the panic was captured
             if let SupervisionEvent::ActorPanicked(dead_actor, _panic_msg) = message {
                 self.flag.store(dead_actor.get_id(), Ordering::Relaxed);
-                this_actor.stop();
+                this_actor.stop(None);
             }
 
             None
@@ -134,7 +134,7 @@ async fn test_supervision_panic_in_handle() {
             // check that the panic was captured
             if let SupervisionEvent::ActorPanicked(dead_actor, _panic_msg) = message {
                 self.flag.store(dead_actor.get_id(), Ordering::Relaxed);
-                this_actor.stop();
+                this_actor.stop(None);
             }
 
             None
@@ -159,7 +159,7 @@ async fn test_supervision_panic_in_handle() {
 
     // trigger the child failure
     child_ref
-        .send_message::<Child, _>(())
+        .send_message::<Child>(())
         .expect("Failed to send message");
 
     let (_, _) = tokio::join!(s_handle, c_handle);
@@ -183,7 +183,7 @@ async fn test_supervision_panic_in_post_stop() {
         type State = ();
         async fn pre_start(&self, this_actor: ActorCell) -> Self::State {
             // trigger stop, which starts shutdown
-            this_actor.stop();
+            this_actor.stop(None);
         }
         async fn post_stop(&self, _this_actor: ActorCell, _state: Self::State) -> Self::State {
             panic!("Boom");
@@ -215,7 +215,7 @@ async fn test_supervision_panic_in_post_stop() {
             // check that the panic was captured
             if let SupervisionEvent::ActorPanicked(dead_actor, _panic_msg) = message {
                 self.flag.store(dead_actor.get_id(), Ordering::Relaxed);
-                this_actor.stop();
+                this_actor.stop(None);
             }
 
             None
@@ -310,7 +310,7 @@ async fn test_supervision_panic_in_supervisor_handle() {
             // check that the panic was captured
             if let SupervisionEvent::ActorPanicked(dead_actor, _panic_msg) = message {
                 self.flag.store(dead_actor.get_id(), Ordering::Relaxed);
-                this_actor.stop();
+                this_actor.stop(None);
             }
 
             None
@@ -346,7 +346,7 @@ async fn test_supervision_panic_in_supervisor_handle() {
 
     // trigger the child failure
     child_ref
-        .send_message::<Child, _>(())
+        .send_message::<Child>(())
         .expect("Failed to send message");
 
     // which triggers the handler in the midpoint, which panic's in supervision
@@ -387,7 +387,7 @@ async fn test_killing_a_supervisor_terminates_children() {
             _state: &Self::State,
         ) -> Option<Self::State> {
             // stop the supervisor, which starts the supervision shutdown of children
-            _this_actor.stop();
+            _this_actor.stop(None);
             None
         }
     }
@@ -408,7 +408,7 @@ async fn test_killing_a_supervisor_terminates_children() {
 
     // initate the shutdown of the supervisor
     supervisor_ref
-        .cast::<Supervisor, _>(())
+        .cast::<Supervisor>(())
         .expect("Sending message to supervisor failed");
 
     s_handle

--- a/ractor/src/rpc/tests.rs
+++ b/ractor/src/rpc/tests.rs
@@ -49,9 +49,9 @@ async fn test_rpc_cast() {
     .await
     .expect("Failed to start test actor");
 
-    rpc::cast::<TestActor, _>(&actor_ref, ()).expect("Failed to send message");
+    rpc::cast::<TestActor>(&actor_ref, ()).expect("Failed to send message");
     actor_ref
-        .cast::<TestActor, _>(())
+        .cast::<TestActor>(())
         .expect("Failed to send message");
 
     // make sure they have time to process
@@ -61,7 +61,7 @@ async fn test_rpc_cast() {
     assert_eq!(2, counter.load(Ordering::Relaxed));
 
     // cleanup
-    actor_ref.stop();
+    actor_ref.stop(None);
     handle.await.expect("Actor stopped with err");
 }
 
@@ -104,7 +104,7 @@ async fn test_rpc_call() {
         .await
         .expect("Failed to start test actor");
 
-    let rpc_result = rpc::call::<TestActor, _, _, _>(
+    let rpc_result = rpc::call::<TestActor, _, _>(
         &actor_ref,
         MessageFormat::TestRpc,
         Some(Duration::from_millis(100)),
@@ -122,7 +122,7 @@ async fn test_rpc_call() {
     assert_eq!("howdy".to_string(), rpc_result);
 
     // cleanup
-    actor_ref.stop();
+    actor_ref.stop(None);
     handle.await.expect("Actor stopped with err");
 }
 
@@ -207,7 +207,7 @@ async fn test_rpc_call_forwarding() {
     .await
     .expect("Failed to start forwarder actor");
 
-    let forward_handle = rpc::call_and_forward::<Worker, Forwarder, _, _, _, _, _>(
+    let forward_handle = rpc::call_and_forward::<Worker, Forwarder, _, _, _>(
         &worker_ref,
         WorkerMessage::TestRpc,
         forwarder_ref.clone(),
@@ -240,8 +240,8 @@ async fn test_rpc_call_forwarding() {
     assert_eq!(2, counter.load(Ordering::Relaxed));
 
     // cleanup
-    forwarder_ref.stop();
-    worker_ref.stop();
+    forwarder_ref.stop(None);
+    worker_ref.stop(None);
 
     forwarder_handle.await.expect("Actor stopped with err");
     worker_handle.await.expect("Actor stopped with err");


### PR DESCRIPTION
1. Signal will KILL async work
2. Stop will gracefully exit on the next iteration (so async work will complete, but no new messages processed)

Addtionally test coverage around what's stopped vs killed.

Also wired up signal such that a Kill signal will also terminate any supervisor work

Blocked on #7 and a rebase