### PR TITLE
Adding support for "instant" spawning

### DIFF
--- a/ractor/src/factory/tests.rs
+++ b/ractor/src/factory/tests.rs
@@ -25,8 +25,6 @@ struct TestKey {
     id: u64,
 }
 #[cfg(feature = "cluster")]
-impl crate::Message for TestKey {}
-#[cfg(feature = "cluster")]
 impl crate::BytesConvertable for TestKey {
     fn from_bytes(bytes: Vec<u8>) -> Self {
         Self {

--- a/ractor/src/serialization.rs
+++ b/ractor/src/serialization.rs
@@ -55,6 +55,13 @@ implement_numeric! {u128}
 implement_numeric! {f32}
 implement_numeric! {f64}
 
+impl BytesConvertable for () {
+    fn into_bytes(self) -> Vec<u8> {
+        Vec::new()
+    }
+    fn from_bytes(_: Vec<u8>) -> Self {}
+}
+
 impl BytesConvertable for bool {
     fn into_bytes(self) -> Vec<u8> {
         if self {


### PR DESCRIPTION
This PR adds support for spawning actors "instantly" in that we don't wait on the `pre_start` routine. This is helpful if you want to immediately have access to the `ActorRef<TActor>` so you can begin sending messages to it without blocking on the `pre_start` routine.

**However** if the `pre_start` fails for any reason, it won't be captured unless the specific join handle is handled manually to monitor the spawning error. Documentation updated to reflect this.

New tests covering instant spawning added.

Additionally we're adding a small auto-implementation for types which implement `BytesSerializable` such that they are automatically implementing `ractor::Message` and can be network-sent. This makes most of the built-in numeric types, `()`, `String`s, and vectors of such able to immediately used in a cluster context.