### PR TITLE
Small macro cleanups + big concurrency cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ A pure-Rust actor framework. Inspired from [Erlang's `gen_server`](https://www.e
 
 `ractor` tries to solve the problem of building and maintaing an Erlang-like actor framework in Rust. It gives
 a set of generic primitives and helps automate the supervision tree and management of our actors along with the traditional actor message processing logic. It's built *heavily* on `tokio` which is a
-hard requirement for `ractor`. 
+hard requirement for `ractor`.
 
-`ractor` is a modern actor framework written in 100% rust with NO `unsafe` code. 
+`ractor` is a modern actor framework written in 100% rust with NO `unsafe` code.
 
 ### Why ractor?
 
@@ -27,7 +27,7 @@ Ractor tries to be different my modelling more on a pure Erlang `gen_server`. Th
 
 Additionally we wrote `ractor` without building on some kind of "Runtime" or "System" which needs to be spawned. Actors can be run independently, in conjunction with other basic `tokio` runtimes with little additional overhead.
 
-We currently have full support for 
+We currently have full support for:
 
 1. Single-threaded message processing
 2. Actor supervision tree
@@ -35,7 +35,6 @@ We currently have full support for
 4. Timers
 5. Named actor registry (`ractor::registry`) from [Erlang's `Registered processes`](https://www.erlang.org/doc/reference_manual/processes.html)
 6. Process groups (`ractor::pg`) from [Erlang's `pg` module](https://www.erlang.org/doc/man/pg.html)
-
 
 On our roadmap is to add more of the Erlang functionality including potentially a distributed actor cluster.
 
@@ -45,7 +44,7 @@ Install `ractor` by adding the following to your Cargo.toml dependencies
 
 ```toml
 [dependencies]
-ractor = "0.3"
+ractor = "0.4"
 ```
 
 ## Working with Actors
@@ -150,7 +149,7 @@ work will complete, and on the next message processing iteration Stop will take 
 currently executing work, regardless of the provided reason.
 3. SupervisionEvent: Supervision events are messages from child actors to their supervisors in the event of their startup, death, and/or unhandled panic. Supervision events
 are how an actor's supervisor(s) are notified of events of their children and can handle lifetime events for them.
-4. Messages: Regular, user-defined, messages are the last channel of communication to actors. They are the lowest priority of the 4 message types and denote general actor work. The first 
+4. Messages: Regular, user-defined, messages are the last channel of communication to actors. They are the lowest priority of the 4 message types and denote general actor work. The first
 3 messages types (signals, stop, supervision) are generally quiet unless it's a lifecycle event for the actor, but this channel is the "work" channel doing what your actor wants to do!
 
 ## Contributors

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -12,12 +12,21 @@ readme = "../README.md"
 homepage = "https://github.com/slawlor/ractor"
 categories = ["actor", "erlang"]
 
+# WIP
+# [features]
+# tokio_runtime = ["tokio/time"]
+# async_std_runtime = ["async-std"]
+
+# default = ["tokio_runtime"]
+# default = ["async_std_runtime"]
+
 [dependencies]
+async-std = { version = "1", optional = true }
 async-trait = "0.1"
 dashmap = "5"
 futures = "0.3"
 once_cell = "1"
-tokio = { version = "1", features = ["rt", "time", "sync", "macros"]}
+tokio = { version = "1", features = ["sync", "time"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/ractor/src/actor/errors.rs
+++ b/ractor/src/actor/errors.rs
@@ -99,19 +99,6 @@ impl<T> From<tokio::sync::mpsc::error::SendError<T>> for MessagingErr {
         Self::ChannelClosed
     }
 }
-
-impl<T> From<tokio::sync::broadcast::error::SendError<T>> for MessagingErr {
-    fn from(_: tokio::sync::broadcast::error::SendError<T>) -> Self {
-        Self::ChannelClosed
-    }
-}
-
-impl<T> From<tokio::sync::watch::error::SendError<T>> for MessagingErr {
-    fn from(_: tokio::sync::watch::error::SendError<T>) -> Self {
-        Self::ChannelClosed
-    }
-}
-
 impl<T> From<tokio::sync::mpsc::error::TrySendError<T>> for MessagingErr {
     fn from(_: tokio::sync::mpsc::error::TrySendError<T>) -> Self {
         Self::ChannelClosed

--- a/ractor/src/actor/mod.rs
+++ b/ractor/src/actor/mod.rs
@@ -11,8 +11,8 @@
 
 use std::{panic::AssertUnwindSafe, sync::Arc};
 
+use crate::concurrency::JoinHandle;
 use futures::TryFutureExt;
-use tokio::task::JoinHandle;
 
 pub mod messages;
 use messages::*;
@@ -216,7 +216,7 @@ where
 
     /// Start the actor immediately, optionally linking to a parent actor (supervision tree)
     ///
-    /// NOTE: This returned [tokio::task::JoinHandle] is guaranteed to not panic (unless the runtime is shutting down perhaps).
+    /// NOTE: This returned [crate::concurrency::JoinHandle] is guaranteed to not panic (unless the runtime is shutting down perhaps).
     /// An inner join handle is capturing panic results from any part of the inner tasks, so therefore
     /// we can safely ignore it, or wait on it to block on the actor's progress
     ///
@@ -249,7 +249,7 @@ where
         // run the processing loop, backgrounding the work
         let myself = self.base.clone();
         let myself_ret = self.base.clone();
-        let handle = tokio::spawn(async move {
+        let handle = crate::concurrency::spawn(async move {
             let evt = match Self::processing_loop(
                 ports,
                 &mut state,

--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -10,11 +10,11 @@ use std::sync::{
     Arc,
 };
 
-use tokio::time::Duration;
+use crate::concurrency::Duration;
 
 use crate::{Actor, ActorCell, ActorRef, ActorStatus, SupervisionEvent};
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_supervision_panic_in_post_startup() {
     struct Child;
     struct Supervisor {
@@ -81,7 +81,7 @@ async fn test_supervision_panic_in_post_startup() {
     assert_eq!(0, supervisor_ref.get_num_children());
 }
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_supervision_panic_in_handle() {
     struct Child;
     struct Supervisor {
@@ -161,7 +161,7 @@ async fn test_supervision_panic_in_handle() {
     assert_eq!(0, supervisor_ref.get_num_children());
 }
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_supervision_panic_in_post_stop() {
     struct Child;
     struct Supervisor {
@@ -224,7 +224,7 @@ async fn test_supervision_panic_in_post_stop() {
 
 /// Test that a panic in the supervisor's handling propogates to
 /// the supervisor's supervisor
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_supervision_panic_in_supervisor_handle() {
     struct Child;
     struct Midpoint;
@@ -339,7 +339,7 @@ async fn test_supervision_panic_in_supervisor_handle() {
     assert_eq!(0, supervisor_ref.get_num_children());
 }
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_killing_a_supervisor_terminates_children() {
     struct Child;
     struct Supervisor;
@@ -389,7 +389,7 @@ async fn test_killing_a_supervisor_terminates_children() {
         .expect("Failed to wait for supervisor to shutdown");
 
     // wait for async shutdown
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    crate::concurrency::sleep(Duration::from_millis(50)).await;
 
     assert_eq!(ActorStatus::Stopped, child_ref.get_status());
 

--- a/ractor/src/concurrency.rs
+++ b/ractor/src/concurrency.rs
@@ -1,0 +1,156 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! Shared concurrency primatives utilized within the library for different frameworks (tokio, async-std, etc)
+
+/// A timoeout error
+#[derive(Debug)]
+pub struct Timeout;
+
+/// A one-use sender
+pub type OneshotSender<T> = tokio::sync::oneshot::Sender<T>;
+/// A one-use receiver
+pub type OneshotReceiver<T> = tokio::sync::oneshot::Receiver<T>;
+
+/// A bounded MP;SC sender
+pub type MpscSender<T> = tokio::sync::mpsc::Sender<T>;
+/// A bounded MP;SC receiver
+pub type MpscReceiver<T> = tokio::sync::mpsc::Receiver<T>;
+
+/// A bounded MP;SC sender
+pub type MpscUnboundedSender<T> = tokio::sync::mpsc::UnboundedSender<T>;
+/// A bounded MP;SC receiver
+pub type MpscUnboundedReceiver<T> = tokio::sync::mpsc::UnboundedReceiver<T>;
+
+/// MPSC bounded channel
+pub fn mpsc_bounded<T>(buffer: usize) -> (MpscSender<T>, MpscReceiver<T>) {
+    tokio::sync::mpsc::channel(buffer)
+}
+
+/// MPSC unbounded channel
+pub fn mpsc_unbounded<T>() -> (MpscUnboundedSender<T>, MpscUnboundedReceiver<T>) {
+    tokio::sync::mpsc::unbounded_channel()
+}
+
+/// Oneshot channel
+pub fn oneshot<T>() -> (OneshotSender<T>, OneshotReceiver<T>) {
+    tokio::sync::oneshot::channel()
+}
+
+// =============== TOKIO =============== //
+
+/// Tokio-based primatives
+// #[cfg(feature = "tokio_runtime")]
+pub mod tokio_primatives {
+    use std::future::Future;
+
+    /// Represents a task JoinHandle
+    pub type JoinHandle<T> = tokio::task::JoinHandle<T>;
+
+    /// A duration of time
+    pub type Duration = tokio::time::Duration;
+
+    /// Sleep the task for a duration of time
+    pub async fn sleep(dur: super::Duration) {
+        tokio::time::sleep(dur).await;
+    }
+
+    /// Spawn a task on the executor runtime
+    pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        tokio::task::spawn(future)
+    }
+
+    /// Execute the future up to a timeout
+    ///
+    /// * `dur`: The duration of time to allow the future to execute for
+    /// * `future`: The future to execute
+    ///
+    /// Returns [Ok(_)] if the future succeeded before the timeout, [Err(super::Timeout)] otherwise
+    pub async fn timeout<F, T>(dur: super::Duration, future: F) -> Result<T, super::Timeout>
+    where
+        F: Future<Output = T>,
+    {
+        tokio::time::timeout(dur, future)
+            .await
+            .map_err(|_| super::Timeout)
+    }
+
+    macro_rules! select {
+        ($($tokens:tt)*) => {{
+            tokio::select! {
+                // Biased ensures that we poll the ports in the order they appear, giving
+                // priority to our message reception operations. See:
+                // https://docs.rs/tokio/latest/tokio/macro.select.html#fairness
+                // for more information
+                biased;
+
+                $( $tokens )*
+            }
+        }}
+    }
+
+    pub(crate) use select;
+
+    // pub use tokio::select;
+    // test macro
+    #[cfg(test)]
+    pub(crate) use tokio::test;
+}
+// #[cfg(feature = "tokio_runtime")]
+pub use tokio_primatives::*;
+
+// =============== ASYNC-STD =============== //
+
+/// Tokio-based primatives
+#[cfg(feature = "async_std_runtime")]
+pub mod async_std_primatives {
+    use std::future::Future;
+
+    /// Represents a task JoinHandle
+    pub type JoinHandle<T> = async_std::task::JoinHandle<T>;
+
+    /// A duration of time
+    pub type Duration = std::time::Duration;
+
+    /// Sleep the task for a duration of time
+    pub async fn sleep(dur: super::Duration) {
+        async_std::task::sleep(dur).await;
+    }
+
+    /// Spawn a task on the executor runtime
+    pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        async_std::task::spawn(future)
+    }
+
+    /// Execute the future up to a timeout
+    ///
+    /// * `dur`: The duration of time to allow the future to execute for
+    /// * `future`: The future to execute
+    ///
+    /// Returns [Ok(_)] if the future succeeded before the timeout, [Err(super::Timeout)] otherwise
+    pub async fn timeout<F, T>(dur: super::Duration, future: F) -> Result<T, super::Timeout>
+    where
+        F: Future<Output = T>,
+    {
+        async_std::future::timeout(dur, future)
+            .await
+            .map_err(|_| super::Timeout)
+    }
+
+    pub use futures::select_biased as select;
+    // test macro
+    #[cfg(test)]
+    pub(crate) use tokio::test;
+}
+#[cfg(feature = "async_std_runtime")]
+pub use async_std_primatives::*;

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -145,6 +145,7 @@ pub type GroupName = &'static str;
 
 pub mod actor;
 pub mod actor_id;
+pub mod concurrency;
 pub mod macros;
 pub mod pg;
 pub mod port;

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ractor = "0.1"
+//! ractor = "0.4"
 //! ```
 //!
 //! ## Getting started

--- a/ractor/src/macros.rs
+++ b/ractor/src/macros.rs
@@ -143,7 +143,7 @@ macro_rules! call {
 macro_rules! call_t {
     ($actor:expr, $msg:expr, $timeout_ms:expr) => {{
         let err = $actor
-            .call(|tx| $msg(tx), Some(tokio::time::Duration::from_millis($timeout_ms)))
+            .call(|tx| $msg(tx), Some($crate::concurrency::Duration::from_millis($timeout_ms)))
             .await
             .map_err($crate::RactorErr::from);
         match err {
@@ -154,7 +154,7 @@ macro_rules! call_t {
     }};
     ($actor:expr, $msg:expr, $timeout_ms:expr, $($args:expr),*) => {{
         let err = $actor
-            .call(|tx| $msg($($args),*, tx), Some(tokio::time::Duration::from_millis($timeout_ms)))
+            .call(|tx| $msg($($args),*, tx), Some($crate::concurrency::Duration::from_millis($timeout_ms)))
             .await
             .map_err($crate::RactorErr::from);
         match err {
@@ -173,7 +173,7 @@ macro_rules! call_t {
 /// the actor supports.
 /// * `$forward` - The [crate::ActorRef] to forward the call to
 /// * `$forward_mapping` - The message transformer from the RPC result to the forwarding actor's message format
-/// * `$timeout` - The [tokio::time::Duration] to allow the call to complete before timing out.
+/// * `$timeout` - The [crate::concurrency::Duration] to allow the call to complete before timing out.
 ///
 /// Returns [Ok(())] on successful call forwarding, [Err(crate::RactorErr)] otherwies
 #[macro_export]

--- a/ractor/src/macros.rs
+++ b/ractor/src/macros.rs
@@ -9,7 +9,7 @@
 /// which can be pattern matched on in order to derive the output
 #[macro_export]
 macro_rules! cast {
-    ($actor:ident, $msg:expr) => {
+    ($actor:expr, $msg:expr) => {
         $actor.cast($msg).map_err($crate::RactorErr::from)
     };
 }
@@ -65,7 +65,7 @@ macro_rules! cast {
 /// ```
 #[macro_export]
 macro_rules! call {
-    ($actor:ident, $msg:expr) => {{
+    ($actor:expr, $msg:expr) => {{
         let err = $actor
             .call(|tx| $msg(tx), None)
             .await
@@ -76,7 +76,7 @@ macro_rules! call {
             Err(e) => Err(e),
         }
     }};
-    ($actor:ident, $msg:expr, $($args:expr),*) => {{
+    ($actor:expr, $msg:expr, $($args:expr),*) => {{
         let err = $actor
             .call(|tx| $msg($($args),*, tx), None)
             .await
@@ -141,7 +141,7 @@ macro_rules! call {
 /// ```
 #[macro_export]
 macro_rules! call_t {
-    ($actor:ident, $msg:expr, $timeout_ms:literal) => {{
+    ($actor:expr, $msg:expr, $timeout_ms:expr) => {{
         let err = $actor
             .call(|tx| $msg(tx), Some(tokio::time::Duration::from_millis($timeout_ms)))
             .await
@@ -152,7 +152,7 @@ macro_rules! call_t {
             Err(e) => Err(e),
         }
     }};
-    ($actor:ident, $msg:expr, $timeout_ms:literal, $($args:expr),*) => {{
+    ($actor:expr, $msg:expr, $timeout_ms:expr, $($args:expr),*) => {{
         let err = $actor
             .call(|tx| $msg($($args),*, tx), Some(tokio::time::Duration::from_millis($timeout_ms)))
             .await
@@ -178,7 +178,7 @@ macro_rules! call_t {
 /// Returns [Ok(())] on successful call forwarding, [Err(crate::RactorErr)] otherwies
 #[macro_export]
 macro_rules! forward {
-    ($actor:ident, $msg:expr, $forward:ident, $forward_mapping:expr) => {{
+    ($actor:expr, $msg:expr, $forward:ident, $forward_mapping:expr) => {{
         let future_or_err = $actor
             .call_and_forward(|tx| $msg(tx), &$forward, $forward_mapping, None)
             .map_err($crate::RactorErr::from);
@@ -197,7 +197,7 @@ macro_rules! forward {
             Err(e) => Err(e),
         }
     }};
-    ($actor:ident, $msg:expr, $forward:ident, $forward_mapping:expr, $timeout:expr) => {{
+    ($actor:expr, $msg:expr, $forward:ident, $forward_mapping:expr, $timeout:expr) => {{
         let future_or_err = $actor
             .call_and_forward(|tx| $msg(tx), &$forward, $forward_mapping, Some($timeout))
             .map_err($crate::RactorErr::from);

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -6,8 +6,8 @@
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
+use crate::concurrency::Duration;
 use ::function_name::named;
-use tokio::time::Duration;
 
 use crate::{Actor, GroupName, SupervisionEvent};
 
@@ -25,7 +25,7 @@ impl Actor for TestActor {
 }
 
 #[named]
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_basic_group() {
     let (actor, handle) = Actor::spawn(None, TestActor)
         .await
@@ -45,7 +45,7 @@ async fn test_basic_group() {
 }
 
 #[named]
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_multiple_members_in_group() {
     let group = function_name!();
 
@@ -81,7 +81,7 @@ async fn test_multiple_members_in_group() {
 }
 
 #[named]
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_multiple_groups() {
     let group_a = concat!(function_name!(), "_a");
     let group_b = concat!(function_name!(), "_b");
@@ -125,7 +125,7 @@ async fn test_multiple_groups() {
 }
 
 #[named]
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_actor_leaves_pg_group_on_shutdown() {
     let (actor, handle) = Actor::spawn(None, TestActor)
         .await
@@ -149,7 +149,7 @@ async fn test_actor_leaves_pg_group_on_shutdown() {
 }
 
 #[named]
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_actor_leaves_pg_group_manually() {
     let group = function_name!();
 
@@ -184,7 +184,7 @@ async fn test_actor_leaves_pg_group_manually() {
 }
 
 #[named]
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_pg_monitoring() {
     let group = function_name!();
 
@@ -254,7 +254,7 @@ async fn test_pg_monitoring() {
         .expect("Failed to start test actor");
 
     // the monitor is notified async, so we need to wait a tiny bit
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    crate::concurrency::sleep(Duration::from_millis(100)).await;
     assert_eq!(1, counter.load(Ordering::Relaxed));
 
     // kill the pg member

--- a/ractor/src/port/mod.rs
+++ b/ractor/src/port/mod.rs
@@ -10,22 +10,9 @@
 //! and utilities to make working with mailbox processing in `ractor` easier in
 //! the actor framework.
 
-use tokio::sync::mpsc;
-use tokio::sync::oneshot;
+use crate::concurrency;
 
 use crate::MessagingErr;
-
-// ============ Input Ports ============ //
-
-/// A bounded-depth message port (alias of [mpsc::Sender])
-pub(crate) type BoundedInputPort<TMsg> = mpsc::Sender<TMsg>;
-/// A bounded-depth message port's receiver (alias of [mpsc::Receiver])
-pub(crate) type BoundedInputPortReceiver<TMsg> = mpsc::Receiver<TMsg>;
-
-/// An unbounded message port (alias of [mpsc::UnboundedSender])
-pub(crate) type InputPort<TMsg> = mpsc::UnboundedSender<TMsg>;
-/// An unbounded message port's receiver (alias of [mpsc::UnboundedReceiver])
-pub(crate) type InputPortReceiver<TMsg> = mpsc::UnboundedReceiver<TMsg>;
 
 // ============ Output Ports ============ //
 pub mod output;
@@ -33,10 +20,10 @@ pub use output::*;
 
 // ============ Rpc (one-use) Ports ============ //
 
-/// A remote procedure call's reply port. Wrapper of [tokio::sync::oneshot::Sender] with a
+/// A remote procedure call's reply port. Wrapper of [concurrency::OneshotSender] with a
 /// consistent error type
 pub struct RpcReplyPort<TMsg> {
-    port: oneshot::Sender<TMsg>,
+    port: concurrency::OneshotSender<TMsg>,
 }
 
 impl<TMsg> RpcReplyPort<TMsg> {
@@ -59,8 +46,8 @@ impl<TMsg> RpcReplyPort<TMsg> {
     }
 }
 
-impl<TMsg> From<oneshot::Sender<TMsg>> for RpcReplyPort<TMsg> {
-    fn from(value: oneshot::Sender<TMsg>) -> Self {
+impl<TMsg> From<concurrency::OneshotSender<TMsg>> for RpcReplyPort<TMsg> {
+    fn from(value: concurrency::OneshotSender<TMsg>) -> Self {
         Self { port: value }
     }
 }

--- a/ractor/src/port/output/mod.rs
+++ b/ractor/src/port/output/mod.rs
@@ -12,8 +12,8 @@
 
 use std::sync::RwLock;
 
+use crate::concurrency::JoinHandle;
 use tokio::sync::broadcast as pubsub;
-use tokio::task::JoinHandle;
 
 use crate::{Actor, ActorRef, Message};
 
@@ -109,7 +109,7 @@ where
 
 // ============== Subscription implementation ============== //
 
-/// The output port's subscription handle. It holds a handle to a tokio [JoinHandle]
+/// The output port's subscription handle. It holds a handle to a [JoinHandle]
 /// which listens to the [pubsub::Receiver] to see if there's a new message, and if there is
 /// forwards it to the [ActorRef] asynchronously using the specified converter.
 struct OutputPortSubscription {
@@ -138,7 +138,7 @@ impl OutputPortSubscription {
         F: Fn(TMsg) -> Option<TReceiver::Msg> + Send + 'static,
         TReceiver: Actor,
     {
-        let handle = tokio::spawn(async move {
+        let handle = crate::concurrency::spawn(async move {
             while let Ok(Some(msg)) = port.recv().await {
                 if let Some(new_msg) = converter(msg) {
                     if receiver.cast(new_msg).is_err() {

--- a/ractor/src/port/output/tests.rs
+++ b/ractor/src/port/output/tests.rs
@@ -7,14 +7,14 @@
 
 use std::time::Duration;
 
+use crate::concurrency::timeout;
 use futures::future::join_all;
-use tokio::time::timeout;
 
 use crate::{Actor, ActorRef};
 
 use super::*;
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_single_forward() {
     struct TestActor;
     enum TestActorMessage {
@@ -70,7 +70,7 @@ async fn test_single_forward() {
         .unwrap();
 }
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_50_receivers() {
     struct TestActor;
     enum TestActorMessage {
@@ -125,13 +125,13 @@ async fn test_50_receivers() {
         output.subscribe(actor, |_| Some(TestActorMessage::Stop));
     }
 
-    let all_handle = tokio::spawn(async move { join_all(actor_handles).await });
+    let all_handle = crate::concurrency::spawn(async move { join_all(actor_handles).await });
 
     // send 3 sends, should not exit
     for _ in 0..4 {
         output.send(());
     }
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    crate::concurrency::sleep(Duration::from_millis(50)).await;
     assert!(!all_handle.is_finished());
 
     // last send should trigger the exit condition

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -5,11 +5,11 @@
 
 //! Tests on the actor registry
 
-use tokio::time::Duration;
+use crate::concurrency::Duration;
 
 use crate::{Actor, SpawnErr};
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_basic_registation() {
     struct EmptyActor;
 
@@ -32,7 +32,7 @@ async fn test_basic_registation() {
     handle.await.expect("Failed to clean stop the actor");
 }
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_duplicate_registration() {
     struct EmptyActor;
 
@@ -65,7 +65,7 @@ async fn test_duplicate_registration() {
     handle.await.expect("Failed to clean stop the actor");
 }
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_actor_registry_unenrollment() {
     struct EmptyActor;
 
@@ -92,7 +92,7 @@ async fn test_actor_registry_unenrollment() {
     drop(actor);
 
     // unenrollment is a cast operation, so it's not immediate. wait for cleanup
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    crate::concurrency::sleep(Duration::from_millis(100)).await;
 
     // the actor was automatically removed
     assert!(crate::registry::where_is("unenrollment").is_none());

--- a/ractor/src/rpc/tests.rs
+++ b/ractor/src/rpc/tests.rs
@@ -8,12 +8,12 @@
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
-use tokio::time::Duration;
+use crate::concurrency::Duration;
 
 use crate::rpc;
 use crate::{call, call_t, cast, forward, Actor, ActorRef};
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_rpc_cast() {
     let counter = Arc::new(AtomicU8::new(0u8));
 
@@ -53,7 +53,7 @@ async fn test_rpc_cast() {
     cast!(actor_ref, ()).unwrap();
 
     // make sure they have time to process
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    crate::concurrency::sleep(Duration::from_millis(100)).await;
 
     // assert the actor received 2 cast requests
     assert_eq!(3, counter.load(Ordering::Relaxed));
@@ -63,7 +63,7 @@ async fn test_rpc_cast() {
     handle.await.expect("Actor stopped with err");
 }
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_rpc_call() {
     struct TestActor;
     enum MessageFormat {
@@ -95,7 +95,7 @@ async fn test_rpc_call() {
                     }
                 }
                 Self::Msg::Timeout(reply) => {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    crate::concurrency::sleep(Duration::from_millis(100)).await;
                     let _ = reply.send("howdy".to_string());
                 }
                 Self::Msg::MultiArg(message, count, reply) => {
@@ -142,14 +142,14 @@ async fn test_rpc_call() {
     // cleanup
     actor_ref.stop(None);
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    crate::concurrency::sleep(Duration::from_millis(200)).await;
 
     let rpc_send_fail = call!(actor_ref, MessageFormat::Rpc);
     assert!(rpc_send_fail.is_err());
     handle.await.expect("Actor stopped with err");
 }
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_rpc_call_forwarding() {
     struct Worker;
 

--- a/ractor/src/time/mod.rs
+++ b/ractor/src/time/mod.rs
@@ -14,7 +14,7 @@
 //! 3. Stop after a delay
 //! 4. Kill after a delay
 
-use tokio::{task::JoinHandle, time::Duration};
+use crate::concurrency::{Duration, JoinHandle};
 
 use crate::{Actor, ActorCell, MessagingErr, ACTIVE_STATES};
 
@@ -38,9 +38,9 @@ where
     TActor: Actor,
     F: Fn() -> TActor::Msg + Send + 'static,
 {
-    tokio::spawn(async move {
+    crate::concurrency::spawn(async move {
         while ACTIVE_STATES.contains(&actor.get_status()) {
-            tokio::time::sleep(period).await;
+            crate::concurrency::sleep(period).await;
             // if we receive an error trying to send, the channel is closed and we should stop trying
             // actor died
             if actor.send_message::<TActor>(msg()).is_err() {
@@ -69,8 +69,8 @@ pub fn send_after<TActor>(
 where
     TActor: Actor,
 {
-    tokio::spawn(async move {
-        tokio::time::sleep(period).await;
+    crate::concurrency::spawn(async move {
+        crate::concurrency::sleep(period).await;
         actor.send_message::<TActor>(msg)
     })
 }
@@ -84,8 +84,8 @@ where
 /// Returns: The [JoinHandle] which denotes the backgrounded operation. To cancel the
 /// exit operation, you can abort the handle
 pub fn exit_after(period: Duration, actor: ActorCell) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        tokio::time::sleep(period).await;
+    crate::concurrency::spawn(async move {
+        crate::concurrency::sleep(period).await;
         actor.stop(Some(format!("Exit after {}ms", period.as_millis())))
     })
 }
@@ -98,8 +98,8 @@ pub fn exit_after(period: Duration, actor: ActorCell) -> JoinHandle<()> {
 /// Returns: The [JoinHandle] which denotes the backgrounded operation. To cancel the
 /// kill operation, you can abort the handle
 pub fn kill_after(period: Duration, actor: ActorCell) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        tokio::time::sleep(period).await;
+    crate::concurrency::spawn(async move {
+        crate::concurrency::sleep(period).await;
         actor.kill()
     })
 }

--- a/ractor/src/time/tests.rs
+++ b/ractor/src/time/tests.rs
@@ -10,11 +10,11 @@ use std::sync::{
     Arc,
 };
 
-use tokio::time::Duration;
+use crate::concurrency::Duration;
 
 use crate::{Actor, ActorRef};
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_intervals() {
     let counter = Arc::new(AtomicU8::new(0u8));
 
@@ -55,11 +55,11 @@ async fn test_intervals() {
     // therefore the counter should be empty
     assert_eq!(0, counter.load(Ordering::Relaxed));
 
-    tokio::time::sleep(Duration::from_millis(120)).await;
+    crate::concurrency::sleep(Duration::from_millis(120)).await;
     // kill the actor
     actor_ref.stop(None);
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    crate::concurrency::sleep(Duration::from_millis(50)).await;
     // make sure the actor is dead + the interval handle doesn't send again
     assert!(interval_handle.is_finished());
     assert!(actor_handle.is_finished());
@@ -69,7 +69,7 @@ async fn test_intervals() {
     assert!(counter.load(Ordering::Relaxed) >= 9);
 }
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_send_after() {
     let counter = Arc::new(AtomicU8::new(0u8));
 
@@ -110,11 +110,11 @@ async fn test_send_after() {
     // therefore the counter should be empty
     assert_eq!(0, counter.load(Ordering::Relaxed));
 
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    crate::concurrency::sleep(Duration::from_millis(20)).await;
     // kill the actor
     actor_ref.stop(None);
 
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    crate::concurrency::sleep(Duration::from_millis(50)).await;
     // make sure the actor is dead + the interval handle doesn't send again
     assert!(send_after_handle.is_finished());
     assert!(actor_handle.is_finished());
@@ -124,7 +124,7 @@ async fn test_send_after() {
     assert_eq!(1, counter.load(Ordering::Relaxed));
 }
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_exit_after() {
     struct TestActor;
 
@@ -141,13 +141,13 @@ async fn test_exit_after() {
 
     let exit_handle = actor_ref.exit_after(Duration::from_millis(10));
 
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    crate::concurrency::sleep(Duration::from_millis(20)).await;
     // make sure the actor is dead + the interval handle doesn't send again
     assert!(exit_handle.is_finished());
     assert!(actor_handle.is_finished());
 }
 
-#[tokio::test]
+#[crate::concurrency::test]
 async fn test_kill_after() {
     struct TestActor;
 
@@ -162,7 +162,7 @@ async fn test_kill_after() {
             _message: Self::Msg,
             _state: &mut Self::State,
         ) {
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            crate::concurrency::sleep(Duration::from_millis(100)).await;
         }
     }
 
@@ -174,12 +174,12 @@ async fn test_kill_after() {
     actor_ref
         .send_message(())
         .expect("Failed to send message to actor");
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    crate::concurrency::sleep(Duration::from_millis(10)).await;
 
     // kill the actor
     let kill_handle = actor_ref.kill_after(Duration::from_millis(10));
 
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    crate::concurrency::sleep(Duration::from_millis(20)).await;
     // make sure the actor is dead + the interval handle doesn't send again
     assert!(kill_handle.is_finished());
     assert!(actor_handle.is_finished());


### PR DESCRIPTION
Start moving all the concurrency calls to a common path in order to facilitate moving to multiple runtimes in the future (e.g. `async-std`). However there's more generalization work to do to make that work, this is an initial step and reduces the usage of the `tokio` namespace to just some common patterns used throughout the crate.