### PR TITLE
Cleanup trait definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ never be executed in parallel. Following the actor model leads to microservices 
 An example `ping-pong` actor might be the following
 
 ```rust
-use ractor::{Actor, ActorCell, ActorHandler};
+use ractor::{Actor, ActorCell};
 
 /// [PingPong] is a basic actor that will print
 /// ping..pong.. repeatedly until some exit
@@ -90,7 +90,7 @@ impl Message {
 
 // the implementation of our actor's "logic"
 #[async_trait::async_trait]
-impl ActorHandler for PingPong {
+impl Actor for PingPong {
     // An actor has a message type
     type Msg = Message;
     // and (optionally) internal state

--- a/ractor-playground/src/ping_pong.rs
+++ b/ractor-playground/src/ping_pong.rs
@@ -5,7 +5,7 @@
 
 //! A ping-pong actor implementation
 
-use ractor::{ActorHandler, ActorRef};
+use ractor::{Actor, ActorRef};
 
 pub struct PingPong;
 
@@ -32,7 +32,7 @@ impl Message {
 }
 
 #[async_trait::async_trait]
-impl ActorHandler for PingPong {
+impl Actor for PingPong {
     type Msg = Message;
 
     type State = u8;

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/benches/actor.rs
+++ b/ractor/benches/actor.rs
@@ -7,12 +7,12 @@
 extern crate criterion;
 
 use criterion::{BatchSize, Criterion};
-use ractor::{Actor, ActorHandler, ActorRef};
+use ractor::{Actor, ActorRef};
 
 struct BenchActor;
 
 #[async_trait::async_trait]
-impl ActorHandler for BenchActor {
+impl Actor for BenchActor {
     type Msg = ();
 
     type State = ();
@@ -137,7 +137,7 @@ fn process_messages(c: &mut Criterion) {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for MessagingActor {
+    impl Actor for MessagingActor {
         type Msg = ();
 
         type State = u64;

--- a/ractor/examples/counter.rs
+++ b/ractor/examples/counter.rs
@@ -14,7 +14,7 @@
 
 extern crate ractor;
 
-use ractor::{Actor, ActorHandler, ActorRef, RpcReplyPort};
+use ractor::{Actor, ActorRef, RpcReplyPort};
 use tokio::time::Duration;
 
 struct Counter;
@@ -31,7 +31,7 @@ enum CounterMessage {
 }
 
 #[async_trait::async_trait]
-impl ActorHandler for Counter {
+impl Actor for Counter {
     type Msg = CounterMessage;
 
     type State = CounterState;

--- a/ractor/examples/monte_carlo.rs
+++ b/ractor/examples/monte_carlo.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 
-use ractor::{Actor, ActorHandler, ActorId, ActorRef};
+use ractor::{Actor, ActorId, ActorRef};
 use rand::{thread_rng, Rng};
 
 // ================== Player Actor ================== //
@@ -60,7 +60,7 @@ impl GameState {
 struct Game;
 
 #[async_trait::async_trait]
-impl ActorHandler for Game {
+impl Actor for Game {
     type Msg = ActorRef<GameManager>;
 
     type State = GameState;
@@ -122,7 +122,7 @@ impl GameManagerState {
 }
 
 #[async_trait::async_trait]
-impl ActorHandler for GameManager {
+impl Actor for GameManager {
     type Msg = GameManagerMessage;
 
     type State = GameManagerState;

--- a/ractor/examples/output_port.rs
+++ b/ractor/examples/output_port.rs
@@ -15,7 +15,7 @@ extern crate ractor;
 
 use std::sync::Arc;
 
-use ractor::{Actor, ActorHandler, ActorRef, OutputPort};
+use ractor::{Actor, ActorRef, OutputPort};
 use tokio::time::{timeout, Duration};
 
 enum PublisherMessage {
@@ -27,7 +27,7 @@ struct Publisher {
 }
 
 #[async_trait::async_trait]
-impl ActorHandler for Publisher {
+impl Actor for Publisher {
     type Msg = PublisherMessage;
 
     type State = ();
@@ -51,7 +51,7 @@ enum SubscriberMessage {
 }
 
 #[async_trait::async_trait]
-impl ActorHandler for Subscriber {
+impl Actor for Subscriber {
     type Msg = SubscriberMessage;
 
     type State = ();

--- a/ractor/examples/philosophers.rs
+++ b/ractor/examples/philosophers.rs
@@ -20,7 +20,7 @@
 
 use std::collections::{HashMap, VecDeque};
 
-use ractor::{Actor, ActorHandler, ActorId, ActorName, ActorRef, RpcReplyPort};
+use ractor::{Actor, ActorId, ActorName, ActorRef, RpcReplyPort};
 use tokio::time::{Duration, Instant};
 
 // ============================ Fork Actor ============================ //
@@ -114,7 +114,7 @@ impl Fork {
 }
 
 #[async_trait::async_trait]
-impl ActorHandler for Fork {
+impl Actor for Fork {
     type Msg = ForkMessage;
     type State = ForkState;
     async fn pre_start(&self, _myself: ActorRef<Self>) -> Self::State {
@@ -299,7 +299,7 @@ impl Philosopher {
 }
 
 #[async_trait::async_trait]
-impl ActorHandler for Philosopher {
+impl Actor for Philosopher {
     type Msg = PhilosopherMessage;
     type State = PhilosopherState;
     async fn pre_start(&self, myself: ActorRef<Self>) -> Self::State {

--- a/ractor/examples/ping_pong.rs
+++ b/ractor/examples/ping_pong.rs
@@ -14,7 +14,7 @@
 
 extern crate ractor;
 
-use ractor::{Actor, ActorHandler, ActorRef};
+use ractor::{Actor, ActorRef};
 
 pub struct PingPong;
 
@@ -41,7 +41,7 @@ impl Message {
 }
 
 #[async_trait::async_trait]
-impl ActorHandler for PingPong {
+impl Actor for PingPong {
     type Msg = Message;
 
     type State = u8;

--- a/ractor/examples/supervisor.rs
+++ b/ractor/examples/supervisor.rs
@@ -11,7 +11,7 @@
 //! cargo run --example supervisor
 //! ```
 
-use ractor::{Actor, ActorHandler, ActorRef, RpcReplyPort, SupervisionEvent};
+use ractor::{Actor, ActorRef, RpcReplyPort, SupervisionEvent};
 
 use tokio::time::Duration;
 
@@ -67,7 +67,7 @@ enum LeafActorMessage {
 }
 
 #[async_trait::async_trait]
-impl ActorHandler for LeafActor {
+impl Actor for LeafActor {
     type Msg = LeafActorMessage;
     type State = LeafActorState;
     async fn pre_start(&self, _myself: ActorRef<Self>) -> Self::State {
@@ -117,7 +117,7 @@ enum MidLevelActorMessage {
 }
 
 #[async_trait::async_trait]
-impl ActorHandler for MidLevelActor {
+impl Actor for MidLevelActor {
     type Msg = MidLevelActorMessage;
     type State = MidLevelActorState;
 
@@ -189,7 +189,7 @@ enum RootActorMessage {
 }
 
 #[async_trait::async_trait]
-impl ActorHandler for RootActor {
+impl Actor for RootActor {
     type Msg = RootActorMessage;
     type State = RootActorState;
 

--- a/ractor/src/actor/actor_cell/actor_properties.rs
+++ b/ractor/src/actor/actor_cell/actor_properties.rs
@@ -11,9 +11,7 @@ use tokio::sync::mpsc;
 use crate::actor::messages::{BoxedMessage, StopMessage};
 use crate::actor::supervision::SupervisionTree;
 use crate::port::{BoundedInputPort, BoundedInputPortReceiver, InputPort, InputPortReceiver};
-use crate::{
-    ActorHandler, ActorId, ActorName, ActorStatus, MessagingErr, Signal, SupervisionEvent,
-};
+use crate::{Actor, ActorId, ActorName, ActorStatus, MessagingErr, Signal, SupervisionEvent};
 
 // The inner-properties of an Actor
 pub(crate) struct ActorProperties {
@@ -39,7 +37,7 @@ impl ActorProperties {
         InputPortReceiver<BoxedMessage>,
     )
     where
-        TActor: ActorHandler,
+        TActor: Actor,
     {
         let (tx_signal, rx_signal) = mpsc::channel(2);
         let (tx_stop, rx_stop) = mpsc::channel(2);
@@ -89,7 +87,7 @@ impl ActorProperties {
 
     pub fn send_message<TActor>(&self, message: TActor::Msg) -> Result<(), MessagingErr>
     where
-        TActor: ActorHandler,
+        TActor: Actor,
     {
         if self.type_id != std::any::TypeId::of::<TActor>() {
             return Err(MessagingErr::InvalidActorType);

--- a/ractor/src/actor/actor_cell/actor_ref.rs
+++ b/ractor/src/actor/actor_cell/actor_ref.rs
@@ -8,7 +8,7 @@
 use std::any::TypeId;
 use std::marker::PhantomData;
 
-use crate::{ActorHandler, ActorName, MessagingErr, SupervisionEvent};
+use crate::{Actor, ActorName, MessagingErr, SupervisionEvent};
 
 use super::ActorCell;
 
@@ -17,7 +17,7 @@ use super::ActorCell;
 /// the actor type everywhere
 pub struct ActorRef<TActor>
 where
-    TActor: ActorHandler,
+    TActor: Actor,
 {
     pub(crate) inner: ActorCell,
     _tactor: PhantomData<TActor>,
@@ -25,7 +25,7 @@ where
 
 impl<TActor> Clone for ActorRef<TActor>
 where
-    TActor: ActorHandler,
+    TActor: Actor,
 {
     fn clone(&self) -> Self {
         ActorRef {
@@ -37,7 +37,7 @@ where
 
 impl<TActor> std::ops::Deref for ActorRef<TActor>
 where
-    TActor: ActorHandler,
+    TActor: Actor,
 {
     type Target = ActorCell;
 
@@ -48,7 +48,7 @@ where
 
 impl<TActor> From<ActorCell> for ActorRef<TActor>
 where
-    TActor: ActorHandler,
+    TActor: Actor,
 {
     fn from(value: ActorCell) -> Self {
         Self {
@@ -60,7 +60,7 @@ where
 
 impl<TActor> From<ActorRef<TActor>> for ActorCell
 where
-    TActor: ActorHandler,
+    TActor: Actor,
 {
     fn from(value: ActorRef<TActor>) -> Self {
         value.inner
@@ -69,7 +69,7 @@ where
 
 impl<TActor> std::fmt::Debug for ActorRef<TActor>
 where
-    TActor: ActorHandler,
+    TActor: Actor,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.inner)
@@ -78,7 +78,7 @@ where
 
 impl<TActor> ActorRef<TActor>
 where
-    TActor: ActorHandler,
+    TActor: Actor,
 {
     /// Retrieve a cloned [ActorCell] representing this [ActorRef]
     pub fn get_cell(&self) -> ActorCell {

--- a/ractor/src/actor/actor_cell/mod.rs
+++ b/ractor/src/actor/actor_cell/mod.rs
@@ -16,7 +16,7 @@ use super::messages::{BoxedMessage, Signal, StopMessage};
 
 use super::SupervisionEvent;
 use crate::port::{BoundedInputPortReceiver, InputPortReceiver};
-use crate::{ActorHandler, ActorId, ActorName, SpawnErr};
+use crate::{Actor, ActorId, ActorName, SpawnErr};
 
 pub mod actor_ref;
 pub use actor_ref::ActorRef;
@@ -156,7 +156,7 @@ impl ActorCell {
     /// Returns a tuple [(ActorCell, ActorPortSet)] to bootstrap the [crate::Actor]
     pub(crate) fn new<TActor>(name: Option<ActorName>) -> Result<(Self, ActorPortSet), SpawnErr>
     where
-        TActor: ActorHandler,
+        TActor: Actor,
     {
         let (props, rx1, rx2, rx3, rx4) = ActorProperties::new::<TActor>(name);
         let cell = Self {
@@ -284,7 +284,7 @@ impl ActorCell {
     /// Returns [Ok(())] on successful message send, [Err(MessagingErr)] otherwise
     pub fn send_message<TActor>(&self, message: TActor::Msg) -> Result<(), MessagingErr>
     where
-        TActor: ActorHandler,
+        TActor: Actor,
     {
         self.inner.send_message::<TActor>(message)
     }
@@ -294,7 +294,7 @@ impl ActorCell {
     /// * `evt` - The event to send to this [super::Actor]'s supervisors
     pub fn notify_supervisor<TActor>(&self, evt: SupervisionEvent)
     where
-        TActor: ActorHandler,
+        TActor: Actor,
     {
         self.inner.tree.notify_supervisor::<TActor>(evt)
     }

--- a/ractor/src/actor/supervision.rs
+++ b/ractor/src/actor/supervision.rs
@@ -9,7 +9,7 @@
 //! Supervisors are responsible for the lifecycle of a child actor such that they get notified
 //! when a child actor starts, stops, or panics (when possible). The supervisor can then decide
 //! how to handle the event. Should it restart the actor, leave it dead, potentially die itself
-//! notifying the supervisor's supervisor? That's up to the implementation of the [super::ActorHandler]
+//! notifying the supervisor's supervisor? That's up to the implementation of the [super::Actor]
 //!
 //! This is currently an initial implementation of [Erlang supervisors](https://www.erlang.org/doc/man/supervisor.html)
 //! which will be expanded upon as the library develops. Next in line is likely supervision strategies
@@ -23,7 +23,7 @@ use std::sync::{
 use dashmap::DashMap;
 
 use super::{actor_cell::ActorCell, messages::SupervisionEvent};
-use crate::{ActorHandler, ActorId};
+use crate::{Actor, ActorId};
 
 /// A supervision tree
 #[derive(Default)]
@@ -107,7 +107,7 @@ impl SupervisionTree {
     /// Send a notification to all supervisors
     pub fn notify_supervisor<TActor>(&self, evt: SupervisionEvent)
     where
-        TActor: ActorHandler,
+        TActor: Actor,
     {
         if let Some(parent) = &*(self.supervisor.read().unwrap()) {
             let _ = parent.send_supervisor_evt(evt);

--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -12,7 +12,7 @@ use std::sync::{
 
 use tokio::time::Duration;
 
-use crate::{Actor, ActorCell, ActorHandler, ActorRef, ActorStatus, SupervisionEvent};
+use crate::{Actor, ActorCell, ActorRef, ActorStatus, SupervisionEvent};
 
 #[tokio::test]
 async fn test_supervision_panic_in_post_startup() {
@@ -22,7 +22,7 @@ async fn test_supervision_panic_in_post_startup() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for Child {
+    impl Actor for Child {
         type Msg = ();
         type State = ();
         async fn pre_start(&self, _this_actor: ActorRef<Self>) -> Self::State {}
@@ -32,7 +32,7 @@ async fn test_supervision_panic_in_post_startup() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for Supervisor {
+    impl Actor for Supervisor {
         type Msg = ();
         type State = ();
         async fn pre_start(&self, _this_actor: ActorRef<Self>) -> Self::State {}
@@ -89,7 +89,7 @@ async fn test_supervision_panic_in_handle() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for Child {
+    impl Actor for Child {
         type Msg = ();
         type State = ();
         async fn pre_start(&self, _this_actor: ActorRef<Self>) -> Self::State {}
@@ -104,7 +104,7 @@ async fn test_supervision_panic_in_handle() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for Supervisor {
+    impl Actor for Supervisor {
         type Msg = ();
         type State = ();
         async fn pre_start(&self, _this_actor: ActorRef<Self>) -> Self::State {}
@@ -169,7 +169,7 @@ async fn test_supervision_panic_in_post_stop() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for Child {
+    impl Actor for Child {
         type Msg = ();
         type State = ();
         async fn pre_start(&self, myself: ActorRef<Self>) -> Self::State {
@@ -182,7 +182,7 @@ async fn test_supervision_panic_in_post_stop() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for Supervisor {
+    impl Actor for Supervisor {
         type Msg = ();
         type State = ();
         async fn pre_start(&self, _this_actor: ActorRef<Self>) -> Self::State {}
@@ -233,7 +233,7 @@ async fn test_supervision_panic_in_supervisor_handle() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for Child {
+    impl Actor for Child {
         type Msg = ();
         type State = ();
         async fn pre_start(&self, _this_actor: ActorRef<Self>) -> Self::State {}
@@ -248,7 +248,7 @@ async fn test_supervision_panic_in_supervisor_handle() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for Midpoint {
+    impl Actor for Midpoint {
         type Msg = ();
         type State = ();
         async fn pre_start(&self, _this_actor: ActorRef<Self>) -> Self::State {}
@@ -265,7 +265,7 @@ async fn test_supervision_panic_in_supervisor_handle() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for Supervisor {
+    impl Actor for Supervisor {
         type Msg = ();
         type State = ();
         async fn pre_start(&self, _this_actor: ActorRef<Self>) -> Self::State {}
@@ -345,14 +345,14 @@ async fn test_killing_a_supervisor_terminates_children() {
     struct Supervisor;
 
     #[async_trait::async_trait]
-    impl ActorHandler for Child {
+    impl Actor for Child {
         type Msg = ();
         type State = ();
         async fn pre_start(&self, _this_actor: ActorRef<Self>) -> Self::State {}
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for Supervisor {
+    impl Actor for Supervisor {
         type Msg = ();
         type State = ();
         async fn pre_start(&self, _this_actor: ActorRef<Self>) -> Self::State {}

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -20,7 +20,7 @@
 //! An example "ping-pong" actor might be the following
 //!
 //! ```rust
-//! use ractor::{Actor, ActorRef, ActorHandler};
+//! use ractor::{Actor, ActorRef};
 //!
 //! /// [PingPong] is a basic actor that will print
 //! /// ping..pong.. repeatedly until some exit
@@ -54,7 +54,7 @@
 //!
 //! // the implementation of our actor's "logic"
 //! #[async_trait::async_trait]
-//! impl ActorHandler for PingPong {
+//! impl Actor for PingPong {
 //!     // An actor has a message type
 //!     type Msg = Message;
 //!     // and (optionally) internal state
@@ -111,7 +111,7 @@
 //!
 //! NOTE: panic's in `pre_start` of an actor will cause failures to spawn, rather than supervision notified failurs as the actor hasn't "linked"
 //! to its supervisor yet. However failures in `post_start`, `handle`, `handle_supervisor_evt`, `post_stop` will notify the supervisor should a failure
-//! occur. See [crate::ActorHandler] documentation for more information
+//! occur. See [crate::Actor] documentation for more information
 //!
 //! ## Messaging actors
 //!
@@ -164,9 +164,9 @@ use rand as _;
 pub use actor::actor_cell::{ActorCell, ActorRef, ActorStatus, ACTIVE_STATES};
 pub use actor::errors::{ActorErr, MessagingErr, SpawnErr};
 pub use actor::messages::{Signal, SupervisionEvent};
-pub use actor::{Actor, ActorHandler};
+pub use actor::{Actor, ActorRuntime};
 pub use actor_id::ActorId;
-pub use port::{InputPort, OutputMessage, OutputPort, RpcReplyPort};
+pub use port::{OutputMessage, OutputPort, RpcReplyPort};
 
 /// Message type for an actor. Generally an enum
 /// which muxes the various types of inner-messages the actor

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -9,14 +9,14 @@ use std::sync::Arc;
 use ::function_name::named;
 use tokio::time::Duration;
 
-use crate::{Actor, ActorHandler, GroupName, SupervisionEvent};
+use crate::{Actor, GroupName, SupervisionEvent};
 
 use crate::pg;
 
 struct TestActor;
 
 #[async_trait::async_trait]
-impl ActorHandler for TestActor {
+impl Actor for TestActor {
     type Msg = ();
 
     type State = ();
@@ -195,7 +195,7 @@ async fn test_pg_monitoring() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for AutoJoinActor {
+    impl Actor for AutoJoinActor {
         type Msg = ();
 
         type State = ();
@@ -211,7 +211,7 @@ async fn test_pg_monitoring() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for NotificationMonitor {
+    impl Actor for NotificationMonitor {
         type Msg = ();
 
         type State = ();

--- a/ractor/src/port/mod.rs
+++ b/ractor/src/port/mod.rs
@@ -23,7 +23,7 @@ pub(crate) type BoundedInputPort<TMsg> = mpsc::Sender<TMsg>;
 pub(crate) type BoundedInputPortReceiver<TMsg> = mpsc::Receiver<TMsg>;
 
 /// An unbounded message port (alias of [mpsc::UnboundedSender])
-pub type InputPort<TMsg> = mpsc::UnboundedSender<TMsg>;
+pub(crate) type InputPort<TMsg> = mpsc::UnboundedSender<TMsg>;
 /// An unbounded message port's receiver (alias of [mpsc::UnboundedReceiver])
 pub(crate) type InputPortReceiver<TMsg> = mpsc::UnboundedReceiver<TMsg>;
 

--- a/ractor/src/port/output/mod.rs
+++ b/ractor/src/port/output/mod.rs
@@ -15,7 +15,7 @@ use std::sync::RwLock;
 use tokio::sync::broadcast as pubsub;
 use tokio::task::JoinHandle;
 
-use crate::{ActorHandler, ActorRef, Message};
+use crate::{Actor, ActorRef, Message};
 
 #[cfg(test)]
 mod tests;
@@ -69,7 +69,7 @@ where
     pub fn subscribe<TReceiver, F>(&self, receiver: ActorRef<TReceiver>, converter: F)
     where
         F: Fn(TMsg) -> Option<TReceiver::Msg> + Send + 'static,
-        TReceiver: ActorHandler,
+        TReceiver: Actor,
     {
         let mut subs = self.subscriptions.write().unwrap();
 
@@ -136,7 +136,7 @@ impl OutputPortSubscription {
     where
         TMsg: OutputMessage,
         F: Fn(TMsg) -> Option<TReceiver::Msg> + Send + 'static,
-        TReceiver: ActorHandler,
+        TReceiver: Actor,
     {
         let handle = tokio::spawn(async move {
             while let Ok(Some(msg)) = port.recv().await {

--- a/ractor/src/port/output/tests.rs
+++ b/ractor/src/port/output/tests.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use futures::future::join_all;
 use tokio::time::timeout;
 
-use crate::{Actor, ActorHandler, ActorRef};
+use crate::{Actor, ActorRef};
 
 use super::*;
 
@@ -21,7 +21,7 @@ async fn test_single_forward() {
         Stop,
     }
     #[async_trait::async_trait]
-    impl ActorHandler for TestActor {
+    impl Actor for TestActor {
         type Msg = TestActorMessage;
 
         type State = u8;
@@ -77,7 +77,7 @@ async fn test_50_receivers() {
         Stop,
     }
     #[async_trait::async_trait]
-    impl ActorHandler for TestActor {
+    impl Actor for TestActor {
         type Msg = TestActorMessage;
 
         type State = u8;

--- a/ractor/src/registry/mod.rs
+++ b/ractor/src/registry/mod.rs
@@ -15,7 +15,7 @@
 //!
 //! You can then retrieve actors by name with [where_is]. Note: this
 //! function only returns the [ActorCell] reference to the actor, it
-//! additionally requires knowledge of the [crate::ActorHandler] in order
+//! additionally requires knowledge of the [crate::Actor] in order
 //! to send messages to it (since you need to know the message type)
 //! or agents will runtime panic on message reception, and supervision
 //! processes would need to restart the actors.

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -7,14 +7,14 @@
 
 use tokio::time::Duration;
 
-use crate::{Actor, ActorHandler, SpawnErr};
+use crate::{Actor, SpawnErr};
 
 #[tokio::test]
 async fn test_basic_registation() {
     struct EmptyActor;
 
     #[async_trait::async_trait]
-    impl ActorHandler for EmptyActor {
+    impl Actor for EmptyActor {
         type Msg = ();
 
         type State = ();
@@ -37,7 +37,7 @@ async fn test_duplicate_registration() {
     struct EmptyActor;
 
     #[async_trait::async_trait]
-    impl ActorHandler for EmptyActor {
+    impl Actor for EmptyActor {
         type Msg = ();
 
         type State = ();
@@ -70,7 +70,7 @@ async fn test_actor_registry_unenrollment() {
     struct EmptyActor;
 
     #[async_trait::async_trait]
-    impl ActorHandler for EmptyActor {
+    impl Actor for EmptyActor {
         type Msg = ();
 
         type State = ();

--- a/ractor/src/rpc/tests.rs
+++ b/ractor/src/rpc/tests.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use tokio::time::Duration;
 
 use crate::rpc;
-use crate::{Actor, ActorHandler, ActorRef};
+use crate::{Actor, ActorRef};
 
 #[tokio::test]
 async fn test_rpc_cast() {
@@ -22,7 +22,7 @@ async fn test_rpc_cast() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for TestActor {
+    impl Actor for TestActor {
         type Msg = ();
 
         type State = ();
@@ -71,7 +71,7 @@ async fn test_rpc_call() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for TestActor {
+    impl Actor for TestActor {
         type Msg = MessageFormat;
 
         type State = ();
@@ -128,7 +128,7 @@ async fn test_rpc_call_forwarding() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for Worker {
+    impl Actor for Worker {
         type Msg = WorkerMessage;
 
         type State = ();
@@ -163,7 +163,7 @@ async fn test_rpc_call_forwarding() {
     }
 
     #[async_trait::async_trait]
-    impl ActorHandler for Forwarder {
+    impl Actor for Forwarder {
         type Msg = ForwarderMessage;
 
         type State = ();


### PR DESCRIPTION
This change renames `ActorHandler` to `Actor` and `Actor` to `ActorRuntime`. This is helpful because 90% of what people will work with is just the trait definition, which `Actor` is more logical than the "handler" naming scheme.

Additionally we can avoid existing breakages by re-defining on the `Actor{Handler}` trait the `spawn` and `spawn_linked` calls such that anyone already calling `Actor::spawn` doesn't have to change any syntax.