### PR TITLE
Adding support for RPC macros

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/examples/counter.rs
+++ b/ractor/examples/counter.rs
@@ -14,8 +14,7 @@
 
 extern crate ractor;
 
-use ractor::{Actor, ActorRef, RpcReplyPort};
-use tokio::time::Duration;
+use ractor::{call_t, Actor, ActorRef, RpcReplyPort};
 
 struct Counter;
 
@@ -76,10 +75,7 @@ async fn main() {
             .send_message(CounterMessage::Decrement(5))
             .expect("Failed to send message");
 
-        let rpc_result = actor
-            .call(CounterMessage::Retrieve, Some(Duration::from_millis(10)))
-            .await
-            .expect("Failed to send RPC");
+        let rpc_result = call_t!(actor, CounterMessage::Retrieve, 10);
 
         println!(
             "Count is: {}",

--- a/ractor/examples/ping_pong.rs
+++ b/ractor/examples/ping_pong.rs
@@ -14,7 +14,7 @@
 
 extern crate ractor;
 
-use ractor::{Actor, ActorRef};
+use ractor::{cast, Actor, ActorRef};
 
 pub struct PingPong;
 
@@ -48,7 +48,7 @@ impl Actor for PingPong {
 
     async fn pre_start(&self, myself: ActorRef<Self>) -> Self::State {
         // startup the event processing
-        myself.send_message(Message::Ping).unwrap();
+        cast!(myself, Message::Ping).unwrap();
         // create the initial state
         0u8
     }
@@ -56,7 +56,7 @@ impl Actor for PingPong {
     async fn handle(&self, myself: ActorRef<Self>, message: Self::Msg, state: &mut Self::State) {
         if *state < 10u8 {
             message.print();
-            myself.send_message(message.next()).unwrap();
+            cast!(myself, message.next()).unwrap();
             *state += 1;
         } else {
             println!();

--- a/ractor/src/time/tests.rs
+++ b/ractor/src/time/tests.rs
@@ -114,7 +114,7 @@ async fn test_send_after() {
     // kill the actor
     actor_ref.stop(None);
 
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
     // make sure the actor is dead + the interval handle doesn't send again
     assert!(send_after_handle.is_finished());
     assert!(actor_handle.is_finished());


### PR DESCRIPTION
This PR cleans up the recent addition of macros along with some cleaner matching syntax

1. `call!` - Make an Rpc call without a timeout
2. `call_t!` - Make an Rpc call with a timeout
3. `forward!` - Make an Rpc call and forward it to another actor
4. `cast!` - Cast a message to an actor

There's more to come, but it cleans up the need to build a closure on the fly