### PR TITLE
Adding PG groups

### DIFF
--- a/ractor-playground/src/ping_pong.rs
+++ b/ractor-playground/src/ping_pong.rs
@@ -45,36 +45,24 @@ impl ActorHandler for PingPong {
         0u8
     }
 
-    async fn post_start(
-        &self,
-        _this_actor: ActorRef<Self>,
-        _state: &Self::State,
-    ) -> Option<Self::State> {
+    async fn post_start(&self, _this_actor: ActorRef<Self>, _state: &mut Self::State) {
         println!("post_start called");
-        None
     }
 
     /// Invoked after an actor has been stopped.
-    async fn post_stop(&self, _this_actor: ActorRef<Self>, _state: Self::State) -> Self::State {
+    async fn post_stop(&self, _this_actor: ActorRef<Self>, _state: &mut Self::State) {
         println!("post_stop called");
-        _state
     }
 
-    async fn handle(
-        &self,
-        myself: ActorRef<Self>,
-        message: Self::Msg,
-        state: &Self::State,
-    ) -> Option<Self::State> {
+    async fn handle(&self, myself: ActorRef<Self>, message: Self::Msg, state: &mut Self::State) {
         if *state < 10u8 {
             message.print();
             myself.send_message(message.next()).unwrap();
-            Some(*state + 1)
+            *state += 1;
         } else {
             println!();
             myself.stop(None);
             // don't send another message, rather stop the agent after 10 iterations
-            None
         }
     }
 }

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "ractor"
-version = "0.2.0"
-authors = ["Sean Lawlor <seanlawlor@fb.com>"]
+version = "0.3.0"
+authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
+documentation = "https://docs.rs/ractor"
 license = "MIT"
 edition = "2018"
 keywords = ["actor", "ractor"]
 repository = "https://github.com/slawlor/ractor"
 readme = "../README.md"
-license-file = "../LICENSE"
 homepage = "https://github.com/slawlor/ractor"
-categories = ["actor"]
+categories = ["actor", "erlang"]
 
 [dependencies]
 async-trait = "0.1"
@@ -20,4 +20,5 @@ once_cell = "1"
 tokio = { version = "1.23", features = ["rt", "time", "sync", "macros"]}
 
 [dev-dependencies]
+function_name = "0.3"
 tokio = { version = "1.23", features = ["rt", "time", "sync", "macros", "rt-multi-thread"] }

--- a/ractor/examples/counter.rs
+++ b/ractor/examples/counter.rs
@@ -41,24 +41,18 @@ impl ActorHandler for Counter {
         CounterState { count: 0 }
     }
 
-    async fn handle(
-        &self,
-        _myself: ActorRef<Self>,
-        message: Self::Msg,
-        state: &Self::State,
-    ) -> Option<Self::State> {
+    async fn handle(&self, _myself: ActorRef<Self>, message: Self::Msg, state: &mut Self::State) {
         match message {
-            CounterMessage::Increment(how_much) => Some(CounterState {
-                count: state.count + how_much,
-            }),
-            CounterMessage::Decrement(how_much) => Some(CounterState {
-                count: state.count - how_much,
-            }),
+            CounterMessage::Increment(how_much) => {
+                state.count += how_much;
+            }
+            CounterMessage::Decrement(how_much) => {
+                state.count -= how_much;
+            }
             CounterMessage::Retrieve(reply_port) => {
                 if !reply_port.is_closed() {
                     reply_port.send(state.count).unwrap();
                 }
-                None
             }
         }
     }

--- a/ractor/examples/output_port.rs
+++ b/ractor/examples/output_port.rs
@@ -34,19 +34,13 @@ impl ActorHandler for Publisher {
 
     async fn pre_start(&self, _myself: ActorRef<Self>) -> Self::State {}
 
-    async fn handle(
-        &self,
-        _myself: ActorRef<Self>,
-        message: Self::Msg,
-        _state: &Self::State,
-    ) -> Option<Self::State> {
+    async fn handle(&self, _myself: ActorRef<Self>, message: Self::Msg, _state: &mut Self::State) {
         match message {
             Self::Msg::Publish(msg) => {
                 println!("Publishing {}", msg);
                 self.output.send(format!("Published: {}", msg));
             }
         }
-        None
     }
 }
 
@@ -64,12 +58,7 @@ impl ActorHandler for Subscriber {
 
     async fn pre_start(&self, _myself: ActorRef<Self>) -> Self::State {}
 
-    async fn handle(
-        &self,
-        myself: ActorRef<Self>,
-        message: Self::Msg,
-        _state: &Self::State,
-    ) -> Option<Self::State> {
+    async fn handle(&self, myself: ActorRef<Self>, message: Self::Msg, _state: &mut Self::State) {
         match message {
             Self::Msg::Published(msg) => {
                 println!(
@@ -78,7 +67,6 @@ impl ActorHandler for Subscriber {
                 );
             }
         }
-        None
     }
 }
 

--- a/ractor/examples/ping_pong.rs
+++ b/ractor/examples/ping_pong.rs
@@ -53,20 +53,14 @@ impl ActorHandler for PingPong {
         0u8
     }
 
-    async fn handle(
-        &self,
-        myself: ActorRef<Self>,
-        message: Self::Msg,
-        state: &Self::State,
-    ) -> Option<Self::State> {
+    async fn handle(&self, myself: ActorRef<Self>, message: Self::Msg, state: &mut Self::State) {
         if *state < 10u8 {
             message.print();
             myself.send_message(message.next()).unwrap();
-            Some(*state + 1)
+            *state += 1;
         } else {
             println!();
             myself.stop(None);
-            None
         }
     }
 }

--- a/ractor/examples/supervisor.rs
+++ b/ractor/examples/supervisor.rs
@@ -81,12 +81,7 @@ impl ActorHandler for LeafActor {
     //     state
     // }
 
-    async fn handle(
-        &self,
-        _myself: ActorRef<Self>,
-        message: Self::Msg,
-        _state: &Self::State,
-    ) -> Option<Self::State> {
+    async fn handle(&self, _myself: ActorRef<Self>, message: Self::Msg, _state: &mut Self::State) {
         match message {
             Self::Msg::Boom => {
                 panic!("LeafActor: Oh crap!");
@@ -95,7 +90,6 @@ impl ActorHandler for LeafActor {
                 println!("LeafActor: No-op!");
             }
         }
-        None
     }
 
     // async fn handle_supervisor_evt(
@@ -140,12 +134,7 @@ impl ActorHandler for MidLevelActor {
     //     state
     // }
 
-    async fn handle(
-        &self,
-        _myself: ActorRef<Self>,
-        message: Self::Msg,
-        state: &Self::State,
-    ) -> Option<Self::State> {
+    async fn handle(&self, _myself: ActorRef<Self>, message: Self::Msg, state: &mut Self::State) {
         match message {
             MidLevelActorMessage::GetLeaf(reply) => {
                 if !reply.is_closed() {
@@ -155,15 +144,14 @@ impl ActorHandler for MidLevelActor {
                 }
             }
         }
-        None
     }
 
     async fn handle_supervisor_evt(
         &self,
         _myself: ActorRef<Self>,
         message: SupervisionEvent,
-        state: &Self::State,
-    ) -> Option<Self::State> {
+        state: &mut Self::State,
+    ) {
         match message {
             SupervisionEvent::ActorPanicked(dead_actor, panic_msg)
                 if dead_actor.get_id() == state.leaf_actor.get_id() =>
@@ -182,7 +170,6 @@ impl ActorHandler for MidLevelActor {
                 println!("MidLevelActor: recieved supervisor event '{}'", other);
             }
         }
-        None
     }
 }
 
@@ -220,12 +207,7 @@ impl ActorHandler for RootActor {
     //     state
     // }
 
-    async fn handle(
-        &self,
-        _myself: ActorRef<Self>,
-        message: Self::Msg,
-        state: &Self::State,
-    ) -> Option<Self::State> {
+    async fn handle(&self, _myself: ActorRef<Self>, message: Self::Msg, state: &mut Self::State) {
         match message {
             RootActorMessage::GetMidLevel(reply) => {
                 if !reply.is_closed() {
@@ -235,15 +217,14 @@ impl ActorHandler for RootActor {
                 }
             }
         }
-        None
     }
 
     async fn handle_supervisor_evt(
         &self,
         myself: ActorRef<Self>,
         message: SupervisionEvent,
-        state: &Self::State,
-    ) -> Option<Self::State> {
+        state: &mut Self::State,
+    ) {
         match message {
             SupervisionEvent::ActorPanicked(dead_actor, panic_msg)
                 if dead_actor.get_id() == state.mid_level_actor.get_id() =>
@@ -257,6 +238,5 @@ impl ActorHandler for RootActor {
                 println!("RootActor: recieved supervisor event '{}'", other);
             }
         }
-        None
     }
 }

--- a/ractor/src/actor/actor_cell/actor_ref.rs
+++ b/ractor/src/actor/actor_cell/actor_ref.rs
@@ -8,7 +8,7 @@
 use std::any::TypeId;
 use std::marker::PhantomData;
 
-use crate::{ActorHandler, ActorId, ActorName, ActorStatus, MessagingErr, SupervisionEvent};
+use crate::{ActorHandler, ActorName, MessagingErr, SupervisionEvent};
 
 use super::ActorCell;
 
@@ -85,61 +85,6 @@ where
         self.inner.clone()
     }
 
-    /// Retrieve the [crate::Actor]'s unique identifier [ActorId]
-    pub fn get_id(&self) -> ActorId {
-        self.inner.get_id()
-    }
-
-    /// Retrieve the [crate::Actor]'s name
-    pub fn get_name(&self) -> Option<ActorName> {
-        self.inner.get_name()
-    }
-
-    /// Retrieve the current status of an [crate::Actor]
-    ///
-    /// Returns the [crate::Actor]'s current [ActorStatus]
-    pub fn get_status(&self) -> ActorStatus {
-        self.inner.get_status()
-    }
-
-    /// Set the status of the [crate::Actor]
-    ///
-    /// * `status` - The [ActorStatus] to set
-    pub(crate) fn set_status(&self, status: ActorStatus) {
-        self.inner.set_status(status)
-    }
-
-    /// Terminate this [crate::Actor] and all it's children
-    pub(crate) fn terminate(&self) {
-        self.inner.terminate();
-    }
-
-    /// Link this [crate::Actor] to the supervisor
-    ///
-    /// * `supervisor` - The supervisor to link this [crate::Actor] to
-    pub fn link(&self, supervisor: ActorCell) {
-        self.inner.link(supervisor);
-    }
-
-    /// Unlink this [crate::Actor] from the supervisor
-    ///
-    /// * `supervisor` - The supervisor to unlink this [crate::Actor] from
-    pub fn unlink(&self, supervisor: ActorCell) {
-        self.inner.unlink(supervisor)
-    }
-
-    /// Kill this [crate::Actor] forcefully (terminates async work)
-    pub fn kill(&self) {
-        self.inner.kill();
-    }
-
-    /// Stop this [crate::Actor] gracefully (stopping message processing)
-    ///
-    /// * `reason` - An optional static string reason why the stop is occurring
-    pub fn stop(&self, reason: Option<String>) {
-        self.inner.stop(reason);
-    }
-
     /// Send a strongly-typed message, constructing the boxed message on the fly
     ///
     /// * `message` - The message to send
@@ -147,19 +92,6 @@ where
     /// Returns [Ok(())] on successful message send, [Err(MessagingErr)] otherwise
     pub fn send_message(&self, message: TActor::Msg) -> Result<(), MessagingErr> {
         self.inner.send_message::<TActor>(message)
-    }
-
-    /// Send a supervisor event to the supervisory port
-    ///
-    /// * `message` - The [SupervisionEvent] to send to the supervisory port
-    ///
-    /// Returns [Ok(())] on successful message send, [Err(MessagingErr)] otherwise
-    #[cfg(test)]
-    pub(crate) fn send_supervisor_evt(
-        &self,
-        message: SupervisionEvent,
-    ) -> Result<(), MessagingErr> {
-        self.inner.send_supervisor_evt(message)
     }
 
     /// Notify the supervisors that a supervision event occurred

--- a/ractor/src/actor/messages.rs
+++ b/ractor/src/actor/messages.rs
@@ -146,6 +146,9 @@ pub enum SupervisionEvent {
     ),
     /// An actor panicked
     ActorPanicked(super::actor_cell::ActorCell, String),
+
+    /// A subscribed process group changed
+    ProcessGroupChanged(crate::pg::GroupChangeMessage),
 }
 
 impl Debug for SupervisionEvent {
@@ -169,6 +172,9 @@ impl std::fmt::Display for SupervisionEvent {
             }
             SupervisionEvent::ActorPanicked(actor, panic_msg) => {
                 write!(f, "Actor panicked {:?} - {}", actor, panic_msg)
+            }
+            SupervisionEvent::ProcessGroupChanged(change) => {
+                write!(f, "Process group {} changed", change.get_group())
             }
         }
     }
@@ -200,6 +206,7 @@ impl SupervisionEvent {
             Self::ActorPanicked(actor, message) => {
                 Ok(Self::ActorPanicked(actor.clone(), message.clone()))
             }
+            Self::ProcessGroupChanged(change) => Ok(Self::ProcessGroupChanged(change.clone())),
         }
     }
 }

--- a/ractor/src/actor/supervision.rs
+++ b/ractor/src/actor/supervision.rs
@@ -15,18 +15,16 @@
 //! which will be expanded upon as the library develops. Next in line is likely supervision strategies
 //! for automatic restart routines.
 
-use std::sync::Arc;
-
 use dashmap::DashMap;
 
 use super::{actor_cell::ActorCell, messages::SupervisionEvent};
 use crate::{ActorHandler, ActorId};
 
 /// A supervision tree
-#[derive(Clone, Default)]
+#[derive(Default)]
 pub struct SupervisionTree {
-    children: Arc<DashMap<ActorId, ActorCell>>,
-    parents: Arc<DashMap<ActorId, ActorCell>>,
+    children: DashMap<ActorId, ActorCell>,
+    parents: DashMap<ActorId, ActorCell>,
 }
 
 impl SupervisionTree {

--- a/ractor/src/actor/tests/mod.rs
+++ b/ractor/src/actor/tests/mod.rs
@@ -55,11 +55,10 @@ async fn test_stop_higher_priority_over_messages() {
             &self,
             _myself: ActorRef<Self>,
             _message: Self::Msg,
-            _state: &Self::State,
-        ) -> Option<Self::State> {
+            _state: &mut Self::State,
+        ) {
             self.counter.fetch_add(1, Ordering::Relaxed);
             tokio::time::sleep(Duration::from_millis(100)).await;
-            None
         }
     }
 
@@ -119,10 +118,9 @@ async fn test_kill_terminates_work() {
             &self,
             _myself: ActorRef<Self>,
             _message: Self::Msg,
-            _state: &Self::State,
-        ) -> Option<Self::State> {
+            _state: &mut Self::State,
+        ) {
             tokio::time::sleep(Duration::from_secs(10)).await;
-            None
         }
     }
 
@@ -158,10 +156,9 @@ async fn test_stop_does_not_terminate_async_work() {
             &self,
             _myself: ActorRef<Self>,
             _message: Self::Msg,
-            _state: &Self::State,
-        ) -> Option<Self::State> {
+            _state: &mut Self::State,
+        ) {
             tokio::time::sleep(Duration::from_millis(100)).await;
-            None
         }
     }
 
@@ -204,10 +201,9 @@ async fn test_kill_terminates_supervision_work() {
             &self,
             _myself: ActorRef<Self>,
             _message: SupervisionEvent,
-            _state: &Self::State,
-        ) -> Option<Self::State> {
+            _state: &mut Self::State,
+        ) {
             tokio::time::sleep(Duration::from_millis(100)).await;
-            None
         }
     }
 

--- a/ractor/src/actor_id.rs
+++ b/ractor/src/actor_id.rs
@@ -18,6 +18,15 @@ pub enum ActorId {
     Remote(u64, u64),
 }
 
+impl ActorId {
+    /// Determine if this actor id is a local or remote actor
+    ///
+    /// Returns [true] if it is a local actor, [false] otherwise
+    pub fn is_local(&self) -> bool {
+        matches!(self, ActorId::Local(_))
+    }
+}
+
 impl Display for ActorId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -74,16 +74,15 @@
 //!         &self,
 //!         myself: ActorRef<Self>,
 //!         message: Self::Msg,
-//!         state: &Self::State,
-//!     ) -> Option<Self::State> {
+//!         state: &mut Self::State,
+//!     ) {
 //!         if *state < 10u8 {
 //!             message.print();
 //!             myself.send_message(message.next()).unwrap();
-//!             Some(*state + 1)
+//!             *state += 1;
 //!         } else {
 //!             myself.stop(None);
 //!             // don't send another message, rather stop the agent after 10 iterations
-//!             None
 //!         }
 //!     }
 //! }
@@ -141,8 +140,12 @@ use std::any::Any;
 /// An actor's `atom()` similar name
 pub type ActorName = &'static str;
 
+/// A process group's name, equivalent to an Erlang `atom()`
+pub type GroupName = &'static str;
+
 pub mod actor;
 pub mod actor_id;
+pub mod pg;
 pub mod port;
 pub mod registry;
 pub mod rpc;

--- a/ractor/src/pg/mod.rs
+++ b/ractor/src/pg/mod.rs
@@ -1,0 +1,242 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! Process groups (PG)
+//!
+//! Inspired from [Erlang's `pg` module](https://www.erlang.org/doc/man/pg.html)
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use dashmap::mapref::entry::Entry::{Occupied, Vacant};
+use dashmap::DashMap;
+
+use once_cell::sync::OnceCell;
+
+use crate::{ActorCell, ActorId, GroupName, SupervisionEvent};
+
+#[cfg(test)]
+mod tests;
+
+/// Represents a change in group or scope membership
+#[derive(Clone)]
+pub enum GroupChangeMessage {
+    /// Some actors joined a group
+    Join(GroupName, Vec<ActorCell>),
+    /// Some actors left a group
+    Leave(GroupName, Vec<ActorCell>),
+}
+
+impl GroupChangeMessage {
+    /// Retrieve the group that changed
+    pub fn get_group(&self) -> GroupName {
+        match self {
+            Self::Join(name, _) => name,
+            Self::Leave(name, _) => name,
+        }
+    }
+}
+
+struct PgState {
+    map: Arc<DashMap<GroupName, HashMap<ActorId, ActorCell>>>,
+    listeners: Arc<DashMap<GroupName, Vec<ActorCell>>>,
+}
+
+static PG_MONITOR: OnceCell<PgState> = OnceCell::new();
+
+fn get_monitor<'a>() -> &'a PgState {
+    PG_MONITOR.get_or_init(|| PgState {
+        map: Arc::new(DashMap::new()),
+        listeners: Arc::new(DashMap::new()),
+    })
+}
+
+/// Join actors to the group `group`
+///
+/// * `group` - The staticly named group. Will be created if first actors to join
+/// * `actors` - Thie list of [crate::Actor]s to add to the group
+pub fn join(group: GroupName, actors: Vec<ActorCell>) {
+    let monitor = get_monitor();
+    // insert into the monitor group
+    match monitor.map.entry(group) {
+        Occupied(mut occupied) => {
+            let oref = occupied.get_mut();
+            for actor in actors.iter() {
+                oref.insert(actor.get_id(), actor.clone());
+            }
+        }
+        Vacant(vacancy) => {
+            let map = actors
+                .iter()
+                .map(|a| (a.get_id(), a.clone()))
+                .collect::<HashMap<_, _>>();
+            vacancy.insert(map);
+        }
+    }
+    // notify supervisors
+    if let Some(listeners) = monitor.listeners.get(&group) {
+        for listener in listeners.value() {
+            let _ = listener.send_supervisor_evt(SupervisionEvent::ProcessGroupChanged(
+                GroupChangeMessage::Join(group, actors.clone()),
+            ));
+        }
+    }
+}
+
+/// Leaves the specified [crate::Actor]s from the PG group
+///
+/// * `group` - The staticly named group
+/// * `actors` - Thie list of actors to remove from the group
+pub fn leave(group: GroupName, actors: Vec<ActorCell>) {
+    let monitor = get_monitor();
+    match monitor.map.entry(group) {
+        Vacant(_) => {}
+        Occupied(mut occupied) => {
+            let mut_ref = occupied.get_mut();
+            for actor in actors.iter() {
+                mut_ref.remove(&actor.get_id());
+            }
+            // the group is empty, remove it
+            if mut_ref.is_empty() {
+                occupied.remove();
+            }
+            if let Some(listeners) = monitor.listeners.get(&group) {
+                for listener in listeners.value() {
+                    let _ = listener.send_supervisor_evt(SupervisionEvent::ProcessGroupChanged(
+                        GroupChangeMessage::Leave(group, actors.clone()),
+                    ));
+                }
+            }
+        }
+    }
+}
+
+/// Leave all groups for a specific [ActorId].
+/// Used only during actor shutdown
+pub(crate) fn leave_all(actor: ActorId) {
+    let pg_monitor = get_monitor();
+    let map = pg_monitor.map.clone();
+
+    let mut empty_groups = vec![];
+    let mut removal_events = HashMap::new();
+
+    for mut kv in map.iter_mut() {
+        if let Some(actor_cell) = kv.value_mut().remove(&actor) {
+            removal_events.insert(*kv.key(), actor_cell);
+        }
+        if kv.value().is_empty() {
+            empty_groups.push(*kv.key());
+        }
+    }
+
+    // notify the listeners
+    let all_listeners = pg_monitor.listeners.clone();
+    for (group, cell) in removal_events.into_iter() {
+        if let Some(this_listeners) = all_listeners.get(&group) {
+            this_listeners.iter().for_each(|listener| {
+                let _ = listener.send_supervisor_evt(SupervisionEvent::ProcessGroupChanged(
+                    GroupChangeMessage::Leave(group, vec![cell.clone()]),
+                ));
+            });
+        }
+    }
+
+    // Cleanup empty groups
+    for group in empty_groups {
+        map.remove(group);
+    }
+}
+
+/// Returns all the actors running on the local node in the group `group`.
+///
+/// * `group_name` - Either a statically named group or scope
+pub fn get_local_members(group_name: GroupName) -> Vec<ActorCell> {
+    let monitor = get_monitor();
+    if let Some(actors) = monitor.map.get(&group_name) {
+        actors
+            .value()
+            .values()
+            .filter(|a| a.get_id().is_local())
+            .cloned()
+            .collect::<Vec<_>>()
+    } else {
+        vec![]
+    }
+}
+
+/// Returns all the actors running on any node in the group `group`.
+///
+/// * `group_name` - Either a statically named group or scope
+///
+/// Returns [Vec<_>] with the associated actors
+pub fn get_members(group_name: GroupName) -> Vec<ActorCell> {
+    let monitor = get_monitor();
+    if let Some(actors) = monitor.map.get(&group_name) {
+        actors.value().values().cloned().collect::<Vec<_>>()
+    } else {
+        vec![]
+    }
+}
+
+/// Return a list of all known groups
+///
+/// Returns a [Vec<_>] representing all the registered group names
+pub fn which_groups() -> Vec<GroupName> {
+    let monitor = get_monitor();
+    monitor
+        .map
+        .iter()
+        .map(|kvp| *(kvp.key()))
+        .collect::<Vec<_>>()
+}
+
+/// Subscribes the provided [crate::Actor] to the scope or group for updates
+///
+/// * `group_name` - The scope or group to monitor
+/// * `actor` - The [ActorCell] representing who will receive updates
+pub fn monitor(group_name: GroupName, actor: ActorCell) {
+    let monitor = get_monitor();
+    match monitor.listeners.entry(group_name) {
+        Occupied(mut occupied) => occupied.get_mut().push(actor),
+        Vacant(vacancy) => {
+            vacancy.insert(vec![actor]);
+        }
+    }
+}
+
+/// Unsubscribes the provided [crate::Actor] from the scope or group for updates
+///
+/// * `group_name` - The scope or group to monitor
+/// * `actor` - The [ActorCell] representing who will receive updates
+pub fn demonitor(group_name: GroupName, actor: ActorId) {
+    let monitor = get_monitor();
+    if let Occupied(mut entry) = monitor.listeners.entry(group_name) {
+        let mut_ref = entry.get_mut();
+        mut_ref.retain(|a| a.get_id() != actor);
+        if mut_ref.is_empty() {
+            entry.remove();
+        }
+    }
+}
+
+/// Remove the specified [ActorId] from monitoring all groups it might be.
+/// Used only during actor shutdown
+pub(crate) fn demonitor_all(actor: ActorId) {
+    let monitor = get_monitor();
+    let mut empty_groups = vec![];
+
+    for mut kvp in monitor.listeners.iter_mut() {
+        let v = kvp.value_mut();
+        v.retain(|v| v.get_id() != actor);
+        if v.is_empty() {
+            empty_groups.push(*kvp.key());
+        }
+    }
+
+    // cleanup empty listener groups
+    for empty_group in empty_groups {
+        monitor.listeners.remove(&empty_group);
+    }
+}

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -1,0 +1,272 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
+
+use ::function_name::named;
+use tokio::time::Duration;
+
+use crate::{Actor, ActorHandler, GroupName, SupervisionEvent};
+
+use crate::pg;
+
+struct TestActor;
+
+#[async_trait::async_trait]
+impl ActorHandler for TestActor {
+    type Msg = ();
+
+    type State = ();
+
+    async fn pre_start(&self, _this_actor: crate::ActorRef<Self>) -> Self::State {}
+}
+
+#[named]
+#[tokio::test]
+async fn test_basic_group() {
+    let (actor, handle) = Actor::spawn(None, TestActor)
+        .await
+        .expect("Failed to spawn test actor");
+
+    let group = function_name!();
+
+    // join the group
+    pg::join(group, vec![actor.clone().into()]);
+
+    let members = pg::get_members(group);
+    assert_eq!(1, members.len());
+
+    // Cleanup
+    actor.stop(None);
+    handle.await.expect("Actor cleanup failed");
+}
+
+#[named]
+#[tokio::test]
+async fn test_multiple_members_in_group() {
+    let group = function_name!();
+
+    let mut actors = vec![];
+    let mut handles = vec![];
+    for _ in 0..10 {
+        let (actor, handle) = Actor::spawn(None, TestActor)
+            .await
+            .expect("Failed to spawn test actor");
+        actors.push(actor);
+        handles.push(handle);
+    }
+
+    // join the group
+    pg::join(
+        group,
+        actors
+            .iter()
+            .map(|aref| aref.clone().get_cell())
+            .collect::<Vec<_>>(),
+    );
+
+    let members = pg::get_members(group);
+    assert_eq!(10, members.len());
+
+    // Cleanup
+    for actor in actors {
+        actor.stop(None);
+    }
+    for handle in handles.into_iter() {
+        handle.await.expect("Actor cleanup failed");
+    }
+}
+
+#[named]
+#[tokio::test]
+async fn test_multiple_groups() {
+    let group_a = concat!(function_name!(), "_a");
+    let group_b = concat!(function_name!(), "_b");
+
+    let mut actors = vec![];
+    let mut handles = vec![];
+    for _ in 0..10 {
+        let (actor, handle) = Actor::spawn(None, TestActor)
+            .await
+            .expect("Failed to spawn test actor");
+        actors.push(actor);
+        handles.push(handle);
+    }
+
+    // setup group_a and group_b
+    let these_actors = actors[0..5]
+        .iter()
+        .map(|a| a.clone().get_cell())
+        .collect::<Vec<_>>();
+    pg::join(group_a, these_actors);
+
+    let these_actors = actors[5..10]
+        .iter()
+        .map(|a| a.clone().get_cell())
+        .collect::<Vec<_>>();
+    pg::join(group_b, these_actors);
+
+    let members = pg::get_members(group_a);
+    assert_eq!(5, members.len());
+
+    let members = pg::get_members(group_b);
+    assert_eq!(5, members.len());
+
+    // Cleanup
+    for actor in actors {
+        actor.stop(None);
+    }
+    for handle in handles.into_iter() {
+        handle.await.expect("Actor cleanup failed");
+    }
+}
+
+#[named]
+#[tokio::test]
+async fn test_actor_leaves_pg_group_on_shutdown() {
+    let (actor, handle) = Actor::spawn(None, TestActor)
+        .await
+        .expect("Failed to spawn test actor");
+
+    let group = function_name!();
+
+    // join the group
+    pg::join(group, vec![actor.clone().into()]);
+
+    let members = pg::get_members(group);
+    assert_eq!(1, members.len());
+
+    // Cleanup
+    actor.stop(None);
+    handle.await.expect("Actor cleanup failed");
+    drop(actor);
+
+    let members = pg::get_members(group);
+    assert_eq!(0, members.len());
+}
+
+#[named]
+#[tokio::test]
+async fn test_actor_leaves_pg_group_manually() {
+    let group = function_name!();
+
+    let (actor, handle) = Actor::spawn(None, TestActor)
+        .await
+        .expect("Failed to spawn test actor");
+
+    // join the group (create on first use)
+    pg::join(group, vec![actor.clone().into()]);
+
+    // the group was created and is present
+    let groups = pg::which_groups();
+    assert!(groups.contains(&group));
+
+    let members = pg::get_members(group);
+    assert_eq!(1, members.len());
+
+    // leave the group
+    pg::leave(group, vec![actor.clone().into()]);
+
+    // pif-paf-poof the group is gone!
+    let groups = pg::which_groups();
+    assert!(!groups.contains(&group));
+
+    // members comes back empty
+    let members = pg::get_members(group);
+    assert_eq!(0, members.len());
+
+    // Cleanup
+    actor.stop(None);
+    handle.await.expect("Actor cleanup failed");
+}
+
+#[named]
+#[tokio::test]
+async fn test_pg_monitoring() {
+    let group = function_name!();
+
+    let counter = Arc::new(AtomicU8::new(0u8));
+
+    struct AutoJoinActor {
+        pg_group: GroupName,
+    }
+
+    #[async_trait::async_trait]
+    impl ActorHandler for AutoJoinActor {
+        type Msg = ();
+
+        type State = ();
+
+        async fn pre_start(&self, myself: crate::ActorRef<Self>) -> Self::State {
+            pg::join(self.pg_group, vec![myself.into()]);
+        }
+    }
+
+    struct NotificationMonitor {
+        pg_group: GroupName,
+        counter: Arc<AtomicU8>,
+    }
+
+    #[async_trait::async_trait]
+    impl ActorHandler for NotificationMonitor {
+        type Msg = ();
+
+        type State = ();
+
+        async fn pre_start(&self, myself: crate::ActorRef<Self>) -> Self::State {
+            pg::monitor(self.pg_group, myself.into());
+        }
+
+        async fn handle_supervisor_evt(
+            &self,
+            _myself: crate::ActorRef<Self>,
+            message: SupervisionEvent,
+            _state: &mut Self::State,
+        ) {
+            if let SupervisionEvent::ProcessGroupChanged(change) = message {
+                match change {
+                    pg::GroupChangeMessage::Join(_which, who) => {
+                        self.counter.fetch_add(who.len() as u8, Ordering::Relaxed);
+                    }
+                    pg::GroupChangeMessage::Leave(_which, who) => {
+                        self.counter.fetch_sub(who.len() as u8, Ordering::Relaxed);
+                    }
+                }
+            }
+        }
+    }
+    let (monitor_actor, monitor_handle) = Actor::spawn(
+        None,
+        NotificationMonitor {
+            pg_group: group,
+            counter: counter.clone(),
+        },
+    )
+    .await
+    .expect("Failed to start monitor actor");
+
+    // this actor's startup should "monitor" for PG changes
+    let (test_actor, test_handle) = Actor::spawn(None, AutoJoinActor { pg_group: group })
+        .await
+        .expect("Failed to start test actor");
+
+    // the monitor is notified async, so we need to wait a tiny bit
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(1, counter.load(Ordering::Relaxed));
+
+    // kill the pg member
+    test_actor.stop(None);
+    test_handle.await.expect("Actor cleanup failed");
+    // it should have notified that it's unsubscribed
+    assert_eq!(0, counter.load(Ordering::Relaxed));
+
+    // cleanup
+    monitor_actor.stop(None);
+    monitor_handle.await.expect("Actor cleanup failed");
+}
+
+// TODO: Tests to add
+// 1. Local vs remote members (can't test until we have proper remoting)

--- a/ractor/src/port/output/mod.rs
+++ b/ractor/src/port/output/mod.rs
@@ -74,16 +74,7 @@ where
         let mut subs = self.subscriptions.write().unwrap();
 
         // filter out dead subscriptions, since they're no longer valid
-        let dead_subs = subs
-            .iter()
-            .enumerate()
-            .rev()
-            .filter(|(_, sub)| sub.is_dead())
-            .map(|(a, _)| a)
-            .collect::<Vec<_>>();
-        for dead_sub in dead_subs {
-            subs.remove(dead_sub);
-        }
+        subs.retain(|sub| !sub.is_dead());
 
         let sub = OutputPortSubscription::new::<TMsg, F, TReceiver>(
             self.tx.subscribe(),

--- a/ractor/src/port/output/tests.rs
+++ b/ractor/src/port/output/tests.rs
@@ -34,8 +34,8 @@ async fn test_single_forward() {
             &self,
             myself: ActorRef<Self>,
             message: Self::Msg,
-            state: &Self::State,
-        ) -> Option<Self::State> {
+            state: &mut Self::State,
+        ) {
             println!("Test actor received a message");
             match message {
                 Self::Msg::Stop => {
@@ -44,7 +44,7 @@ async fn test_single_forward() {
                     }
                 }
             }
-            Some(*state + 1)
+            *state += 1;
         }
     }
 
@@ -90,8 +90,8 @@ async fn test_50_receivers() {
             &self,
             myself: ActorRef<Self>,
             message: Self::Msg,
-            state: &Self::State,
-        ) -> Option<Self::State> {
+            state: &mut Self::State,
+        ) {
             println!("Test actor received a message");
             match message {
                 Self::Msg::Stop => {
@@ -100,7 +100,7 @@ async fn test_50_receivers() {
                     }
                 }
             }
-            Some(*state + 1)
+            *state += 1;
         }
     }
 

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -5,6 +5,8 @@
 
 //! Tests on the actor registry
 
+use tokio::time::Duration;
+
 use crate::{Actor, ActorHandler, SpawnErr};
 
 #[tokio::test]
@@ -88,6 +90,9 @@ async fn test_actor_registry_unenrollment() {
 
     // drop the actor ref's
     drop(actor);
+
+    // unenrollment is a cast operation, so it's not immediate. wait for cleanup
+    tokio::time::sleep(Duration::from_millis(100)).await;
 
     // the actor was automatically removed
     assert!(crate::registry::try_get("unenrollment").is_none());

--- a/ractor/src/rpc/call_result.rs
+++ b/ractor/src/rpc/call_result.rs
@@ -48,8 +48,14 @@ impl<T> CallResult<T> {
     pub fn expect(self, msg: &'static str) -> T {
         match self {
             Self::Success(t) => t,
-            Self::Timeout => panic!("{}", msg),
-            Self::SenderError => panic!("{}", msg),
+            Self::Timeout => panic!(
+                "{} - called CallResult::<T>::expect()  on a `Timeout` value",
+                msg
+            ),
+            Self::SenderError => panic!(
+                "{} - called CallResult::<T>::expect() on a `SenderError` value",
+                msg
+            ),
         }
     }
 

--- a/ractor/src/rpc/tests.rs
+++ b/ractor/src/rpc/tests.rs
@@ -33,10 +33,9 @@ async fn test_rpc_cast() {
             &self,
             _this_actor: ActorRef<Self>,
             _message: Self::Msg,
-            _state: &Self::State,
-        ) -> Option<Self::State> {
+            _state: &mut Self::State,
+        ) {
             self.counter.fetch_add(1u8, Ordering::Relaxed);
-            None
         }
     }
 
@@ -83,8 +82,8 @@ async fn test_rpc_call() {
             &self,
             _this_actor: ActorRef<Self>,
             message: Self::Msg,
-            _state: &Self::State,
-        ) -> Option<Self::State> {
+            _state: &mut Self::State,
+        ) {
             match message {
                 Self::Msg::TestRpc(reply) => {
                     // An error sending means no one is listening anymore (the receiver was dropped),
@@ -94,7 +93,6 @@ async fn test_rpc_call() {
                     }
                 }
             }
-            None
         }
     }
 
@@ -141,8 +139,8 @@ async fn test_rpc_call_forwarding() {
             &self,
             _this_actor: ActorRef<Self>,
             message: Self::Msg,
-            _state: &Self::State,
-        ) -> Option<Self::State> {
+            _state: &mut Self::State,
+        ) {
             match message {
                 Self::Msg::TestRpc(reply) => {
                     // An error sending means no one is listening anymore (the receiver was dropped),
@@ -152,7 +150,6 @@ async fn test_rpc_call_forwarding() {
                     }
                 }
             }
-            None
         }
     }
 
@@ -177,15 +174,14 @@ async fn test_rpc_call_forwarding() {
             &self,
             _this_actor: ActorRef<Self>,
             message: Self::Msg,
-            _state: &Self::State,
-        ) -> Option<Self::State> {
+            _state: &mut Self::State,
+        ) {
             match message {
                 Self::Msg::ForwardResult(s) if s == *"howdy" => {
                     self.counter.fetch_add(1, Ordering::Relaxed);
                 }
                 _ => {}
             }
-            None
         }
     }
 

--- a/ractor/src/time/tests.rs
+++ b/ractor/src/time/tests.rs
@@ -33,11 +33,10 @@ async fn test_intervals() {
             &self,
             _this_actor: ActorRef<Self>,
             _message: Self::Msg,
-            state: &Self::State,
-        ) -> Option<Self::State> {
+            state: &mut Self::State,
+        ) {
             // stop the supervisor, which starts the supervision shutdown of children
             state.fetch_add(1, Ordering::Relaxed);
-            None
         }
     }
 
@@ -64,7 +63,7 @@ async fn test_intervals() {
     // kill the actor
     actor_ref.stop(None);
 
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
     // make sure the actor is dead + the interval handle doesn't send again
     assert!(interval_handle.is_finished());
     assert!(actor_handle.is_finished());
@@ -93,11 +92,10 @@ async fn test_send_after() {
             &self,
             _this_actor: ActorRef<Self>,
             _message: Self::Msg,
-            state: &Self::State,
-        ) -> Option<Self::State> {
+            state: &mut Self::State,
+        ) {
             // stop the supervisor, which starts the supervision shutdown of children
             state.fetch_add(1, Ordering::Relaxed);
-            None
         }
     }
 
@@ -170,10 +168,9 @@ async fn test_kill_after() {
             &self,
             _myself: ActorRef<Self>,
             _message: Self::Msg,
-            _state: &Self::State,
-        ) -> Option<Self::State> {
+            _state: &mut Self::State,
+        ) {
             tokio::time::sleep(Duration::from_millis(100)).await;
-            None
         }
     }
 


### PR DESCRIPTION
Erlang's process groups are named groups of collections of actors. They provide easy to use reference material for actors which may have "dispatching" purposes, in that you may want to send to 1, all, a region, etc.

This change also includes making state mutable. We've removed a lot of extra tasks and migrated to using the future's crate `catch_unwind` which saves a lot of state synchronization code laying around.