### PR TITLE
Adding a factory spec which dispatches job to a worker pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ We currently have full support for:
 
 On our roadmap is to add more of the Erlang functionality including potentially a distributed actor cluster.
 
+### Performance
+
+Actor's in `ractor` are generally quite lightweight and there are benchmarks which you are welcome to run on your own host system with
+
+```bash
+cargo bench -p ractor
+```
+
 ## Installation
 
 Install `ractor` by adding the following to your Cargo.toml dependencies

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"
@@ -28,7 +28,9 @@ default = []
 async-trait = "0.1"
 dashmap = "5"
 futures = "0.3"
+log = "0.4"
 once_cell = "1"
+rand = "0.8"
 tokio = { version = "1", features = ["sync", "time"] }
 
 [dev-dependencies]

--- a/ractor/src/actor/actor_cell/mod.rs
+++ b/ractor/src/actor/actor_cell/mod.rs
@@ -66,6 +66,24 @@ pub(crate) struct ActorPortSet {
     pub(crate) message_rx: InputPortReceiver<BoxedMessage>,
 }
 
+impl Drop for ActorPortSet {
+    fn drop(&mut self) {
+        // Close all the message ports and flush all the message queue backlogs.
+        // See: https://docs.rs/tokio/0.1.22/tokio/sync/mpsc/index.html#clean-shutdown
+        self.signal_rx.close();
+        while self.signal_rx.try_recv().is_ok() {}
+
+        self.stop_rx.close();
+        while self.stop_rx.try_recv().is_ok() {}
+
+        self.supervisor_rx.close();
+        while self.supervisor_rx.try_recv().is_ok() {}
+
+        self.message_rx.close();
+        while self.message_rx.try_recv().is_ok() {}
+    }
+}
+
 /// Messages that come in off an actor's port, with associated priority
 pub(crate) enum ActorPortMessage {
     /// A signal message

--- a/ractor/src/actor/actor_cell/mod.rs
+++ b/ractor/src/actor/actor_cell/mod.rs
@@ -71,15 +71,13 @@ impl Drop for ActorPortSet {
         // Close all the message ports and flush all the message queue backlogs.
         // See: https://docs.rs/tokio/0.1.22/tokio/sync/mpsc/index.html#clean-shutdown
         self.signal_rx.close();
-        while self.signal_rx.try_recv().is_ok() {}
-
         self.stop_rx.close();
-        while self.stop_rx.try_recv().is_ok() {}
-
         self.supervisor_rx.close();
-        while self.supervisor_rx.try_recv().is_ok() {}
-
         self.message_rx.close();
+
+        while self.signal_rx.try_recv().is_ok() {}
+        while self.stop_rx.try_recv().is_ok() {}
+        while self.supervisor_rx.try_recv().is_ok() {}
         while self.message_rx.try_recv().is_ok() {}
     }
 }

--- a/ractor/src/factory/hash.rs
+++ b/ractor/src/factory/hash.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+/// Hash a key into a finite space
+pub fn hash_with_max<TKey>(key: &TKey, excluded_max: usize) -> usize
+where
+    TKey: Hash,
+{
+    let mut dh = DefaultHasher::new();
+    key.hash(&mut dh);
+    let bounded_hash = dh.finish() % (excluded_max as u64);
+    bounded_hash as usize
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[derive(Hash)]
+    struct TestHashable(u128);
+
+    #[test]
+    fn test_bounded_hashing() {
+        let test_values = [
+            TestHashable(0),
+            TestHashable(10),
+            TestHashable(23),
+            TestHashable(128),
+            TestHashable(u64::MAX as u128),
+        ];
+
+        let test_results = [0usize, 2, 1, 0, 0];
+
+        for (test_value, test_result) in test_values.iter().zip(test_results) {
+            let hashed = hash_with_max(test_value, 3);
+            assert_eq!(test_result, hashed);
+        }
+    }
+}

--- a/ractor/src/factory/job.rs
+++ b/ractor/src/factory/job.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! Specification for a job sent to a factory
+
+use std::hash::Hash;
+
+use crate::{
+    concurrency::{Duration, Instant},
+    Message,
+};
+
+/// Represents options for the specified job
+pub struct JobOptions {
+    /// Time job was submitted from the client
+    pub submit_time: Instant,
+    /// Time job was processed by the factory
+    pub factory_time: Instant,
+    /// Time-to-live for the job
+    pub ttl: Duration,
+}
+
+/// Represents a job sent to a factory
+pub struct Job<TKey, TMsg>
+where
+    TKey: Message + Hash + Sync,
+    TMsg: Message,
+{
+    /// The key of the job
+    pub key: TKey,
+    /// The message of the job
+    pub msg: TMsg,
+    /// The options of the job
+    pub options: JobOptions,
+}
+
+#[cfg(feature = "cluster")]
+impl<TKey, TMsg> Message for Job<TKey, TMsg>
+where
+    TKey: Message + Hash + Sync,
+    TMsg: Message,
+{
+}
+
+impl<TKey, TMsg> Job<TKey, TMsg>
+where
+    TKey: Message + Hash + Sync,
+    TMsg: Message,
+{
+    pub(crate) fn is_expired(&self) -> bool {
+        Instant::now() - self.options.submit_time > self.options.ttl
+    }
+
+    pub(crate) fn set_factory_time(&mut self) {
+        self.options.factory_time = Instant::now()
+    }
+}

--- a/ractor/src/factory/mod.rs
+++ b/ractor/src/factory/mod.rs
@@ -1,0 +1,350 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! TBFilled out. Representative gen_factory implementation
+//!
+//! A factory is a supervisor/manager to a pool of workers on the same node. This
+//! is helpful for job dispatch
+//!
+//! TODO:
+//! * Batch job processing (incl splitting batches, etc)
+//! * Factor stats
+//!
+
+use std::collections::{HashMap, VecDeque};
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+use rand::Rng;
+
+use crate::{Actor, ActorId, ActorProcessingErr, ActorRef, Message, SupervisionEvent};
+
+mod hash;
+
+pub mod worker;
+pub use worker::{WorkerProperties, WorkerStartContext};
+
+pub mod job;
+pub mod routing_mode;
+
+pub use job::{Job, JobOptions};
+pub use routing_mode::{CustomHashFunction, RoutingMode};
+
+#[cfg(test)]
+mod tests;
+
+/// Trait defining the discard handler for a factory.
+pub trait DiscardHandler<TKey, TMsg>: Send + Sync + 'static
+where
+    TKey: Message + Hash + Sync,
+    TMsg: Message,
+{
+    /// Called on a job
+    fn discard(&self, job: Job<TKey, TMsg>);
+
+    /// clone yourself into a box
+    fn clone_box(&self) -> Box<dyn DiscardHandler<TKey, TMsg>>;
+}
+
+/// Trait defining a builder of workers for a factory
+pub trait WorkerBuilder<TWorker>: Send + Sync
+where
+    TWorker: Actor,
+{
+    /// Build a new worker
+    ///
+    /// * `wid`: The worker's "id" or index in the worker pool
+    fn build(&self, wid: usize) -> TWorker;
+}
+
+/// A factory is a manager to a pool of worker actors used for job dispatching
+pub struct Factory<TKey, TMsg, TWorker>
+where
+    TKey: Message + Hash + Sync,
+    TMsg: Message,
+    TWorker: Actor<Msg = Job<TKey, TMsg>>,
+{
+    /// Number of workers in the factory
+    pub worker_count: usize,
+
+    /// Message routing mode
+    pub routing_mode: RoutingMode<TKey>,
+
+    /// Maximum queue length. Any job arriving when the queue is at its max length
+    /// will cause an oldest job at the head of the queue will be dropped.
+    ///
+    /// * For [RoutingMode::Queuer] factories, applied to the factory's internal queue.
+    /// * For [RoutingMode::KeyPersistent] and [RoutingMode::CustomHashFunction], this applies to the worker's
+    /// message queue
+    ///
+    /// Default is disabled
+    pub discard_threshold: Option<usize>,
+
+    /// Discard callback when a job is discarded
+    pub discard_handler: Option<Box<dyn DiscardHandler<TKey, TMsg>>>,
+
+    /// A worker's ability for parallelized work
+    ///
+    /// Default is 1 (worker is strictly sequential in dispatched work)
+    pub worker_parallel_capacity: usize,
+
+    _worker: PhantomData<TWorker>,
+}
+
+impl<TKey, TMsg, TWorker> Factory<TKey, TMsg, TWorker>
+where
+    TKey: Message + Hash + Sync,
+    TMsg: Message,
+    TWorker: Actor<Msg = Job<TKey, TMsg>>,
+{
+    fn maybe_discard(&self, state: &mut FactoryState<TKey, TMsg, TWorker>) {
+        if let Some(threshold) = self.discard_threshold {
+            if state.messages.len() > threshold {
+                if let Some(msg) = state.messages.pop_front() {
+                    if let Some(handler) = &self.discard_handler {
+                        handler.discard(msg);
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<TKey, TMsg, TWorker> Default for Factory<TKey, TMsg, TWorker>
+where
+    TKey: Message + Hash + Sync,
+    TMsg: Message,
+    TWorker: Actor<Msg = Job<TKey, TMsg>>,
+{
+    fn default() -> Self {
+        Self {
+            worker_count: 1,
+            routing_mode: RoutingMode::default(),
+            discard_threshold: None,
+            discard_handler: None,
+            _worker: PhantomData,
+            worker_parallel_capacity: 1,
+        }
+    }
+}
+
+/// State of a factory (backlogged jobs, handler, etc)
+pub struct FactoryState<TKey, TMsg, TWorker>
+where
+    TKey: Message + Hash + Sync,
+    TMsg: Message,
+    TWorker: Actor<Msg = Job<TKey, TMsg>>,
+{
+    worker_builder: Box<dyn WorkerBuilder<TWorker>>,
+    pool: HashMap<usize, WorkerProperties<TKey, TMsg, TWorker>>,
+
+    messages: VecDeque<Job<TKey, TMsg>>,
+    last_worker: usize,
+}
+
+/// Messages to a factory
+pub enum FactoryMessage<TKey, TMsg>
+where
+    TKey: Message + Hash + Sync,
+    TMsg: Message,
+{
+    /// Dispatch a new message
+    Dispatch(Job<TKey, TMsg>),
+
+    /// A job finished
+    Finished(ActorId, TKey),
+}
+#[cfg(feature = "cluster")]
+impl<TKey, TMsg> Message for FactoryMessage<TKey, TMsg>
+where
+    TKey: Message + Hash + Sync,
+    TMsg: Message,
+{
+}
+
+#[async_trait::async_trait]
+impl<TKey, TMsg, TWorker> Actor for Factory<TKey, TMsg, TWorker>
+where
+    TKey: Message + Hash + Sync,
+    TMsg: Message,
+    TWorker: Actor<Msg = Job<TKey, TMsg>, Arguments = WorkerStartContext<TKey, TMsg, TWorker>>,
+{
+    type Msg = FactoryMessage<TKey, TMsg>;
+    type State = FactoryState<TKey, TMsg, TWorker>;
+    type Arguments = Box<dyn WorkerBuilder<TWorker>>;
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self>,
+        builder: Box<dyn WorkerBuilder<TWorker>>,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        // build the pool
+        let mut pool = HashMap::new();
+        for wid in 0..self.worker_count {
+            let context = WorkerStartContext {
+                wid,
+                factory: myself.clone(),
+            };
+            let handler = builder.build(wid);
+            let (worker, _) =
+                Actor::spawn_linked(None, handler, context, myself.get_cell()).await?;
+            pool.insert(
+                wid,
+                WorkerProperties::new(
+                    wid,
+                    worker,
+                    self.worker_parallel_capacity,
+                    self.discard_threshold,
+                    self.discard_handler.as_ref().map(|a| a.clone_box()),
+                ),
+            );
+        }
+
+        // initial state
+        Ok(Self::State {
+            messages: VecDeque::new(),
+            worker_builder: builder,
+            pool,
+            last_worker: 0,
+        })
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self>,
+        message: FactoryMessage<TKey, TMsg>,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        // TODO: based on the routing spec, dispatch the message
+        match message {
+            FactoryMessage::Dispatch(mut job) => {
+                // set the time the factory received the message
+                job.set_factory_time();
+
+                match &self.routing_mode {
+                    RoutingMode::KeyPersistent => {
+                        let key = hash::hash_with_max(&job.key, self.worker_count);
+                        if let Some(worker) = state.pool.get_mut(&key) {
+                            worker.enqueue_job(job)?;
+                        }
+                    }
+                    RoutingMode::Queuer => {
+                        let maybe_worker =
+                            state.pool.values_mut().find(|worker| worker.is_available());
+                        if let Some(worker) = maybe_worker {
+                            worker.enqueue_job(job)?;
+                        } else {
+                            // no free worker, backlog the message
+                            state.messages.push_back(job);
+                            self.maybe_discard(state);
+                        }
+                    }
+                    RoutingMode::RoundRobin => {
+                        let mut key = state.last_worker + 1;
+                        if key >= self.worker_count {
+                            key = 0;
+                        }
+                        if let Some(worker) = state.pool.get_mut(&key) {
+                            worker.enqueue_job(job)?;
+                        }
+                        state.last_worker = key;
+                    }
+                    RoutingMode::Random => {
+                        let key = rand::thread_rng().gen_range(0..self.worker_count);
+                        if let Some(worker) = state.pool.get_mut(&key) {
+                            worker.enqueue_job(job)?;
+                        }
+                    }
+                    RoutingMode::CustomHashFunction(hasher) => {
+                        let key = hasher.hash(&job.key, self.worker_count);
+                        if let Some(worker) = state.pool.get_mut(&key) {
+                            worker.enqueue_job(job)?;
+                        }
+                    }
+                }
+            }
+            FactoryMessage::Finished(who, job_key) => {
+                if let Some(worker) = state.pool.values_mut().find(|v| v.is_pid(who)) {
+                    worker.worker_complete(job_key)?;
+                }
+
+                if let RoutingMode::Queuer = self.routing_mode {
+                    // de-queue another job and send it to the free worker
+                    if let Some(job) = state.messages.pop_front() {
+                        let maybe_worker =
+                            state.pool.values_mut().find(|worker| worker.is_available());
+                        if let Some(worker) = maybe_worker {
+                            worker.enqueue_job(job)?;
+                        } else {
+                            // no free worker, backlog the message
+                            state.messages.push_front(job);
+                            self.maybe_discard(state);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_supervisor_evt(
+        &self,
+        myself: ActorRef<Self>,
+        message: SupervisionEvent,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            SupervisionEvent::ActorTerminated(who, _, reason) => {
+                if let Some(worker) = state
+                    .pool
+                    .values_mut()
+                    .find(|actor| actor.is_pid(who.get_id()))
+                {
+                    log::warn!(
+                        "Factory {:?}'s worker {} terminated with {:?}",
+                        myself.get_name(),
+                        worker.wid,
+                        reason
+                    );
+                    let new_worker = state.worker_builder.build(worker.wid);
+                    let spec = WorkerStartContext {
+                        wid: worker.wid,
+                        factory: myself.clone(),
+                    };
+                    let (replacement, _) =
+                        Actor::spawn_linked(None, new_worker, spec, myself.get_cell()).await?;
+
+                    worker.replace_worker(replacement);
+                }
+            }
+            SupervisionEvent::ActorPanicked(who, reason) => {
+                if let Some(worker) = state
+                    .pool
+                    .values_mut()
+                    .find(|actor| actor.is_pid(who.get_id()))
+                {
+                    log::warn!(
+                        "Factory {:?}'s worker {} panicked with {}",
+                        myself.get_name(),
+                        worker.wid,
+                        reason
+                    );
+                    let new_worker = state.worker_builder.build(worker.wid);
+                    let spec = WorkerStartContext {
+                        wid: worker.wid,
+                        factory: myself.clone(),
+                    };
+                    let (replacement, _) =
+                        Actor::spawn_linked(None, new_worker, spec, myself.get_cell()).await?;
+
+                    worker.replace_worker(replacement);
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/ractor/src/factory/routing_mode.rs
+++ b/ractor/src/factory/routing_mode.rs
@@ -1,0 +1,49 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! Factory routing mode
+
+use crate::Message;
+
+/// Custom hashing behavior for factory routing to workers
+pub trait CustomHashFunction<TKey>: Send + Sync
+where
+    TKey: Message + Sync,
+{
+    /// Hash the key into the space 0..usize
+    fn hash(&self, key: &TKey, worker_count: usize) -> usize;
+}
+
+/// Routing mode for jobs through the factory to workers
+pub enum RoutingMode<TKey>
+where
+    TKey: Message + Sync,
+{
+    /// Factory will select worker by hashing the job's key.
+    /// Workers will have jobs placed into their incoming message queue's
+    KeyPersistent,
+
+    /// Factory will dispatch job to first available worker.
+    /// Factory will maintain shared internal queue of messages
+    Queuer,
+
+    /// Factory will dispatch to the next worker in order
+    RoundRobin,
+
+    /// Factory will dispatch to a worker in a random order
+    Random,
+
+    /// Similar to [RoutingMode::KeyPersistent] but with a custom hash function
+    CustomHashFunction(Box<dyn CustomHashFunction<TKey>>),
+}
+
+impl<TKey> Default for RoutingMode<TKey>
+where
+    TKey: Message + Sync,
+{
+    fn default() -> Self {
+        Self::KeyPersistent
+    }
+}

--- a/ractor/src/factory/tests.rs
+++ b/ractor/src/factory/tests.rs
@@ -1,0 +1,343 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use std::{
+    marker::PhantomData,
+    sync::{
+        atomic::{AtomicU16, Ordering},
+        Arc,
+    },
+};
+
+use crate::{
+    concurrency::{Duration, Instant},
+    Actor, ActorProcessingErr, ActorRef,
+};
+
+use super::{
+    CustomHashFunction, Factory, FactoryMessage, Job, JobOptions, RoutingMode, WorkerStartContext,
+};
+
+const NUM_TEST_WORKERS: usize = 3;
+
+#[derive(Hash)]
+struct TestKey {
+    id: u64,
+}
+#[cfg(feature = "cluster")]
+impl crate::Message for TestKey {}
+
+#[derive(Debug)]
+enum TestMessage {
+    /// Doh'k
+    #[allow(dead_code)]
+    Ok,
+}
+#[cfg(feature = "cluster")]
+impl crate::Message for TestMessage {}
+
+struct TestWorker {
+    counter: Arc<AtomicU16>,
+}
+
+#[async_trait::async_trait]
+impl Actor for TestWorker {
+    type Msg = super::Job<TestKey, TestMessage>;
+    type State = Self::Arguments;
+    type Arguments = WorkerStartContext<TestKey, TestMessage, Self>;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self>,
+        startup_context: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(startup_context)
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        log::debug!("Worker received {:?}", message.msg);
+
+        self.counter.fetch_add(1, Ordering::Relaxed);
+
+        // job finished, on success or err we report back to the factory
+        state
+            .factory
+            .cast(FactoryMessage::Finished(myself.get_id(), message.key))?;
+        Ok(())
+    }
+}
+
+struct TestWorkerBuilder {
+    counters: [Arc<AtomicU16>; NUM_TEST_WORKERS],
+}
+
+impl super::WorkerBuilder<TestWorker> for TestWorkerBuilder {
+    fn build(&self, wid: usize) -> TestWorker {
+        TestWorker {
+            counter: self.counters[wid].clone(),
+        }
+    }
+}
+
+#[crate::concurrency::test]
+async fn test_dispatch_key_persistent() {
+    let worker_counters: [_; NUM_TEST_WORKERS] = [
+        Arc::new(AtomicU16::new(0)),
+        Arc::new(AtomicU16::new(0)),
+        Arc::new(AtomicU16::new(0)),
+    ];
+
+    let worker_builder = TestWorkerBuilder {
+        counters: worker_counters.clone(),
+    };
+    let factory_definition = Factory::<TestKey, TestMessage, TestWorker> {
+        worker_count: NUM_TEST_WORKERS,
+        routing_mode: RoutingMode::<TestKey>::KeyPersistent,
+        ..Default::default()
+    };
+    let (factory, factory_handle) =
+        Actor::spawn(None, factory_definition, Box::new(worker_builder))
+            .await
+            .expect("Failed to spawn factory");
+
+    for _ in 0..999 {
+        factory
+            .cast(FactoryMessage::Dispatch(Job {
+                key: TestKey { id: 1 },
+                msg: TestMessage::Ok,
+                options: JobOptions {
+                    factory_time: Instant::now(),
+                    submit_time: Instant::now(),
+                    ttl: Duration::from_millis(100),
+                },
+            }))
+            .expect("Failed to send to factory");
+    }
+
+    // give some time to process all the messages
+    crate::concurrency::sleep(Duration::from_millis(1000)).await;
+
+    factory.stop(None);
+    factory_handle.await.unwrap();
+
+    // assert
+    let all_counter = worker_counters[0].load(Ordering::Relaxed);
+    assert_eq!(999, all_counter);
+}
+
+// TODO: This test should probably use like a slow queuer or something to check we move to the next item, etc
+#[crate::concurrency::test]
+async fn test_dispatch_queuer() {
+    let worker_counters: [_; NUM_TEST_WORKERS] = [
+        Arc::new(AtomicU16::new(0)),
+        Arc::new(AtomicU16::new(0)),
+        Arc::new(AtomicU16::new(0)),
+    ];
+
+    let worker_builder = TestWorkerBuilder {
+        counters: worker_counters.clone(),
+    };
+    let factory_definition = Factory::<TestKey, TestMessage, TestWorker> {
+        worker_count: NUM_TEST_WORKERS,
+        routing_mode: RoutingMode::<TestKey>::Queuer,
+        ..Default::default()
+    };
+    let (factory, factory_handle) =
+        Actor::spawn(None, factory_definition, Box::new(worker_builder))
+            .await
+            .expect("Failed to spawn factory");
+
+    for _ in 0..999 {
+        factory
+            .cast(FactoryMessage::Dispatch(Job {
+                key: TestKey { id: 1 },
+                msg: TestMessage::Ok,
+                options: JobOptions {
+                    factory_time: Instant::now(),
+                    submit_time: Instant::now(),
+                    ttl: Duration::from_millis(100),
+                },
+            }))
+            .expect("Failed to send to factory");
+    }
+
+    // give some time to process all the messages
+    crate::concurrency::sleep(Duration::from_millis(1000)).await;
+
+    factory.stop(None);
+    factory_handle.await.unwrap();
+
+    // assert
+    let all_counter: u16 = worker_counters
+        .iter()
+        .map(|w| w.load(Ordering::Relaxed))
+        .sum();
+    assert_eq!(999, all_counter);
+}
+
+#[crate::concurrency::test]
+async fn test_dispatch_round_robin() {
+    let worker_counters: [_; NUM_TEST_WORKERS] = [
+        Arc::new(AtomicU16::new(0)),
+        Arc::new(AtomicU16::new(0)),
+        Arc::new(AtomicU16::new(0)),
+    ];
+
+    let worker_builder = TestWorkerBuilder {
+        counters: worker_counters.clone(),
+    };
+    let factory_definition = Factory::<TestKey, TestMessage, TestWorker> {
+        worker_count: NUM_TEST_WORKERS,
+        routing_mode: RoutingMode::<TestKey>::RoundRobin,
+        ..Default::default()
+    };
+    let (factory, factory_handle) =
+        Actor::spawn(None, factory_definition, Box::new(worker_builder))
+            .await
+            .expect("Failed to spawn factory");
+
+    for _ in 0..999 {
+        factory
+            .cast(FactoryMessage::Dispatch(Job {
+                key: TestKey { id: 1 },
+                msg: TestMessage::Ok,
+                options: JobOptions {
+                    factory_time: Instant::now(),
+                    submit_time: Instant::now(),
+                    ttl: Duration::from_millis(100),
+                },
+            }))
+            .expect("Failed to send to factory");
+    }
+
+    // give some time to process all the messages
+    crate::concurrency::sleep(Duration::from_millis(1000)).await;
+
+    factory.stop(None);
+    factory_handle.await.unwrap();
+
+    // assert
+    for counter in worker_counters {
+        assert_eq!(333, counter.load(Ordering::Relaxed));
+    }
+}
+
+#[crate::concurrency::test]
+async fn test_dispatch_random() {
+    let worker_counters: [_; NUM_TEST_WORKERS] = [
+        Arc::new(AtomicU16::new(0)),
+        Arc::new(AtomicU16::new(0)),
+        Arc::new(AtomicU16::new(0)),
+    ];
+
+    let worker_builder = TestWorkerBuilder {
+        counters: worker_counters.clone(),
+    };
+    let factory_definition = Factory::<TestKey, TestMessage, TestWorker> {
+        worker_count: NUM_TEST_WORKERS,
+        routing_mode: RoutingMode::<TestKey>::Random,
+        ..Default::default()
+    };
+    let (factory, factory_handle) =
+        Actor::spawn(None, factory_definition, Box::new(worker_builder))
+            .await
+            .expect("Failed to spawn factory");
+
+    for _ in 0..999 {
+        factory
+            .cast(FactoryMessage::Dispatch(Job {
+                key: TestKey { id: 1 },
+                msg: TestMessage::Ok,
+                options: JobOptions {
+                    factory_time: Instant::now(),
+                    submit_time: Instant::now(),
+                    ttl: Duration::from_millis(100),
+                },
+            }))
+            .expect("Failed to send to factory");
+    }
+
+    // give some time to process all the messages
+    crate::concurrency::sleep(Duration::from_millis(1000)).await;
+
+    factory.stop(None);
+    factory_handle.await.unwrap();
+
+    // assert
+    let all_counter: u16 = worker_counters
+        .iter()
+        .map(|w| w.load(Ordering::Relaxed))
+        .sum();
+    assert_eq!(999, all_counter);
+}
+
+#[crate::concurrency::test]
+async fn test_dispatch_custom_hashing() {
+    struct MyHasher<TKey>
+    where
+        TKey: crate::Message + Sync,
+    {
+        _key: PhantomData<TKey>,
+    }
+
+    impl<TKey> CustomHashFunction<TKey> for MyHasher<TKey>
+    where
+        TKey: crate::Message + Sync,
+    {
+        fn hash(&self, _key: &TKey, _worker_count: usize) -> usize {
+            2
+        }
+    }
+
+    let worker_counters: [_; NUM_TEST_WORKERS] = [
+        Arc::new(AtomicU16::new(0)),
+        Arc::new(AtomicU16::new(0)),
+        Arc::new(AtomicU16::new(0)),
+    ];
+
+    let worker_builder = TestWorkerBuilder {
+        counters: worker_counters.clone(),
+    };
+    let factory_definition = Factory::<TestKey, TestMessage, TestWorker> {
+        worker_count: NUM_TEST_WORKERS,
+        routing_mode: RoutingMode::<TestKey>::CustomHashFunction(Box::new(MyHasher {
+            _key: PhantomData,
+        })),
+        ..Default::default()
+    };
+    let (factory, factory_handle) =
+        Actor::spawn(None, factory_definition, Box::new(worker_builder))
+            .await
+            .expect("Failed to spawn factory");
+
+    for _ in 0..999 {
+        factory
+            .cast(FactoryMessage::Dispatch(Job {
+                key: TestKey { id: 1 },
+                msg: TestMessage::Ok,
+                options: JobOptions {
+                    factory_time: Instant::now(),
+                    submit_time: Instant::now(),
+                    ttl: Duration::from_millis(100),
+                },
+            }))
+            .expect("Failed to send to factory");
+    }
+
+    // give some time to process all the messages
+    crate::concurrency::sleep(Duration::from_millis(1000)).await;
+
+    factory.stop(None);
+    factory_handle.await.unwrap();
+
+    // assert
+    let all_counter = worker_counters[2].load(Ordering::Relaxed);
+    assert_eq!(999, all_counter);
+}

--- a/ractor/src/factory/worker.rs
+++ b/ractor/src/factory/worker.rs
@@ -1,0 +1,147 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! Factory worker properties
+
+use std::collections::VecDeque;
+use std::hash::Hash;
+
+use crate::ActorId;
+use crate::{Actor, ActorRef, Message, MessagingErr};
+
+use super::DiscardHandler;
+use super::Factory;
+use super::Job;
+
+// TODO:
+// 1. Worker stats?
+
+/// Startup context data (`Arguments`) which are passed to a worker on start
+pub struct WorkerStartContext<TKey, TMsg, TWorker>
+where
+    TKey: Message + Hash + Sync,
+    TMsg: Message,
+    TWorker: Actor<Msg = Job<TKey, TMsg>, Arguments = Self>,
+{
+    /// The worker's identifier
+    pub wid: usize,
+
+    /// The factory the worker belongs to
+    pub factory: ActorRef<Factory<TKey, TMsg, TWorker>>,
+}
+
+/// Properties of a worker
+pub struct WorkerProperties<TKey, TMsg, TWorker>
+where
+    TKey: Message + Hash + Sync,
+    TMsg: Message,
+    TWorker: Actor<Msg = Job<TKey, TMsg>>,
+{
+    /// Worker identifier
+    pub wid: usize,
+
+    /// Worker's capacity for parallel work
+    capacity: usize,
+
+    /// Worker actor
+    actor: ActorRef<TWorker>,
+
+    /// Worker's message queue
+    message_queue: VecDeque<Job<TKey, TMsg>>,
+    /// Maximum queue length. Any job arriving when the queue is at its max length
+    /// will cause an oldest job at the head of the queue will be dropped.
+    ///
+    /// Default is disabled
+    discard_threshold: Option<usize>,
+
+    /// A function to be called for each job to be dropped.
+    discard_handler: Option<Box<dyn DiscardHandler<TKey, TMsg>>>,
+
+    /// The current message count being handled by this worker
+    current_count: usize,
+}
+
+impl<TKey, TMsg, TWorker> WorkerProperties<TKey, TMsg, TWorker>
+where
+    TKey: Message + Hash + Sync,
+    TMsg: Message,
+    TWorker: Actor<Msg = Job<TKey, TMsg>, Arguments = WorkerStartContext<TKey, TMsg, TWorker>>,
+{
+    fn get_next_non_expired_job(&mut self) -> Option<Job<TKey, TMsg>> {
+        while let Some(job) = self.message_queue.pop_front() {
+            if !job.is_expired() {
+                return Some(job);
+            }
+        }
+        None
+    }
+
+    pub(crate) fn new(
+        wid: usize,
+        actor: ActorRef<TWorker>,
+        capacity: usize,
+        discard_threshold: Option<usize>,
+        discard_handler: Option<Box<dyn DiscardHandler<TKey, TMsg>>>,
+    ) -> Self {
+        Self {
+            actor,
+            discard_handler,
+            discard_threshold,
+            message_queue: VecDeque::new(),
+            current_count: 0,
+            wid,
+            capacity,
+        }
+    }
+
+    pub(crate) fn is_pid(&self, pid: ActorId) -> bool {
+        self.actor.get_id() == pid
+    }
+
+    pub(crate) fn replace_worker(&mut self, nworker: ActorRef<TWorker>) {
+        self.actor = nworker;
+    }
+
+    pub(crate) fn is_available(&self) -> bool {
+        self.current_count < self.capacity
+    }
+
+    /// Enqueue a new job to this worker. If the discard threshold has been exceeded
+    /// it will discard the oldest elements from the message queue
+    pub(crate) fn enqueue_job(&mut self, job: Job<TKey, TMsg>) -> Result<(), MessagingErr> {
+        if self.current_count < self.capacity {
+            self.current_count += 1;
+            if let Some(older_job) = self.get_next_non_expired_job() {
+                self.message_queue.push_back(job);
+                self.actor.cast(older_job)?;
+            } else {
+                self.actor.cast(job)?;
+            }
+            return Ok(());
+        }
+        self.message_queue.push_back(job);
+        if let Some(discard_threshold) = self.discard_threshold {
+            while discard_threshold > 0 && self.message_queue.len() > discard_threshold {
+                if let Some(discarded) = self.get_next_non_expired_job() {
+                    if let Some(handler) = &self.discard_handler {
+                        handler.discard(discarded);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Called when the factory is notified a worker completed a job. Will push the next message
+    /// if there is any messages in this worker's queue
+    pub(crate) fn worker_complete(&mut self, _key: TKey) -> Result<(), MessagingErr> {
+        if let Some(job) = self.get_next_non_expired_job() {
+            self.actor.cast(job)?;
+        } else {
+            self.current_count -= 1;
+        }
+        Ok(())
+    }
+}

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -149,6 +149,7 @@ pub type GroupName = String;
 pub mod actor;
 pub mod actor_id;
 pub mod concurrency;
+pub mod factory;
 pub mod macros;
 pub mod message;
 pub mod pg;

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"
@@ -24,8 +24,8 @@ bytes = { version = "1" }
 log = "0.4"
 prost = { version = "0.11" }
 prost-types = { version = "0.11" }
-ractor = { version = "0.7.0", features = ["cluster"], path = "../ractor" }
-ractor_cluster_derive = { version = "0.7.0", path = "../ractor_cluster_derive" }
+ractor = { version = "0.7.1", features = ["cluster"], path = "../ractor" }
+ractor_cluster_derive = { version = "0.7.1", path = "../ractor_cluster_derive" }
 rand = "0.8"
 sha2 = "0.10"
 tokio = { version = "1", features = ["rt", "time", "sync", "macros", "net", "io-util"]}

--- a/ractor_cluster/src/remote_actor/mod.rs
+++ b/ractor_cluster/src/remote_actor/mod.rs
@@ -57,14 +57,8 @@ impl RemoteActor {
         supervisor: ActorCell,
     ) -> Result<(ActorRef<Self>, JoinHandle<()>), SpawnErr> {
         let actor_id = ActorId::Remote { node_id, pid };
-        ractor::ActorRuntime::<_, _, Self>::spawn_linked_remote(
-            name,
-            self,
-            actor_id,
-            (),
-            supervisor,
-        )
-        .await
+        ractor::ActorRuntime::<Self>::spawn_linked_remote(name, self, actor_id, (), supervisor)
+            .await
     }
 }
 

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
A factory is a manager of a pool of worker processes (actors). The factory is responsible for dispatching messages to this worker pool based on some predefined routing rules. Additionally depending on the routing mode, various internal message queues are supported.

For remote-procedure-calls, workers are expected to reply directly to the caller who submitted the job, rather than replying through the factory.

The factory additionally manages the lifecycle of internal workers, such that the workers are respawned on failure and all but the current `N` processed messages are handled.