### PR TITLE
Adding support for a global singleton registry for named actors

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "A actor framework for Rust"
 license = "MIT"
@@ -15,6 +15,8 @@ categories = ["actor"]
 [dependencies]
 async-trait = "0.1"
 dashmap = "5"
+futures = "0.3"
+once_cell = "1"
 tokio = { version = "1.23", features = ["rt", "time", "sync", "macros"]}
 
 [dev-dependencies]

--- a/ractor/examples/supervisor.rs
+++ b/ractor/examples/supervisor.rs
@@ -1,0 +1,261 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! An example supervisory tree of actors
+//!
+//! Execute with
+//!
+//! ```text
+//! cargo run --example supervisor
+//! ```
+
+use ractor::{rpc, Actor, ActorCell, ActorHandler, RpcReplyPort, SupervisionEvent};
+
+use tokio::time::Duration;
+
+// ============================== Main ============================== //
+
+#[tokio::main]
+async fn main() {
+    let (root, handle) = Actor::spawn(Some("root"), RootActor)
+        .await
+        .expect("Failed to start root actor");
+    let mid_level = rpc::call::<RootActor, _, _>(
+        &root,
+        RootActorMessage::GetMidLevel,
+        Some(Duration::from_millis(100)),
+    )
+    .await
+    .expect("Failed to send message to root actor")
+    .expect("Failed to get mid level actor");
+
+    let leaf = rpc::call::<MidLevelActor, _, _>(
+        &mid_level,
+        MidLevelActorMessage::GetLeaf,
+        Some(Duration::from_millis(100)),
+    )
+    .await
+    .expect("Failed to send message to mid-level actor")
+    .expect("Failed to get leaf actor");
+
+    // send some no-op's to the leaf
+    for _ in 1..10 {
+        rpc::cast::<LeafActor>(&leaf, LeafActorMessage::NoOp)
+            .expect("Failed to send message to leaf actor");
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // send the "Boom" message and follow the supervision flow
+    rpc::cast::<LeafActor>(&leaf, LeafActorMessage::Boom)
+        .expect("Failed to send message to leaf actor");
+
+    handle.await.expect("Failed waiting for root actor to die");
+}
+
+// ============================== Leaf actor ============================== //
+
+struct LeafActor;
+
+struct LeafActorState {}
+
+enum LeafActorMessage {
+    Boom,
+    NoOp,
+}
+
+#[async_trait::async_trait]
+impl ActorHandler for LeafActor {
+    type Msg = LeafActorMessage;
+    type State = LeafActorState;
+    async fn pre_start(&self, _myself: ActorCell) -> Self::State {
+        LeafActorState {}
+    }
+
+    // async fn post_start(&self, myself: ActorCell, state: &Self::State) -> Option<Self::State> {
+    //     None
+    // }
+
+    // async fn post_stop(&self, myself: ActorCell, state: Self::State) -> Self::State {
+    //     state
+    // }
+
+    async fn handle(
+        &self,
+        _myself: ActorCell,
+        message: Self::Msg,
+        _state: &Self::State,
+    ) -> Option<Self::State> {
+        match message {
+            Self::Msg::Boom => {
+                panic!("LeafActor: Oh crap!");
+            }
+            Self::Msg::NoOp => {
+                println!("LeafActor: No-op!");
+            }
+        }
+        None
+    }
+
+    // async fn handle_supervisor_evt(
+    //     &self,
+    //     myself: ActorCell,
+    //     message: SupervisionEvent,
+    //     state: &Self::State,
+    // ) -> Option<Self::State> {
+    //     None
+    // }
+}
+
+// ============================== Mid-level supervisor ============================== //
+
+struct MidLevelActor;
+
+struct MidLevelActorState {
+    leaf_actor: ActorCell,
+}
+
+enum MidLevelActorMessage {
+    GetLeaf(RpcReplyPort<ActorCell>),
+}
+
+#[async_trait::async_trait]
+impl ActorHandler for MidLevelActor {
+    type Msg = MidLevelActorMessage;
+    type State = MidLevelActorState;
+
+    async fn pre_start(&self, myself: ActorCell) -> Self::State {
+        let (leaf_actor, _) = Actor::spawn_linked(Some("leaf"), LeafActor, myself)
+            .await
+            .expect("Failed to start leaf actor");
+        MidLevelActorState { leaf_actor }
+    }
+
+    // async fn post_start(&self, myself: ActorCell, state: &Self::State) -> Option<Self::State> {
+    //     None
+    // }
+
+    // async fn post_stop(&self, myself: ActorCell, state: Self::State) -> Self::State {
+    //     state
+    // }
+
+    async fn handle(
+        &self,
+        _myself: ActorCell,
+        message: Self::Msg,
+        state: &Self::State,
+    ) -> Option<Self::State> {
+        match message {
+            MidLevelActorMessage::GetLeaf(reply) => {
+                if !reply.is_closed() {
+                    reply
+                        .send(state.leaf_actor.clone())
+                        .expect("Failed to reply to RPC");
+                }
+            }
+        }
+        None
+    }
+
+    async fn handle_supervisor_evt(
+        &self,
+        _myself: ActorCell,
+        message: SupervisionEvent,
+        state: &Self::State,
+    ) -> Option<Self::State> {
+        match message {
+            SupervisionEvent::ActorPanicked(dead_actor, panic_msg)
+                if dead_actor.get_id() == state.leaf_actor.get_id() =>
+            {
+                println!(
+                    "MidLevelActor: {:?} panicked with '{}'",
+                    dead_actor, panic_msg
+                );
+
+                panic!(
+                    "MidLevelActor: Mid-level actor panicking because Leaf actor panicked with '{}'",
+                    panic_msg
+                );
+            }
+            other => {
+                println!("MidLevelActor: recieved supervisor event '{}'", other);
+            }
+        }
+        None
+    }
+}
+
+// ============================== Root Actor Definition ============================== //
+
+struct RootActor;
+
+struct RootActorState {
+    mid_level_actor: ActorCell,
+}
+
+enum RootActorMessage {
+    GetMidLevel(RpcReplyPort<ActorCell>),
+}
+
+#[async_trait::async_trait]
+impl ActorHandler for RootActor {
+    type Msg = RootActorMessage;
+    type State = RootActorState;
+
+    async fn pre_start(&self, myself: ActorCell) -> Self::State {
+        println!("RootActor: Started {:?}", myself);
+        let (mid_level_actor, _) = Actor::spawn_linked(Some("mid-level"), MidLevelActor, myself)
+            .await
+            .expect("Failed to spawn mid-level actor");
+        RootActorState { mid_level_actor }
+    }
+
+    // async fn post_start(&self, myself: ActorCell, state: &Self::State) -> Option<Self::State> {
+    //     None
+    // }
+
+    // async fn post_stop(&self, myself: ActorCell, state: Self::State) -> Self::State {
+    //     state
+    // }
+
+    async fn handle(
+        &self,
+        _myself: ActorCell,
+        message: Self::Msg,
+        state: &Self::State,
+    ) -> Option<Self::State> {
+        match message {
+            RootActorMessage::GetMidLevel(reply) => {
+                if !reply.is_closed() {
+                    reply
+                        .send(state.mid_level_actor.clone())
+                        .expect("Failed to reply to RPC");
+                }
+            }
+        }
+        None
+    }
+
+    async fn handle_supervisor_evt(
+        &self,
+        myself: ActorCell,
+        message: SupervisionEvent,
+        state: &Self::State,
+    ) -> Option<Self::State> {
+        match message {
+            SupervisionEvent::ActorPanicked(dead_actor, panic_msg)
+                if dead_actor.get_id() == state.mid_level_actor.get_id() =>
+            {
+                println!("RootActor: {:?} panicked with '{}'", dead_actor, panic_msg);
+
+                println!("RootActor: Terminating root actor, all my kids are dead!");
+                myself.stop(Some("Everyone died :(".to_string()));
+            }
+            other => {
+                println!("RootActor: recieved supervisor event '{}'", other);
+            }
+        }
+        None
+    }
+}

--- a/ractor/src/actor/errors.rs
+++ b/ractor/src/actor/errors.rs
@@ -7,8 +7,10 @@
 
 use std::fmt::Display;
 
+use crate::ActorName;
+
 /// Spawn errors starting an actor
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum SpawnErr {
     /// Actor panic'd during startup
     StartupPanic(String),
@@ -16,6 +18,8 @@ pub enum SpawnErr {
     StartupCancelled,
     /// An actor cannot be started > 1 time
     ActorAlreadyStarted,
+    /// The named actor is already registered in the registry
+    ActorAlreadyRegistered(ActorName),
 }
 
 impl Display for SpawnErr {
@@ -32,6 +36,23 @@ impl Display for SpawnErr {
             }
             Self::ActorAlreadyStarted => {
                 write!(f, "Actor cannot be re-started more than once")
+            }
+            Self::ActorAlreadyRegistered(actor_name) => {
+                write!(
+                    f,
+                    "Actor '{}' is already registered in the actor registry",
+                    actor_name
+                )
+            }
+        }
+    }
+}
+
+impl From<crate::registry::ActorRegistryErr> for SpawnErr {
+    fn from(value: crate::registry::ActorRegistryErr) -> Self {
+        match value {
+            crate::registry::ActorRegistryErr::AlreadyRegistered(actor_name) => {
+                SpawnErr::ActorAlreadyRegistered(actor_name)
             }
         }
     }

--- a/ractor/src/actor/supervision.rs
+++ b/ractor/src/actor/supervision.rs
@@ -10,6 +10,10 @@
 //! when a child actor starts, stops, or panics (when possible). The supervisor can then decide
 //! how to handle the event. Should it restart the actor, leave it dead, potentially die itself
 //! notifying the supervisor's supervisor? That's up to the implementation of the [super::ActorHandler]
+//!
+//! This is currently an initial implementation of [Erlang supervisors](https://www.erlang.org/doc/man/supervisor.html)
+//! which will be expanded upon as the library develops. Next in line is likely supervision strategies
+//! for automatic restart routines.
 
 use std::sync::Arc;
 

--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -319,9 +319,7 @@ async fn test_supervision_panic_in_supervisor_handle() {
 
     let flag = Arc::new(AtomicU64::new(0));
 
-    let (supervisor, supervisor_ports) = Actor::new(None, Supervisor { flag: flag.clone() });
-    let (supervisor_ref, s_handle) = supervisor
-        .start(supervisor_ports, None)
+    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() })
         .await
         .expect("Supervisor panicked on startup");
 

--- a/ractor/src/port/mod.rs
+++ b/ractor/src/port/mod.rs
@@ -4,6 +4,11 @@
 // LICENSE-MIT file in the root directory of this source tree.
 
 //! Port implementations for signaling and reception of messages in the Ractor environment
+//!
+//! Most of the ports we utilize are direct aliases of [tokio]'s channels
+//! (in the `sync` feature of the crate), however there are some helpful wrappers
+//! and utilities to make working with mailbox processing in `ractor` easier in
+//! the actor framework.
 
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;

--- a/ractor/src/registry/mod.rs
+++ b/ractor/src/registry/mod.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! Represents an actor registry.
+//!
+//! It allows unique naming of actors via `'static &str` (not strings)
+//! so it works more like a Erlang `atom()`
+//!
+//! Actors are automatically registered into the global registry, if they
+//! provide a name, upon construction.Actors are also
+//! automatically unenrolled from the registry upon being dropped, therefore freeing
+//! the name for subsequent registration.
+//!
+//! You can then retrieve actors by name with [try_get]. Note: this
+//! function only returns the [ActorCell] reference to the actor, it
+//! additionally requires knowledge of the [crate::ActorHandler] in order
+//! to send messages to it (since you need to know the message type)
+//! or agents will runtime panic on message reception, and supervision
+//! processes would need to restart the actors.
+//!
+//! ## Example
+//!
+//! ```rust
+//! let maybe_actor = ractor::registry::try_get("my_actor");
+//! if let Some(actor) = maybe_actor {
+//!     // send a message, or interact with the actor
+//!     // but you'll need to know the actor's strong type
+//! }
+//! ```
+
+use std::sync::Arc;
+
+use dashmap::{mapref::entry::Entry, DashMap};
+use once_cell::sync::OnceCell;
+
+use crate::{ActorCell, ActorId, ActorName};
+
+#[cfg(test)]
+mod tests;
+
+/// Errors involving the [crate::registry]'s actor registry
+pub enum ActorRegistryErr {
+    /// Actor already registered
+    AlreadyRegistered(ActorName),
+}
+
+/// The name'd actor registry
+static ACTOR_REGISTRY: OnceCell<Arc<DashMap<ActorName, ActorCell>>> = OnceCell::new();
+
+/// Retrieve the named actor registry handle
+fn get_actor_registry() -> Arc<DashMap<ActorName, ActorCell>> {
+    let reg = ACTOR_REGISTRY.get_or_init(|| Arc::new(DashMap::new()));
+    reg.clone()
+}
+
+/// Put an actor into the registry
+pub(crate) fn enroll(name: ActorName, actor: ActorCell) -> Result<(), ActorRegistryErr> {
+    let reg = get_actor_registry();
+    let entry = reg.entry(name);
+
+    match entry {
+        Entry::Occupied(_) => Err(ActorRegistryErr::AlreadyRegistered(name)),
+        Entry::Vacant(vacancy) => {
+            vacancy.insert(actor);
+            Ok(())
+        }
+    }
+}
+
+/// Check if an actor name is enrolled in the registry
+///
+/// * `name` - The actor's name
+/// * `pid` - the ID of the actor in question
+pub(crate) fn is_enrolled(name: ActorName, pid: ActorId) -> bool {
+    match get_actor_registry().entry(name) {
+        Entry::Occupied(actor) => actor.get().get_id() == pid,
+        _ => false,
+    }
+}
+
+/// Remove an actor from the registry given it's actor name
+pub(crate) fn unenroll(name: ActorName) {
+    let reg = get_actor_registry();
+    let entry = reg.entry(name);
+    if let Entry::Occupied(actor) = entry {
+        let _ = actor.remove();
+    }
+}
+
+/// Try and retrieve an actor from the registry
+///
+/// * `name` - The name of the [ActorCell] to try and retrieve
+///
+/// Returns: Some(actor) on successful identification of an actor, None if
+/// actor not registered
+pub fn try_get(name: ActorName) -> Option<ActorCell> {
+    let reg = get_actor_registry();
+    reg.get(&name).map(|item| item.value().clone())
+}

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -1,0 +1,94 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! Tests on the actor registry
+
+use crate::{Actor, ActorHandler, SpawnErr};
+
+#[tokio::test]
+async fn test_basic_registation() {
+    struct EmptyActor;
+
+    #[async_trait::async_trait]
+    impl ActorHandler for EmptyActor {
+        type Msg = ();
+
+        type State = ();
+
+        async fn pre_start(&self, _this_actor: crate::ActorCell) -> Self::State {}
+    }
+
+    let (actor, handle) = Actor::spawn(Some("my_actor"), EmptyActor)
+        .await
+        .expect("Actor failed to start");
+
+    assert!(crate::registry::try_get("my_actor").is_some());
+
+    actor.stop(None);
+    handle.await.expect("Failed to clean stop the actor");
+}
+
+#[tokio::test]
+async fn test_duplicate_registration() {
+    struct EmptyActor;
+
+    #[async_trait::async_trait]
+    impl ActorHandler for EmptyActor {
+        type Msg = ();
+
+        type State = ();
+
+        async fn pre_start(&self, _this_actor: crate::ActorCell) -> Self::State {}
+    }
+
+    let (actor, handle) = Actor::spawn(Some("my_second_actor"), EmptyActor)
+        .await
+        .expect("Actor failed to start");
+
+    assert!(crate::registry::try_get("my_second_actor").is_some());
+
+    let second_actor = Actor::spawn(Some("my_second_actor"), EmptyActor).await;
+    // fails to spawn the second actor due to name err
+    assert!(matches!(
+        second_actor,
+        Err(SpawnErr::ActorAlreadyRegistered(_))
+    ));
+
+    // make sure the first actor is still registered
+    assert!(crate::registry::try_get("my_second_actor").is_some());
+
+    actor.stop(None);
+    handle.await.expect("Failed to clean stop the actor");
+}
+
+#[tokio::test]
+async fn test_actor_registry_unenrollment() {
+    struct EmptyActor;
+
+    #[async_trait::async_trait]
+    impl ActorHandler for EmptyActor {
+        type Msg = ();
+
+        type State = ();
+
+        async fn pre_start(&self, _this_actor: crate::ActorCell) -> Self::State {}
+    }
+
+    let (actor, handle) = Actor::spawn(Some("unenrollment"), EmptyActor)
+        .await
+        .expect("Actor failed to start");
+
+    assert!(crate::registry::try_get("unenrollment").is_some());
+
+    // stop the actor and wait for its death
+    actor.stop(None);
+    handle.await.expect("Failed to wait for agent stop");
+
+    // drop the actor ref's
+    drop(actor);
+
+    // the actor was automatically removed
+    assert!(crate::registry::try_get("unenrollment").is_none());
+}

--- a/ractor/src/rpc/call_result.rs
+++ b/ractor/src/rpc/call_result.rs
@@ -3,7 +3,8 @@
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree.
 
-//! This module contains the remote procedure call [CallResult] structure and supported operations
+//! This module contains the remote procedure call's [CallResult] structure
+//! and supported operations
 
 /// The result from a [crate::rpc::call] operation
 #[derive(Debug, Eq, PartialEq)]

--- a/ractor/src/rpc/tests.rs
+++ b/ractor/src/rpc/tests.rs
@@ -246,3 +246,5 @@ async fn test_rpc_call_forwarding() {
     forwarder_handle.await.expect("Actor stopped with err");
     worker_handle.await.expect("Actor stopped with err");
 }
+
+// TODO: test multi_call

--- a/ractor/src/time/mod.rs
+++ b/ractor/src/time/mod.rs
@@ -4,6 +4,15 @@
 // LICENSE-MIT file in the root directory of this source tree.
 
 //! Timers for sending messages to actors periodically
+//!
+//! The methodology of timers in `ractor` are based on [Erlang's `timer` module](https://www.erlang.org/doc/man/timer.html).
+//! We aren't supporting all timer functions, as many of them don't make sense but we
+//! support the relevant ones for `ractor`. In short
+//!
+//! 1. Send on a period
+//! 2. Send after a delay
+//! 3. Stop after a delay
+//! 4. Kill after a delay
 
 use tokio::{task::JoinHandle, time::Duration};
 


### PR DESCRIPTION
This follows the Erlang notion of [name registration via `register_name/3`](https://www.erlang.org/doc/man/global.html#register_name-2).

In our case, it's an in-memory naming, but allows global addressing of actors.

Additionally this PR addresses limitations in the port listening routines which wasn't using priorities due to the random way `tokio::select!` operates by default. Now we add the `biased;` indication to identify that we're handling the fairness of the ports, in that there is an inherent priority in them (Signal > Stop > Supervision > Message). 