### PR TITLE
Adds an argument type which will be passed through the spawn invocations to pre_start

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Install `ractor` by adding the following to your Cargo.toml dependencies
 
 ```toml
 [dependencies]
-ractor = "0.4"
+ractor = "0.6"
 ```
 
 ## Features
@@ -104,11 +104,13 @@ impl Actor for PingPong {
     type Msg = Message;
     // and (optionally) internal state
     type State = u8;
+    // Startup initialization args
+    type Arguments = ();
 
     // Initially we need to create our state, and potentially
     // start some internal processing (by posting a message for
     // example)
-    async fn pre_start(&self, myself: ActorCell) -> Result<Self::State, ActorProcessingErr> {
+    async fn pre_start(&self, myself: ActorCell, _: Self::Arguments) -> Result<Self::State, ActorProcessingErr> {
         // startup the event processing
         myself.cast(Message::Ping)?;
         Ok(0u8)

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/benches/actor.rs
+++ b/ractor/benches/actor.rs
@@ -23,7 +23,13 @@ impl Actor for BenchActor {
 
     type State = ();
 
-    async fn pre_start(&self, myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+    type Arguments = ();
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
         let _ = myself.cast(BenchActorMessage);
         Ok(())
     }
@@ -52,7 +58,7 @@ fn create_actors(c: &mut Criterion) {
                 runtime.block_on(async move {
                     let mut handles = vec![];
                     for _ in 0..small {
-                        let (_, handler) = Actor::spawn(None, BenchActor)
+                        let (_, handler) = Actor::spawn(None, BenchActor, ())
                             .await
                             .expect("Failed to create test agent");
                         handles.push(handler);
@@ -73,7 +79,7 @@ fn create_actors(c: &mut Criterion) {
                 runtime.block_on(async move {
                     let mut handles = vec![];
                     for _ in 0..large {
-                        let (_, handler) = Actor::spawn(None, BenchActor)
+                        let (_, handler) = Actor::spawn(None, BenchActor, ())
                             .await
                             .expect("Failed to create test agent");
                         handles.push(handler);
@@ -99,7 +105,7 @@ fn schedule_work(c: &mut Criterion) {
                     let mut join_set = tokio::task::JoinSet::new();
 
                     for _ in 0..small {
-                        let (_, handler) = Actor::spawn(None, BenchActor)
+                        let (_, handler) = Actor::spawn(None, BenchActor, ())
                             .await
                             .expect("Failed to create test agent");
                         join_set.spawn(handler);
@@ -122,7 +128,7 @@ fn schedule_work(c: &mut Criterion) {
                 runtime.block_on(async move {
                     let mut join_set = tokio::task::JoinSet::new();
                     for _ in 0..large {
-                        let (_, handler) = Actor::spawn(None, BenchActor)
+                        let (_, handler) = Actor::spawn(None, BenchActor, ())
                             .await
                             .expect("Failed to create test agent");
                         join_set.spawn(handler);
@@ -152,9 +158,12 @@ fn process_messages(c: &mut Criterion) {
 
         type State = u64;
 
+        type Arguments = ();
+
         async fn pre_start(
             &self,
             myself: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             let _ = myself.cast(BenchActorMessage);
             Ok(0u64)
@@ -182,7 +191,7 @@ fn process_messages(c: &mut Criterion) {
         b.iter_batched(
             || {
                 runtime.block_on(async move {
-                    let (_, handle) = Actor::spawn(None, MessagingActor { num_msgs: NUM_MSGS })
+                    let (_, handle) = Actor::spawn(None, MessagingActor { num_msgs: NUM_MSGS }, ())
                         .await
                         .expect("Failed to create test actor");
                     handle

--- a/ractor/examples/counter.rs
+++ b/ractor/examples/counter.rs
@@ -36,8 +36,13 @@ impl Actor for Counter {
     type Msg = CounterMessage;
 
     type State = CounterState;
+    type Arguments = ();
 
-    async fn pre_start(&self, _myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
         // create the initial state
         Ok(CounterState { count: 0 })
     }
@@ -67,7 +72,7 @@ impl Actor for Counter {
 
 #[tokio::main]
 async fn main() {
-    let (actor, handle) = Actor::spawn(None, Counter)
+    let (actor, handle) = Actor::spawn(None, Counter, ())
         .await
         .expect("Failed to start actor!");
 

--- a/ractor/examples/monte_carlo.rs
+++ b/ractor/examples/monte_carlo.rs
@@ -68,7 +68,13 @@ impl Actor for Game {
 
     type State = GameState;
 
-    async fn pre_start(&self, _myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+    type Arguments = ();
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
         Ok(GameState::default())
     }
 
@@ -141,8 +147,13 @@ impl Actor for GameManager {
     type Msg = GameManagerMessage;
 
     type State = GameManagerState;
+    type Arguments = ();
 
-    async fn pre_start(&self, myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
         // This is the first code that will run in the actor. It spawns the Game actors,
         // registers them to its monitoring list, then sends them a message indicating
         // that they should start their games.
@@ -153,7 +164,7 @@ impl Actor for GameManager {
         println!("Rounds per game: {}", game_conditions.total_rounds);
         println!("Running simulations...");
         for _ in 0..self.num_games {
-            let (actor, _) = Actor::spawn_linked(None, Game, myself.clone().into())
+            let (actor, _) = Actor::spawn_linked(None, Game, (), myself.clone().into())
                 .await
                 .expect("Failed to start game");
             cast!(actor, GameMessage(myself.clone())).expect("Failed to send message");
@@ -200,7 +211,7 @@ async fn main() {
         num_games: NUM_GAMES,
     };
     // spawn it off and wait for it to complete/exit
-    let (_actor, handle) = Actor::spawn(None, manager)
+    let (_actor, handle) = Actor::spawn(None, manager, ())
         .await
         .expect("Failed to start game manager");
 

--- a/ractor/examples/output_port.rs
+++ b/ractor/examples/output_port.rs
@@ -38,8 +38,13 @@ impl Actor for Publisher {
     type Msg = PublisherMessage;
 
     type State = ();
+    type Arguments = ();
 
-    async fn pre_start(&self, _myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
         Ok(())
     }
 
@@ -72,8 +77,13 @@ impl Actor for Subscriber {
     type Msg = SubscriberMessage;
 
     type State = ();
+    type Arguments = ();
 
-    async fn pre_start(&self, _myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
         Ok(())
     }
 
@@ -101,6 +111,7 @@ async fn main() {
         Publisher {
             output: port.clone(),
         },
+        (),
     )
     .await
     .expect("Failed to start publisher");
@@ -110,7 +121,7 @@ async fn main() {
 
     // spawn + setup the subscribers (NOT SUPERVISION LINKAGE)
     for _ in 0..10 {
-        let (actor_ref, actor_handle) = Actor::spawn(None, Subscriber)
+        let (actor_ref, actor_handle) = Actor::spawn(None, Subscriber, ())
             .await
             .expect("Failed to start subscriber");
 

--- a/ractor/examples/philosophers.rs
+++ b/ractor/examples/philosophers.rs
@@ -113,7 +113,12 @@ impl Fork {
 impl Actor for Fork {
     type Msg = ForkMessage;
     type State = ForkState;
-    async fn pre_start(&self, _myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+    type Arguments = ();
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
         Ok(Self::State {
             clean: false,
             owned_by: None,
@@ -308,7 +313,12 @@ impl Philosopher {
 impl Actor for Philosopher {
     type Msg = PhilosopherMessage;
     type State = PhilosopherState;
-    async fn pre_start(&self, myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+    type Arguments = ();
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
         // initialize the simulation by making the philosopher's hungry
         let _ = cast!(myself, Self::Msg::BecomeHungry(0));
         Ok(Self::State::new(self.left.clone(), self.right.clone()))
@@ -461,7 +471,7 @@ async fn main() {
 
     // create the forks
     for _i in 0..philosopher_names.len() {
-        let (fork, handle) = Actor::spawn(None, Fork)
+        let (fork, handle) = Actor::spawn(None, Fork, ())
             .await
             .expect("Failed to create fork!");
         forks.push(fork);
@@ -480,7 +490,7 @@ async fn main() {
             left: forks[left].clone(),
             right: forks[right].clone(),
         };
-        let (philosopher, handle) = Actor::spawn(Some(philosopher_names[left].to_string()), p)
+        let (philosopher, handle) = Actor::spawn(Some(philosopher_names[left].to_string()), p, ())
             .await
             .expect("Failed to create philosopher!");
         results.insert(philosopher_names[left].to_string(), None);

--- a/ractor/examples/ping_pong.rs
+++ b/ractor/examples/ping_pong.rs
@@ -47,8 +47,13 @@ impl Actor for PingPong {
     type Msg = Message;
 
     type State = u8;
+    type Arguments = ();
 
-    async fn pre_start(&self, myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
         // startup the event processing
         cast!(myself, Message::Ping).unwrap();
         // create the initial state
@@ -75,7 +80,7 @@ impl Actor for PingPong {
 
 #[tokio::main]
 async fn main() {
-    let (_actor, handle) = Actor::spawn(None, PingPong)
+    let (_actor, handle) = Actor::spawn(None, PingPong, ())
         .await
         .expect("Failed to start ping-pong actor");
     handle

--- a/ractor/src/actor/tests/mod.rs
+++ b/ractor/src/actor/tests/mod.rs
@@ -29,18 +29,19 @@ async fn test_panic_on_start_captured() {
     #[async_trait::async_trait]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             panic!("Boom!");
         }
     }
 
-    let actor_output = Actor::spawn(None, TestActor).await;
+    let actor_output = Actor::spawn(None, TestActor, ()).await;
     assert!(matches!(actor_output, Err(SpawnErr::StartupPanic(_))));
 }
 
@@ -51,18 +52,19 @@ async fn test_error_on_start_captured() {
     #[async_trait::async_trait]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Err(From::from("boom"))
         }
     }
 
-    let actor_output = Actor::spawn(None, TestActor).await;
+    let actor_output = Actor::spawn(None, TestActor, ()).await;
     assert!(matches!(actor_output, Err(SpawnErr::StartupPanic(_))));
 }
 
@@ -77,12 +79,13 @@ async fn test_stop_higher_priority_over_messages() {
     #[async_trait::async_trait]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -104,6 +107,7 @@ async fn test_stop_higher_priority_over_messages() {
         TestActor {
             counter: message_counter.clone(),
         },
+        (),
     )
     .await
     .expect("Actor failed to start");
@@ -149,12 +153,13 @@ async fn test_kill_terminates_work() {
     #[async_trait::async_trait]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -170,7 +175,7 @@ async fn test_kill_terminates_work() {
         }
     }
 
-    let (actor, handle) = Actor::spawn(None, TestActor)
+    let (actor, handle) = Actor::spawn(None, TestActor, ())
         .await
         .expect("Actor failed to start");
 
@@ -193,12 +198,13 @@ async fn test_stop_does_not_terminate_async_work() {
     #[async_trait::async_trait]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -214,7 +220,7 @@ async fn test_stop_does_not_terminate_async_work() {
         }
     }
 
-    let (actor, handle) = Actor::spawn(None, TestActor)
+    let (actor, handle) = Actor::spawn(None, TestActor, ())
         .await
         .expect("Actor failed to start");
 
@@ -244,12 +250,13 @@ async fn test_kill_terminates_supervision_work() {
     #[async_trait::async_trait]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -265,7 +272,7 @@ async fn test_kill_terminates_supervision_work() {
         }
     }
 
-    let (actor, handle) = Actor::spawn(None, TestActor)
+    let (actor, handle) = Actor::spawn(None, TestActor, ())
         .await
         .expect("Actor failed to start");
 
@@ -293,9 +300,11 @@ async fn test_sending_message_to_invalid_actor_type() {
     impl Actor for TestActor1 {
         type Msg = TestMessage1;
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _myself: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -308,18 +317,20 @@ async fn test_sending_message_to_invalid_actor_type() {
     impl Actor for TestActor2 {
         type Msg = TestMessage2;
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _myself: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
     }
 
-    let (actor1, handle1) = Actor::spawn(None, TestActor1)
+    let (actor1, handle1) = Actor::spawn(None, TestActor1, ())
         .await
         .expect("Failed to start test actor 1");
-    let (actor2, handle2) = Actor::spawn(None, TestActor2)
+    let (actor2, handle2) = Actor::spawn(None, TestActor2, ())
         .await
         .expect("Failed to start test actor 2");
 
@@ -368,9 +379,11 @@ async fn test_serialized_cast() {
     impl Actor for TestActor {
         type Msg = TestMessage;
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _myself: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -391,6 +404,7 @@ async fn test_serialized_cast() {
         TestActor {
             counter: counter.clone(),
         },
+        (),
     )
     .await
     .expect("Failed to spawn test actor");
@@ -491,9 +505,11 @@ async fn test_serialized_rpc() {
     impl Actor for TestActor {
         type Msg = TestMessage;
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _myself: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -519,6 +535,7 @@ async fn test_serialized_rpc() {
         TestActor {
             counter: counter.clone(),
         },
+        (),
     )
     .await
     .expect("Failed to spawn test actor");
@@ -559,9 +576,11 @@ async fn test_remote_actor() {
     impl Actor for DummySupervisor {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _myself: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -591,9 +610,11 @@ async fn test_remote_actor() {
     impl Actor for TestRemoteActor {
         type Msg = TestRemoteMessage;
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _myself: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -618,7 +639,7 @@ async fn test_remote_actor() {
         }
     }
 
-    let (sup, sup_handle) = Actor::spawn(None, DummySupervisor).await.unwrap();
+    let (sup, sup_handle) = Actor::spawn(None, DummySupervisor, ()).await.unwrap();
 
     let (actor, handle) = ActorRuntime::spawn_linked_remote(
         None,
@@ -626,6 +647,7 @@ async fn test_remote_actor() {
             counter: counter.clone(),
         },
         ActorId::Remote { node_id: 1, pid: 1 },
+        (),
         sup.get_cell(),
     )
     .await
@@ -658,9 +680,11 @@ async fn spawning_local_actor_as_remote_fails() {
     impl Actor for RemoteActor {
         type Msg = RemoteActorMessage;
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -671,22 +695,29 @@ async fn spawning_local_actor_as_remote_fails() {
     impl Actor for EmptyActor {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
     }
     let remote_pid = crate::ActorId::Local(1);
 
-    let (actor, handle) = Actor::spawn(None, EmptyActor)
+    let (actor, handle) = Actor::spawn(None, EmptyActor, ())
         .await
         .expect("Actor failed to start");
 
-    let remote_spawn_result =
-        crate::ActorRuntime::spawn_linked_remote(None, RemoteActor, remote_pid, actor.get_cell())
-            .await;
+    let remote_spawn_result = crate::ActorRuntime::spawn_linked_remote(
+        None,
+        RemoteActor,
+        remote_pid,
+        (),
+        actor.get_cell(),
+    )
+    .await;
 
     assert!(remote_spawn_result.is_err());
 

--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -28,9 +28,11 @@ async fn test_supervision_panic_in_post_startup() {
     impl Actor for Child {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -47,9 +49,11 @@ async fn test_supervision_panic_in_post_startup() {
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -82,13 +86,13 @@ async fn test_supervision_panic_in_post_startup() {
 
     let flag = Arc::new(AtomicU64::new(0));
 
-    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() })
+    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() }, ())
         .await
         .expect("Supervisor panicked on startup");
 
     let supervisor_cell: ActorCell = supervisor_ref.clone().into();
 
-    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, supervisor_cell)
+    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, (), supervisor_cell)
         .await
         .expect("Child panicked on startup");
 
@@ -111,9 +115,11 @@ async fn test_supervision_error_in_post_startup() {
     impl Actor for Child {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -130,9 +136,11 @@ async fn test_supervision_error_in_post_startup() {
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -165,13 +173,13 @@ async fn test_supervision_error_in_post_startup() {
 
     let flag = Arc::new(AtomicU64::new(0));
 
-    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() })
+    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() }, ())
         .await
         .expect("Supervisor panicked on startup");
 
     let supervisor_cell: ActorCell = supervisor_ref.clone().into();
 
-    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, supervisor_cell)
+    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, (), supervisor_cell)
         .await
         .expect("Child panicked on startup");
 
@@ -194,9 +202,11 @@ async fn test_supervision_panic_in_handle() {
     impl Actor for Child {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -214,9 +224,11 @@ async fn test_supervision_panic_in_handle() {
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -249,13 +261,13 @@ async fn test_supervision_panic_in_handle() {
 
     let flag = Arc::new(AtomicU64::new(0));
 
-    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() })
+    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() }, ())
         .await
         .expect("Supervisor panicked on startup");
 
     let supervisor_cell: ActorCell = supervisor_ref.clone().into();
 
-    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, supervisor_cell)
+    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, (), supervisor_cell)
         .await
         .expect("Child panicked on startup");
 
@@ -286,9 +298,11 @@ async fn test_supervision_error_in_handle() {
     impl Actor for Child {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -306,9 +320,11 @@ async fn test_supervision_error_in_handle() {
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -341,13 +357,13 @@ async fn test_supervision_error_in_handle() {
 
     let flag = Arc::new(AtomicU64::new(0));
 
-    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() })
+    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() }, ())
         .await
         .expect("Supervisor panicked on startup");
 
     let supervisor_cell: ActorCell = supervisor_ref.clone().into();
 
-    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, supervisor_cell)
+    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, (), supervisor_cell)
         .await
         .expect("Child panicked on startup");
 
@@ -378,9 +394,11 @@ async fn test_supervision_panic_in_post_stop() {
     impl Actor for Child {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             myself: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             // trigger stop, which starts shutdown
             myself.stop(None);
@@ -399,9 +417,11 @@ async fn test_supervision_panic_in_post_stop() {
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -426,11 +446,11 @@ async fn test_supervision_panic_in_post_stop() {
 
     let flag = Arc::new(AtomicU64::new(0));
 
-    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() })
+    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() }, ())
         .await
         .expect("Supervisor panicked on startup");
 
-    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, supervisor_ref.clone().into())
+    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, (), supervisor_ref.clone().into())
         .await
         .expect("Child panicked on startup");
 
@@ -454,9 +474,11 @@ async fn test_supervision_error_in_post_stop() {
     impl Actor for Child {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             myself: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             // trigger stop, which starts shutdown
             myself.stop(None);
@@ -475,9 +497,11 @@ async fn test_supervision_error_in_post_stop() {
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -502,11 +526,11 @@ async fn test_supervision_error_in_post_stop() {
 
     let flag = Arc::new(AtomicU64::new(0));
 
-    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() })
+    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() }, ())
         .await
         .expect("Supervisor panicked on startup");
 
-    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, supervisor_ref.clone().into())
+    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, (), supervisor_ref.clone().into())
         .await
         .expect("Child panicked on startup");
 
@@ -533,9 +557,11 @@ async fn test_supervision_panic_in_supervisor_handle() {
     impl Actor for Child {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -553,9 +579,11 @@ async fn test_supervision_panic_in_supervisor_handle() {
     impl Actor for Midpoint {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -576,9 +604,11 @@ async fn test_supervision_panic_in_supervisor_handle() {
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -611,20 +641,20 @@ async fn test_supervision_panic_in_supervisor_handle() {
 
     let flag = Arc::new(AtomicU64::new(0));
 
-    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() })
+    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() }, ())
         .await
         .expect("Supervisor panicked on startup");
 
     let supervisor_cell: ActorCell = supervisor_ref.clone().into();
 
-    let (midpoint_ref, m_handle) = Actor::spawn_linked(None, Midpoint, supervisor_cell)
+    let (midpoint_ref, m_handle) = Actor::spawn_linked(None, Midpoint, (), supervisor_cell)
         .await
         .expect("Midpoint actor failed to startup");
 
     let midpoint_cell: ActorCell = midpoint_ref.clone().into();
     let midpoint_ref_clone = midpoint_ref.clone();
 
-    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, midpoint_cell)
+    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, (), midpoint_cell)
         .await
         .expect("Child panicked on startup");
 
@@ -667,10 +697,12 @@ async fn test_supervision_error_in_supervisor_handle() {
     #[async_trait::async_trait]
     impl Actor for Child {
         type Msg = ();
+        type Arguments = ();
         type State = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -688,9 +720,11 @@ async fn test_supervision_error_in_supervisor_handle() {
     impl Actor for Midpoint {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -711,9 +745,11 @@ async fn test_supervision_error_in_supervisor_handle() {
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -746,20 +782,20 @@ async fn test_supervision_error_in_supervisor_handle() {
 
     let flag = Arc::new(AtomicU64::new(0));
 
-    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() })
+    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor { flag: flag.clone() }, ())
         .await
         .expect("Supervisor panicked on startup");
 
     let supervisor_cell: ActorCell = supervisor_ref.clone().into();
 
-    let (midpoint_ref, m_handle) = Actor::spawn_linked(None, Midpoint, supervisor_cell)
+    let (midpoint_ref, m_handle) = Actor::spawn_linked(None, Midpoint, (), supervisor_cell)
         .await
         .expect("Midpoint actor failed to startup");
 
     let midpoint_cell: ActorCell = midpoint_ref.clone().into();
     let midpoint_ref_clone = midpoint_ref.clone();
 
-    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, midpoint_cell)
+    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, (), midpoint_cell)
         .await
         .expect("Child panicked on startup");
 
@@ -798,9 +834,11 @@ async fn test_killing_a_supervisor_terminates_children() {
     impl Actor for Child {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -810,9 +848,11 @@ async fn test_killing_a_supervisor_terminates_children() {
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -828,11 +868,11 @@ async fn test_killing_a_supervisor_terminates_children() {
         }
     }
 
-    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor)
+    let (supervisor_ref, s_handle) = Actor::spawn(None, Supervisor, ())
         .await
         .expect("Supervisor panicked on startup");
 
-    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, supervisor_ref.clone().into())
+    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, (), supervisor_ref.clone().into())
         .await
         .expect("Child panicked on startup");
 

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ractor = "0.4"
+//! ractor = "0.6"
 //! ```
 //!
 //! ## Getting started
@@ -61,11 +61,13 @@
 //!     type Msg = Message;
 //!     // and (optionally) internal state
 //!     type State = u8;
+//!     // Startup arguments for actor initialization
+//!     type Arguments = ();
 //!
 //!     // Initially we need to create our state, and potentially
 //!     // start some internal processing (by posting a message for
 //!     // example)
-//!     async fn pre_start(&self, myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+//!     async fn pre_start(&self, myself: ActorRef<Self>, _: ()) -> Result<Self::State, ActorProcessingErr> {
 //!         // startup the event processing
 //!         myself.send_message(Message::Ping).unwrap();
 //!         Ok(0u8)
@@ -91,7 +93,7 @@
 //! }
 //!
 //! async fn run() {
-//!     let (_, actor_handle) = Actor::spawn(None, PingPong).await.expect("Failed to start actor");
+//!     let (_, actor_handle) = Actor::spawn(None, PingPong, ()).await.expect("Failed to start actor");
 //!     actor_handle.await.expect("Actor failed to exit cleanly");
 //! }
 //! ```

--- a/ractor/src/macros.rs
+++ b/ractor/src/macros.rs
@@ -36,10 +36,10 @@ macro_rules! cast {
 /// #[async_trait::async_trait]
 /// impl Actor for TestActor {
 ///     type Msg = MessageFormat;
-///
+///     type Arguments = ();
 ///     type State = ();
 ///
-///     async fn pre_start(&self, _this_actor: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+///     async fn pre_start(&self, _this_actor: ActorRef<Self>, _: ()) -> Result<Self::State, ActorProcessingErr> {
 ///         Ok(())
 ///     }
 ///
@@ -63,7 +63,7 @@ macro_rules! cast {
 /// }
 ///
 /// async fn test() {
-///     let (actor, _handle) = Actor::spawn(None, TestActor).await.unwrap();
+///     let (actor, _handle) = Actor::spawn(None, TestActor, ()).await.unwrap();
 ///     let result = call!(actor, MessageFormat::TestRpc, "Something".to_string()).unwrap();
 ///     assert_eq!(result, "Something".to_string())
 /// }
@@ -117,10 +117,10 @@ macro_rules! call {
 /// #[async_trait::async_trait]
 /// impl Actor for TestActor {
 ///     type Msg = MessageFormat;
-///
+///     type Arguments = ();
 ///     type State = ();
 ///
-///     async fn pre_start(&self, _this_actor: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+///     async fn pre_start(&self, _this_actor: ActorRef<Self>, _: ()) -> Result<Self::State, ActorProcessingErr> {
 ///         Ok(())
 ///     }
 ///
@@ -144,7 +144,7 @@ macro_rules! call {
 /// }
 ///
 /// async fn test() {
-///     let (actor, _handle) = Actor::spawn(None, TestActor).await.unwrap();
+///     let (actor, _handle) = Actor::spawn(None, TestActor, ()).await.unwrap();
 ///     let result = call_t!(actor, MessageFormat::TestRpc, 50, "Something".to_string()).unwrap();
 ///     assert_eq!(result, "Something".to_string())
 /// }

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -18,12 +18,13 @@ struct TestActor;
 #[async_trait::async_trait]
 impl Actor for TestActor {
     type Msg = ();
-
+    type Arguments = ();
     type State = ();
 
     async fn pre_start(
         &self,
         _this_actor: crate::ActorRef<Self>,
+        _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         Ok(())
     }
@@ -32,7 +33,7 @@ impl Actor for TestActor {
 #[named]
 #[crate::concurrency::test]
 async fn test_basic_group() {
-    let (actor, handle) = Actor::spawn(None, TestActor)
+    let (actor, handle) = Actor::spawn(None, TestActor, ())
         .await
         .expect("Failed to spawn test actor");
 
@@ -57,7 +58,7 @@ async fn test_multiple_members_in_group() {
     let mut actors = vec![];
     let mut handles = vec![];
     for _ in 0..10 {
-        let (actor, handle) = Actor::spawn(None, TestActor)
+        let (actor, handle) = Actor::spawn(None, TestActor, ())
             .await
             .expect("Failed to spawn test actor");
         actors.push(actor);
@@ -94,7 +95,7 @@ async fn test_multiple_groups() {
     let mut actors = vec![];
     let mut handles = vec![];
     for _ in 0..10 {
-        let (actor, handle) = Actor::spawn(None, TestActor)
+        let (actor, handle) = Actor::spawn(None, TestActor, ())
             .await
             .expect("Failed to spawn test actor");
         actors.push(actor);
@@ -132,7 +133,7 @@ async fn test_multiple_groups() {
 #[named]
 #[crate::concurrency::test]
 async fn test_actor_leaves_pg_group_on_shutdown() {
-    let (actor, handle) = Actor::spawn(None, TestActor)
+    let (actor, handle) = Actor::spawn(None, TestActor, ())
         .await
         .expect("Failed to spawn test actor");
 
@@ -158,7 +159,7 @@ async fn test_actor_leaves_pg_group_on_shutdown() {
 async fn test_actor_leaves_pg_group_manually() {
     let group = function_name!().to_string();
 
-    let (actor, handle) = Actor::spawn(None, TestActor)
+    let (actor, handle) = Actor::spawn(None, TestActor, ())
         .await
         .expect("Failed to spawn test actor");
 
@@ -202,12 +203,13 @@ async fn test_pg_monitoring() {
     #[async_trait::async_trait]
     impl Actor for AutoJoinActor {
         type Msg = ();
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             myself: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             pg::join(self.pg_group.clone(), vec![myself.into()]);
             Ok(())
@@ -222,12 +224,13 @@ async fn test_pg_monitoring() {
     #[async_trait::async_trait]
     impl Actor for NotificationMonitor {
         type Msg = ();
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             myself: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             pg::monitor(self.pg_group.clone(), myself.into());
             Ok(())
@@ -258,12 +261,13 @@ async fn test_pg_monitoring() {
             pg_group: group.clone(),
             counter: counter.clone(),
         },
+        (),
     )
     .await
     .expect("Failed to start monitor actor");
 
     // this actor's startup should "monitor" for PG changes
-    let (test_actor, test_handle) = Actor::spawn(None, AutoJoinActor { pg_group: group })
+    let (test_actor, test_handle) = Actor::spawn(None, AutoJoinActor { pg_group: group }, ())
         .await
         .expect("Failed to start test actor");
 
@@ -297,9 +301,11 @@ async fn local_vs_remote_pg_members() {
     impl Actor for TestRemoteActor {
         type Msg = TestRemoteActorMessage;
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -310,7 +316,7 @@ async fn local_vs_remote_pg_members() {
     let mut actors: Vec<crate::ActorCell> = vec![];
     let mut handles = vec![];
     for _ in 0..10 {
-        let (actor, handle) = Actor::spawn(None, TestActor)
+        let (actor, handle) = Actor::spawn(None, TestActor, ())
             .await
             .expect("Failed to spawn test actor");
         actors.push(actor.into());
@@ -320,6 +326,7 @@ async fn local_vs_remote_pg_members() {
         None,
         TestRemoteActor,
         remote_pid,
+        (),
         actors.first().unwrap().clone(),
     )
     .await

--- a/ractor/src/port/output/tests.rs
+++ b/ractor/src/port/output/tests.rs
@@ -25,12 +25,13 @@ async fn test_single_forward() {
     #[async_trait::async_trait]
     impl Actor for TestActor {
         type Msg = TestActorMessage;
-
+        type Arguments = ();
         type State = u8;
 
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(0u8)
         }
@@ -54,7 +55,7 @@ async fn test_single_forward() {
         }
     }
 
-    let (actor, handle) = Actor::spawn(None, TestActor)
+    let (actor, handle) = Actor::spawn(None, TestActor, ())
         .await
         .expect("failed to start test actor");
 
@@ -87,12 +88,13 @@ async fn test_50_receivers() {
     #[async_trait::async_trait]
     impl Actor for TestActor {
         type Msg = TestActorMessage;
-
+        type Arguments = ();
         type State = u8;
 
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(0u8)
         }
@@ -117,8 +119,8 @@ async fn test_50_receivers() {
     }
 
     let handles: Vec<(ActorRef<TestActor>, JoinHandle<()>)> =
-        join_all((0..50).into_iter().map(|_| async move {
-            Actor::spawn(None, TestActor)
+        join_all((0..50).map(|_| async move {
+            Actor::spawn(None, TestActor, ())
                 .await
                 .expect("Failed to start test actor")
         }))

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -16,18 +16,19 @@ async fn test_basic_registation() {
     #[async_trait::async_trait]
     impl Actor for EmptyActor {
         type Msg = ();
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
     }
 
-    let (actor, handle) = Actor::spawn(Some("my_actor".to_string()), EmptyActor)
+    let (actor, handle) = Actor::spawn(Some("my_actor".to_string()), EmptyActor, ())
         .await
         .expect("Actor failed to start");
 
@@ -44,24 +45,25 @@ async fn test_duplicate_registration() {
     #[async_trait::async_trait]
     impl Actor for EmptyActor {
         type Msg = ();
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
     }
 
-    let (actor, handle) = Actor::spawn(Some("my_second_actor".to_string()), EmptyActor)
+    let (actor, handle) = Actor::spawn(Some("my_second_actor".to_string()), EmptyActor, ())
         .await
         .expect("Actor failed to start");
 
     assert!(crate::registry::where_is("my_second_actor".to_string()).is_some());
 
-    let second_actor = Actor::spawn(Some("my_second_actor".to_string()), EmptyActor).await;
+    let second_actor = Actor::spawn(Some("my_second_actor".to_string()), EmptyActor, ()).await;
     // fails to spawn the second actor due to name err
     assert!(matches!(
         second_actor,
@@ -82,18 +84,19 @@ async fn test_actor_registry_unenrollment() {
     #[async_trait::async_trait]
     impl Actor for EmptyActor {
         type Msg = ();
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
     }
 
-    let (actor, handle) = Actor::spawn(Some("unenrollment".to_string()), EmptyActor)
+    let (actor, handle) = Actor::spawn(Some("unenrollment".to_string()), EmptyActor, ())
         .await
         .expect("Actor failed to start");
 
@@ -129,9 +132,11 @@ mod pid_registry_tests {
     impl Actor for RemoteActor {
         type Msg = RemoteActorMessage;
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: crate::ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -144,16 +149,18 @@ mod pid_registry_tests {
         impl Actor for EmptyActor {
             type Msg = ();
             type State = ();
+            type Arguments = ();
             async fn pre_start(
                 &self,
                 _this_actor: crate::ActorRef<Self>,
+                _: (),
             ) -> Result<Self::State, ActorProcessingErr> {
                 Ok(())
             }
         }
         let remote_pid = ActorId::Remote { node_id: 1, pid: 1 };
 
-        let (actor, handle) = Actor::spawn(None, EmptyActor)
+        let (actor, handle) = Actor::spawn(None, EmptyActor, ())
             .await
             .expect("Actor failed to start");
 
@@ -161,6 +168,7 @@ mod pid_registry_tests {
             None,
             RemoteActor,
             remote_pid,
+            (),
             actor.get_cell(),
         )
         .await
@@ -186,18 +194,19 @@ mod pid_registry_tests {
         #[async_trait::async_trait]
         impl Actor for EmptyActor {
             type Msg = ();
-
+            type Arguments = ();
             type State = ();
 
             async fn pre_start(
                 &self,
                 _this_actor: crate::ActorRef<Self>,
+                _: (),
             ) -> Result<Self::State, ActorProcessingErr> {
                 Ok(())
             }
         }
 
-        let (actor, handle) = Actor::spawn(None, EmptyActor)
+        let (actor, handle) = Actor::spawn(None, EmptyActor, ())
             .await
             .expect("Actor failed to start");
 
@@ -214,18 +223,19 @@ mod pid_registry_tests {
         #[async_trait::async_trait]
         impl Actor for EmptyActor {
             type Msg = ();
-
+            type Arguments = ();
             type State = ();
 
             async fn pre_start(
                 &self,
                 _this_actor: crate::ActorRef<Self>,
+                _: (),
             ) -> Result<Self::State, ActorProcessingErr> {
                 Ok(())
             }
         }
 
-        let (actor, handle) = Actor::spawn(None, EmptyActor)
+        let (actor, handle) = Actor::spawn(None, EmptyActor, ())
             .await
             .expect("Actor failed to start");
 
@@ -256,12 +266,13 @@ mod pid_registry_tests {
         #[async_trait::async_trait]
         impl Actor for AutoJoinActor {
             type Msg = ();
-
+            type Arguments = ();
             type State = ();
 
             async fn pre_start(
                 &self,
                 _myself: crate::ActorRef<Self>,
+                _: (),
             ) -> Result<Self::State, ActorProcessingErr> {
                 Ok(())
             }
@@ -274,12 +285,13 @@ mod pid_registry_tests {
         #[async_trait::async_trait]
         impl Actor for NotificationMonitor {
             type Msg = ();
-
+            type Arguments = ();
             type State = ();
 
             async fn pre_start(
                 &self,
                 myself: crate::ActorRef<Self>,
+                _: (),
             ) -> Result<Self::State, ActorProcessingErr> {
                 monitor(myself.into());
                 Ok(())
@@ -312,12 +324,13 @@ mod pid_registry_tests {
             NotificationMonitor {
                 counter: counter.clone(),
             },
+            (),
         )
         .await
         .expect("Failed to start monitor actor");
 
         // this actor's startup should "monitor" for PG changes
-        let (test_actor, test_handle) = Actor::spawn(None, AutoJoinActor)
+        let (test_actor, test_handle) = Actor::spawn(None, AutoJoinActor, ())
             .await
             .expect("Failed to start test actor");
 

--- a/ractor/src/rpc/tests.rs
+++ b/ractor/src/rpc/tests.rs
@@ -24,12 +24,13 @@ async fn test_rpc_cast() {
     #[async_trait::async_trait]
     impl Actor for TestActor {
         type Msg = ();
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -50,6 +51,7 @@ async fn test_rpc_cast() {
         TestActor {
             counter: counter.clone(),
         },
+        (),
     )
     .await
     .expect("Failed to start test actor");
@@ -82,12 +84,13 @@ async fn test_rpc_call() {
     #[async_trait::async_trait]
     impl Actor for TestActor {
         type Msg = MessageFormat;
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -118,7 +121,7 @@ async fn test_rpc_call() {
         }
     }
 
-    let (actor_ref, handle) = Actor::spawn(None, TestActor)
+    let (actor_ref, handle) = Actor::spawn(None, TestActor, ())
         .await
         .expect("Failed to start test actor");
 
@@ -174,12 +177,13 @@ async fn test_rpc_call_forwarding() {
     #[async_trait::async_trait]
     impl Actor for Worker {
         type Msg = WorkerMessage;
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -217,12 +221,13 @@ async fn test_rpc_call_forwarding() {
     #[async_trait::async_trait]
     impl Actor for Forwarder {
         type Msg = ForwarderMessage;
-
+        type Arguments = ();
         type State = ();
 
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -243,7 +248,7 @@ async fn test_rpc_call_forwarding() {
         }
     }
 
-    let (worker_ref, worker_handle) = Actor::spawn(None, Worker)
+    let (worker_ref, worker_handle) = Actor::spawn(None, Worker, ())
         .await
         .expect("Failed to start worker actor");
 
@@ -252,6 +257,7 @@ async fn test_rpc_call_forwarding() {
         Forwarder {
             counter: counter.clone(),
         },
+        (),
     )
     .await
     .expect("Failed to start forwarder actor");

--- a/ractor/src/time/tests.rs
+++ b/ractor/src/time/tests.rs
@@ -26,9 +26,11 @@ async fn test_intervals() {
     impl Actor for TestActor {
         type Msg = ();
         type State = Arc<AtomicU8>;
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(self.counter.clone())
         }
@@ -49,6 +51,7 @@ async fn test_intervals() {
         TestActor {
             counter: counter.clone(),
         },
+        (),
     )
     .await
     .expect("Failed to create test actor");
@@ -85,9 +88,11 @@ async fn test_send_after() {
     impl Actor for TestActor {
         type Msg = ();
         type State = Arc<AtomicU8>;
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(self.counter.clone())
         }
@@ -108,6 +113,7 @@ async fn test_send_after() {
         TestActor {
             counter: counter.clone(),
         },
+        (),
     )
     .await
     .expect("Failed to create test actor");
@@ -140,15 +146,17 @@ async fn test_exit_after() {
     impl Actor for TestActor {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
     }
 
-    let (actor_ref, actor_handle) = Actor::spawn(None, TestActor)
+    let (actor_ref, actor_handle) = Actor::spawn(None, TestActor, ())
         .await
         .expect("Failed to create test actor");
 
@@ -168,9 +176,11 @@ async fn test_kill_after() {
     impl Actor for TestActor {
         type Msg = ();
         type State = ();
+        type Arguments = ();
         async fn pre_start(
             &self,
             _this_actor: ActorRef<Self>,
+            _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
@@ -185,7 +195,7 @@ async fn test_kill_after() {
         }
     }
 
-    let (actor_ref, actor_handle) = Actor::spawn(None, TestActor)
+    let (actor_ref, actor_handle) = Actor::spawn(None, TestActor, ())
         .await
         .expect("Failed to create test actor");
 

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"
@@ -24,8 +24,8 @@ bytes = { version = "1" }
 log = "0.4"
 prost = { version = "0.11" }
 prost-types = { version = "0.11" }
-ractor = { version = "0.6.1", features = ["cluster"], path = "../ractor" }
-ractor_cluster_derive = { version = "0.6.1", path = "../ractor_cluster_derive" }
+ractor = { version = "0.7.0", features = ["cluster"], path = "../ractor" }
+ractor_cluster_derive = { version = "0.7.0", path = "../ractor_cluster_derive" }
 rand = "0.8"
 sha2 = "0.10"
 tokio = { version = "1", features = ["rt", "time", "sync", "macros", "net", "io-util"]}

--- a/ractor_cluster/src/net/listener.rs
+++ b/ractor_cluster/src/net/listener.rs
@@ -45,10 +45,14 @@ pub struct ListenerMessage;
 #[async_trait::async_trait]
 impl Actor for Listener {
     type Msg = ListenerMessage;
-
+    type Arguments = ();
     type State = ListenerState;
 
-    async fn pre_start(&self, myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
         let addr = format!("0.0.0.0:{}", self.port);
         let listener = match TcpListener::bind(&addr).await {
             Ok(l) => l,

--- a/ractor_cluster/src/remote_actor/mod.rs
+++ b/ractor_cluster/src/remote_actor/mod.rs
@@ -57,8 +57,14 @@ impl RemoteActor {
         supervisor: ActorCell,
     ) -> Result<(ActorRef<Self>, JoinHandle<()>), SpawnErr> {
         let actor_id = ActorId::Remote { node_id, pid };
-        ractor::ActorRuntime::<_, _, Self>::spawn_linked_remote(name, self, actor_id, supervisor)
-            .await
+        ractor::ActorRuntime::<_, _, Self>::spawn_linked_remote(
+            name,
+            self,
+            actor_id,
+            (),
+            supervisor,
+        )
+        .await
     }
 }
 
@@ -87,8 +93,12 @@ pub(crate) struct RemoteActorMessage;
 impl Actor for RemoteActor {
     type Msg = RemoteActorMessage;
     type State = RemoteActorState;
-
-    async fn pre_start(&self, _myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+    type Arguments = ();
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
         Ok(Self::State::default())
     }
 

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"

--- a/ractor_cluster_integration_tests/src/tests/auth_handshake.rs
+++ b/ractor_cluster_integration_tests/src/tests/auth_handshake.rs
@@ -37,7 +37,7 @@ pub async fn test(config: AuthHandshakeConfig) -> i32 {
 
     log::info!("Starting NodeServer on port {}", config.server_port);
 
-    let (actor, handle) = Actor::spawn(None, server)
+    let (actor, handle) = Actor::spawn(None, server, ())
         .await
         .expect("Failed to start NodeServer");
 

--- a/ractor_cluster_integration_tests/src/tests/pg_groups.rs
+++ b/ractor_cluster_integration_tests/src/tests/pg_groups.rs
@@ -41,8 +41,13 @@ struct PingPongActorState {
 impl Actor for PingPongActor {
     type Msg = PingPongActorMessage;
     type State = PingPongActorState;
+    type Arguments = ();
 
-    async fn pre_start(&self, myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
         ractor::pg::join("test".to_string(), vec![myself.get_cell()]);
         Ok(PingPongActorState {
             count: 0,
@@ -104,11 +109,11 @@ pub(crate) async fn test(config: PgGroupsConfig) -> i32 {
     let server =
         ractor_cluster::NodeServer::new(config.server_port, cookie, super::random_name(), hostname);
 
-    let (actor, handle) = Actor::spawn(None, server)
+    let (actor, handle) = Actor::spawn(None, server, ())
         .await
         .expect("Failed to start NodeServer A");
 
-    let (test_actor, test_handle) = Actor::spawn(None, PingPongActor)
+    let (test_actor, test_handle) = Actor::spawn(None, PingPongActor, ())
         .await
         .expect("Ping pong actor failed to start up!");
 

--- a/ractor_playground/src/distributed.rs
+++ b/ractor_playground/src/distributed.rs
@@ -28,10 +28,10 @@ pub(crate) async fn test_auth_handshake(port_a: u16, port_b: u16, valid_cookies:
     let server_b =
         ractor_cluster::NodeServer::new(port_b, cookie_b, "node_b".to_string(), hostname);
 
-    let (actor_a, handle_a) = Actor::spawn(None, server_a)
+    let (actor_a, handle_a) = Actor::spawn(None, server_a, ())
         .await
         .expect("Failed to start NodeServer A");
-    let (actor_b, handle_b) = Actor::spawn(None, server_b)
+    let (actor_b, handle_b) = Actor::spawn(None, server_b, ())
         .await
         .expect("Failed to start NodeServer B");
 
@@ -68,8 +68,13 @@ enum PingPongActorMessage {
 impl Actor for PingPongActor {
     type Msg = PingPongActorMessage;
     type State = ();
+    type Arguments = ();
 
-    async fn pre_start(&self, myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
         ractor::pg::join("test".to_string(), vec![myself.get_cell()]);
         Ok(())
     }
@@ -121,11 +126,11 @@ pub(crate) async fn startup_ping_pong_test_node(port: u16, connect_client: Optio
 
     let server = ractor_cluster::NodeServer::new(port, cookie, "node_a".to_string(), hostname);
 
-    let (actor, handle) = Actor::spawn(None, server)
+    let (actor, handle) = Actor::spawn(None, server, ())
         .await
         .expect("Failed to start NodeServer A");
 
-    let (test_actor, test_handle) = Actor::spawn(None, PingPongActor)
+    let (test_actor, test_handle) = Actor::spawn(None, PingPongActor, ())
         .await
         .expect("Ping pong actor failed to start up!");
 

--- a/ractor_playground/src/ping_pong.rs
+++ b/ractor_playground/src/ping_pong.rs
@@ -35,10 +35,14 @@ impl Message {
 #[async_trait::async_trait]
 impl Actor for PingPong {
     type Msg = Message;
-
+    type Arguments = ();
     type State = u8;
 
-    async fn pre_start(&self, myself: ActorRef<Self>) -> Result<Self::State, ActorProcessingErr> {
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
         println!("pre_start called");
         // startup the event processing
         myself.send_message(Message::Ping).unwrap();
@@ -90,7 +94,7 @@ impl Actor for PingPong {
 /// cargo run -p ractor-playground -- ping-pong
 /// ```
 pub(crate) async fn run_ping_pong() {
-    let (_, actor_handle) = Actor::spawn(None, PingPong)
+    let (_, actor_handle) = Actor::spawn(None, PingPong, ())
         .await
         .expect("Failed to start actor");
     actor_handle.await.expect("Actor failed to exit cleanly");


### PR DESCRIPTION
This assists in initialization scenarios where the actor's state needs to "take ownership". All tests and docs updated to match new trait argument. Currently you needed to either use the immutable `self` values or take some kind of initialization message which is unnecessary and often causes other problems. This cleans that up allowing the spawner to pass arguments to the actor's startup.