### PR TITLE
[cluster] Add support for transitive connections between nodes

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -42,4 +42,9 @@ jobs:
         working-directory: .
         run: |
           docker compose --env-file ./ractor_cluster_integration_tests/envs/encryption.env up --exit-code-from node-b
+          
+      - name: Transitive connections
+        working-directory: .
+        run: |
+          docker compose --env-file ./ractor_cluster_integration_tests/envs/dist-connect.env up --exit-code-from node-c
       

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,21 @@ services:
     command: ractor_cluster_integration_tests test ${B_TEST}
     environment:
       RUST_LOG: debug
+
+  node-c:
+    depends_on: 
+      - node-b
+    container_name: "node-c"
+    build:
+      context: .
+      dockerfile: ractor_cluster_integration_tests/Dockerfile
+    image: ractor_cluster_tests:latest
+    networks:
+      - test-net
+    entrypoint: ''
+    command: ractor_cluster_integration_tests test ${C_TEST}
+    environment:
+      RUST_LOG: debug
 networks:
   test-net:
     external: false

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"
@@ -24,8 +24,8 @@ bytes = { version = "1" }
 log = "0.4"
 prost = { version = "0.11" }
 prost-types = { version = "0.11" }
-ractor = { version = "0.7.2", features = ["cluster"], path = "../ractor" }
-ractor_cluster_derive = { version = "0.7.2", path = "../ractor_cluster_derive" }
+ractor = { version = "0.7.3", features = ["cluster"], path = "../ractor" }
+ractor_cluster_derive = { version = "0.7.3", path = "../ractor_cluster_derive" }
 rand = "0.8"
 rustls = { version = "0.20" }
 sha2 = "0.10"

--- a/ractor_cluster/src/lib.rs
+++ b/ractor_cluster/src/lib.rs
@@ -42,6 +42,7 @@
 //! serialization is handled. There however is a procedural macro in `ractor_cluster_derive` to facilitate this, which is
 //! re-exposed on this crate under the same naming. Simply derive [RactorMessage] or [RactorClusterMessage] if you want local or
 //! remote-supporting messages, respectively.
+//!
 
 #![deny(warnings)]
 #![warn(unused_imports)]

--- a/ractor_cluster/src/node/auth.rs
+++ b/ractor_cluster/src/node/auth.rs
@@ -211,6 +211,7 @@ mod tests {
                     proto::NameMessage {
                         name: "howdy".to_string(),
                         flags: Some(NodeFlags { version: 1 }),
+                        connection_string: "localhost:123".to_string(),
                     },
                 )),
             },
@@ -324,6 +325,7 @@ mod tests {
                         name: "challenger".to_string(),
                         flags: Some(NodeFlags { version: 1 }),
                         challenge: 123,
+                        connection_string: "localhost:123".to_string(),
                     },
                 )),
             },

--- a/ractor_cluster/src/node/node_session/tests.rs
+++ b/ractor_cluster/src/node/node_session/tests.rs
@@ -12,6 +12,8 @@ use std::sync::{
 
 use ractor::concurrency::sleep;
 
+use crate::node::NodeConnectionMode;
+
 use super::*;
 
 struct DummyNodeServer;
@@ -94,11 +96,13 @@ async fn node_sesison_client_auth_success() {
         cookie: "cookie".to_string(),
         is_server: true,
         node_id: 1,
-        node_name: auth_protocol::NameMessage {
+        this_node_name: auth_protocol::NameMessage {
             name: "myself".to_string(),
             flags: Some(auth_protocol::NodeFlags { version: 1 }),
+            connection_string: "localhost:123".to_string(),
         },
         node_server: server_ref.clone(),
+        connection_mode: NodeConnectionMode::Isolated,
     };
 
     let mut state = NodeSessionState {
@@ -171,6 +175,7 @@ async fn node_sesison_client_auth_success() {
             auth_protocol::Challenge {
                 name: "Something".to_string(),
                 flags: Some(auth_protocol::NodeFlags { version: 1 }),
+                connection_string: "localhost:123".to_string(),
                 challenge: 123,
             },
         )),
@@ -235,11 +240,13 @@ async fn node_session_client_auth_session_state_failures() {
         cookie: "cookie".to_string(),
         is_server: true,
         node_id: 1,
-        node_name: auth_protocol::NameMessage {
+        this_node_name: auth_protocol::NameMessage {
             name: "myself".to_string(),
             flags: Some(auth_protocol::NodeFlags { version: 1 }),
+            connection_string: "localhost:123".to_string(),
         },
         node_server: server_ref.clone(),
+        connection_mode: NodeConnectionMode::Isolated,
     };
 
     let mut state = NodeSessionState {
@@ -312,6 +319,7 @@ async fn node_session_client_auth_session_state_failures() {
             auth_protocol::Challenge {
                 name: "something".to_string(),
                 flags: Some(auth_protocol::NodeFlags { version: 1 }),
+                connection_string: "localhost:123".to_string(),
                 challenge: 123,
             },
             [0u8; 32],
@@ -360,11 +368,13 @@ async fn node_session_server_auth_success() {
         cookie: "cookie".to_string(),
         is_server: true,
         node_id: 1,
-        node_name: auth_protocol::NameMessage {
+        this_node_name: auth_protocol::NameMessage {
             name: "myself".to_string(),
             flags: Some(auth_protocol::NodeFlags { version: 1 }),
+            connection_string: "localhost:123".to_string(),
         },
         node_server: server_ref.clone(),
+        connection_mode: NodeConnectionMode::Isolated,
     };
 
     // let addr = SocketAddr::
@@ -383,6 +393,7 @@ async fn node_session_server_auth_success() {
             auth_protocol::NameMessage {
                 name: "peer".to_string(),
                 flags: Some(auth_protocol::NodeFlags { version: 1 }),
+                connection_string: "localhost:123".to_string(),
             },
         )),
     };
@@ -451,11 +462,13 @@ async fn node_session_server_auth_session_state_failures() {
         cookie: "cookie".to_string(),
         is_server: true,
         node_id: 1,
-        node_name: auth_protocol::NameMessage {
+        this_node_name: auth_protocol::NameMessage {
             name: "myself".to_string(),
             flags: Some(auth_protocol::NodeFlags { version: 1 }),
+            connection_string: "localhost:123".to_string(),
         },
         node_server: server_ref.clone(),
+        connection_mode: NodeConnectionMode::Isolated,
     };
 
     let mut state = NodeSessionState {
@@ -473,6 +486,7 @@ async fn node_session_server_auth_session_state_failures() {
             auth_protocol::NameMessage {
                 name: "other_continues".to_string(),
                 flags: Some(auth_protocol::NodeFlags { version: 1 }),
+                connection_string: "localhost:123".to_string(),
             },
         )),
     };
@@ -491,6 +505,7 @@ async fn node_session_server_auth_session_state_failures() {
             auth_protocol::NameMessage {
                 name: "this_continues".to_string(),
                 flags: Some(auth_protocol::NodeFlags { version: 1 }),
+                connection_string: "localhost:123".to_string(),
             },
         )),
     };
@@ -595,11 +610,13 @@ async fn node_session_handle_node_msg() {
         cookie: "cookie".to_string(),
         is_server: true,
         node_id: 1,
-        node_name: auth_protocol::NameMessage {
+        this_node_name: auth_protocol::NameMessage {
             name: "myself".to_string(),
             flags: Some(auth_protocol::NodeFlags { version: 1 }),
+            connection_string: "localhost:123".to_string(),
         },
         node_server: server_ref.clone(),
+        connection_mode: NodeConnectionMode::Isolated,
     };
 
     let mut state = NodeSessionState {
@@ -689,11 +706,13 @@ async fn node_session_handle_control() {
         cookie: "cookie".to_string(),
         is_server: true,
         node_id: 1,
-        node_name: auth_protocol::NameMessage {
+        this_node_name: auth_protocol::NameMessage {
             name: "myself".to_string(),
             flags: Some(auth_protocol::NodeFlags { version: 1 }),
+            connection_string: "localhost:123".to_string(),
         },
         node_server: server_ref.clone(),
+        connection_mode: NodeConnectionMode::Isolated,
     };
 
     let mut state = NodeSessionState {

--- a/ractor_cluster/src/protocol/auth.proto
+++ b/ractor_cluster/src/protocol/auth.proto
@@ -29,6 +29,9 @@ message NameMessage {
 
     // The node's capability flags
     NodeFlags flags = 2;
+
+    // This node's connection details
+    string connection_string = 3;
 }
 
 // Server -> Client: `SendStatus` is the server replying with the handshake status to the client
@@ -77,6 +80,8 @@ message Challenge {
     NodeFlags flags = 2;
     // The challenge value
     uint32 challenge = 3;
+    // The node's incoming connection string
+    string connection_string = 4;
 }
 
 // The reply to the server's challenge.

--- a/ractor_cluster/src/protocol/control.proto
+++ b/ractor_cluster/src/protocol/control.proto
@@ -15,6 +15,7 @@ syntax = "proto3";
 package control;
 
 import "google/protobuf/timestamp.proto";
+import "auth.proto";
 
 // Represents a single actor
 message Actor {
@@ -65,6 +66,12 @@ message PgLeave {
     repeated Actor actors = 2;
 }
 
+// A collection of NodeSession endpoints
+message NodeSessions {
+    // The list of sessions
+    repeated auth.NameMessage sessions = 1;
+}
+
 // Control messages between authenticated `node()`s which are dist-connected
 message ControlMessage {
     // The message payload
@@ -81,5 +88,9 @@ message ControlMessage {
         PgJoin pg_join = 5;
         // A PG group leave event
         PgLeave pg_leave = 6;
+        // Enumerate the node sessions on the remote peer
+        auth.NameMessage enumerate_node_sessions = 7;
+        // The list of node sessions on the remote host for transitive connections
+        NodeSessions node_sessions = 8;
     }
 }

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"

--- a/ractor_cluster_integration_tests/envs/auth-handshake.env
+++ b/ractor_cluster_integration_tests/envs/auth-handshake.env
@@ -1,2 +1,3 @@
 A_TEST="auth-handshake 8199"
 B_TEST="auth-handshake 8198 8199 node-a"
+C_TEST="nan"

--- a/ractor_cluster_integration_tests/envs/dist-connect.env
+++ b/ractor_cluster_integration_tests/envs/dist-connect.env
@@ -1,0 +1,3 @@
+A_TEST="dist-connect node-a 8199"
+B_TEST="dist-connect node-b 8198 8199 node-a"
+C_TEST="dist-connect node-c 8197 8199 node-a"

--- a/ractor_cluster_integration_tests/envs/pg-groups.env
+++ b/ractor_cluster_integration_tests/envs/pg-groups.env
@@ -1,2 +1,3 @@
 A_TEST="pg-groups 8199"
 B_TEST="pg-groups 8198 8199 node-a"
+C_TEST="nan"

--- a/ractor_cluster_integration_tests/src/repl.rs
+++ b/ractor_cluster_integration_tests/src/repl.rs
@@ -22,6 +22,12 @@ impl ReplCommandProcessor<TestCase> for TestRepl {
             TestCase::AuthHandshake(config) => crate::tests::auth_handshake::test(config).await,
             TestCase::PgGroups(config) => crate::tests::pg_groups::test(config).await,
             TestCase::Encryption(config) => crate::tests::encryption::test(config).await,
+            TestCase::DistConnect(config) => crate::tests::dist_connect::test(config).await,
+
+            TestCase::Nan => {
+                ractor::concurrency::sleep(ractor::concurrency::Duration::from_secs(2)).await;
+                0
+            }
         };
 
         if code < 0 {

--- a/ractor_cluster_integration_tests/src/tests/auth_handshake.rs
+++ b/ractor_cluster_integration_tests/src/tests/auth_handshake.rs
@@ -34,6 +34,7 @@ pub async fn test(config: AuthHandshakeConfig) -> i32 {
         super::random_name(),
         hostname.clone(),
         ractor_cluster::IncomingEncryptionMode::Raw,
+        ractor_cluster::node::NodeConnectionMode::Isolated,
     );
 
     log::info!("Starting NodeServer on port {}", config.server_port);
@@ -90,7 +91,7 @@ pub async fn test(config: AuthHandshakeConfig) -> i32 {
             }
 
             let is_authenticated = ractor::call_t!(
-                item,
+                item.actor,
                 ractor_cluster::NodeSessionMessage::GetAuthenticationState,
                 200
             );

--- a/ractor_cluster_integration_tests/src/tests/dist_connect.rs
+++ b/ractor_cluster_integration_tests/src/tests/dist_connect.rs
@@ -1,0 +1,126 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! The the transitive dist-connect functionality of the cluster. If B -> A and C -> A
+//! then C should auto-connect to B
+
+use clap::Args;
+use ractor::concurrency::{sleep, Duration, Instant};
+use ractor::Actor;
+
+const DIST_CONNECT_TIME_ALLOWANCE_MS: u128 = 2000;
+
+/// Configuration
+#[derive(Args, Debug, Clone)]
+pub struct DistConnectConfig {
+    /// Node's name (also DNS name)
+    node_name: String,
+    /// Server port
+    server_port: u16,
+    /// If specified, represents the client to connect to
+    client_port: Option<u16>,
+    /// If specified, represents the client to connect to
+    client_host: Option<String>,
+}
+
+pub async fn test(config: DistConnectConfig) -> i32 {
+    let cookie = "cookie".to_string();
+
+    let server = ractor_cluster::NodeServer::new(
+        config.server_port,
+        cookie,
+        super::random_name(),
+        config.node_name.clone(),
+        ractor_cluster::IncomingEncryptionMode::Raw,
+        if config.node_name.as_str() == "node-c" {
+            ractor_cluster::node::NodeConnectionMode::Transitive
+        } else {
+            ractor_cluster::node::NodeConnectionMode::Isolated
+        },
+    );
+
+    log::info!("Starting NodeServer on port {}", config.server_port);
+    // startup the node server
+    let (actor, handle) = Actor::spawn(None, server, ())
+        .await
+        .expect("Failed to start NodeServer");
+
+    // let the nodeserver startup and start listening on the port
+    sleep(Duration::from_millis(100)).await;
+
+    // if you're Node-c, wait for Node-b to be fully authenticated first
+    if config.node_name.as_str() == "node-c" {
+        // Let B fully authenticate to A before starting C so it'll be available in the listing.
+        sleep(Duration::from_millis(100)).await;
+    }
+
+    // If this server should connect to a client server, initiate that connection
+    if let (Some(client_host), Some(client_port)) = (config.client_host, config.client_port) {
+        log::info!(
+            "Connecting to remote NodeServer at {}:{}",
+            client_host,
+            client_port
+        );
+        if let Err(error) =
+            ractor_cluster::node::client::connect(&actor, format!("{client_host}:{client_port}"))
+                .await
+        {
+            log::error!("Failed to connect with error {error}");
+            return -3;
+        } else {
+            log::info!(
+                "Client connected {} to {}:{}",
+                config.node_name,
+                client_host,
+                client_port
+            );
+        }
+    }
+
+    let mut err_code = -1;
+    log::info!("Waiting for NodeSession status updates");
+
+    let mut rpc_reply = ractor::call_t!(actor, ractor_cluster::NodeServerMessage::GetSessions, 200);
+    let tic = Instant::now();
+
+    while rpc_reply.is_ok() {
+        let time: Duration = Instant::now() - tic;
+        if time.as_millis() > DIST_CONNECT_TIME_ALLOWANCE_MS {
+            err_code = -2;
+            log::error!(
+                "The dist-connect test time has been going on for over > {}ms. Failing the test",
+                time.as_millis()
+            );
+            break;
+        }
+
+        let values = rpc_reply
+            .unwrap()
+            .into_values()
+            .filter_map(|v| v.peer_name)
+            .collect::<Vec<_>>();
+        if values.len() >= 2 {
+            // Our node as at least 2 connections
+            log::debug!("Connected session information: {:?}", values);
+            log::info!("Transitive connections succeeded. Exiting");
+            err_code = 0;
+            break;
+        }
+
+        // try again
+        rpc_reply = ractor::call_t!(actor, ractor_cluster::NodeServerMessage::GetSessions, 200);
+    }
+
+    log::info!("Terminating test - code {}", err_code);
+
+    // Let the other nodes exist for some time to make sure we get to a stable network state before actually terminating nodes
+    sleep(Duration::from_millis(500)).await;
+
+    // cleanup
+    actor.stop(None);
+    handle.await.unwrap();
+
+    err_code
+}

--- a/ractor_cluster_integration_tests/src/tests/encryption.rs
+++ b/ractor_cluster_integration_tests/src/tests/encryption.rs
@@ -104,6 +104,7 @@ pub async fn test(config: EncryptionConfig) -> i32 {
         super::random_name(),
         hostname.clone(),
         ractor_cluster::IncomingEncryptionMode::Tls(acceptor),
+        ractor_cluster::node::NodeConnectionMode::Isolated,
     );
 
     log::info!("Starting NodeServer on port {}", config.server_port);
@@ -165,7 +166,7 @@ pub async fn test(config: EncryptionConfig) -> i32 {
             }
 
             let is_authenticated = ractor::call_t!(
-                item,
+                item.actor,
                 ractor_cluster::NodeSessionMessage::GetAuthenticationState,
                 200
             );

--- a/ractor_cluster_integration_tests/src/tests/mod.rs
+++ b/ractor_cluster_integration_tests/src/tests/mod.rs
@@ -10,6 +10,7 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 
 pub mod auth_handshake;
+pub mod dist_connect;
 pub mod encryption;
 pub mod pg_groups;
 
@@ -29,4 +30,8 @@ pub enum TestCase {
     PgGroups(pg_groups::PgGroupsConfig),
     /// Test encrypted socket communications (through the auth handshake)
     Encryption(encryption::EncryptionConfig),
+    /// Test the transitive connection of a cluster
+    DistConnect(dist_connect::DistConnectConfig),
+    /// Not-a-Node: Don't run any test and exit this node with code 0
+    Nan,
 }

--- a/ractor_cluster_integration_tests/src/tests/pg_groups.rs
+++ b/ractor_cluster_integration_tests/src/tests/pg_groups.rs
@@ -112,6 +112,7 @@ pub(crate) async fn test(config: PgGroupsConfig) -> i32 {
         super::random_name(),
         hostname,
         ractor_cluster::IncomingEncryptionMode::Raw,
+        ractor_cluster::node::NodeConnectionMode::Isolated,
     );
 
     let (actor, handle) = Actor::spawn(None, server, ())
@@ -151,7 +152,7 @@ pub(crate) async fn test(config: PgGroupsConfig) -> i32 {
             .cloned()
         {
             let is_authenticated = ractor::call_t!(
-                item,
+                item.actor,
                 ractor_cluster::NodeSessionMessage::GetAuthenticationState,
                 200
             );

--- a/ractor_playground/src/distributed.rs
+++ b/ractor_playground/src/distributed.rs
@@ -29,6 +29,7 @@ pub(crate) async fn test_auth_handshake(port_a: u16, port_b: u16, valid_cookies:
         "node_a".to_string(),
         hostname.clone(),
         ractor_cluster::IncomingEncryptionMode::Raw,
+        ractor_cluster::node::NodeConnectionMode::Isolated,
     );
     let server_b = ractor_cluster::NodeServer::new(
         port_b,
@@ -36,6 +37,7 @@ pub(crate) async fn test_auth_handshake(port_a: u16, port_b: u16, valid_cookies:
         "node_b".to_string(),
         hostname,
         ractor_cluster::IncomingEncryptionMode::Raw,
+        ractor_cluster::node::NodeConnectionMode::Isolated,
     );
 
     let (actor_a, handle_a) = Actor::spawn(None, server_a, ())
@@ -140,6 +142,7 @@ pub(crate) async fn startup_ping_pong_test_node(port: u16, connect_client: Optio
         "node_a".to_string(),
         hostname,
         ractor_cluster::IncomingEncryptionMode::Raw,
+        ractor_cluster::node::NodeConnectionMode::Isolated,
     );
 
     let (actor, handle) = Actor::spawn(None, server, ())


### PR DESCRIPTION
This change adds support, upon a peer's connection, to list the peer's peers and then try connecting to them.

Integration tests added

```bash
docker compose build
docker compose --env-file ./ractor_cluster_integration_tests/envs/dist-connect.env up --exit-code-from node-c
...
node-c  | [2023-02-20T01:05:18.159Z DEBUG ractor_cluster_integration_tests::tests::dist_connect] Connected session information: [NameMessage { name: "AjNVdQD5zsl97JiGyyme7poAnsGFCk@node-b", flags: Some(NodeFlags { version: 1 }), connection_string: "node-b:8198" }, NameMessage { name: "5yPiX775t9nVOI2WLwDZKLCRrUW7bK@node-a", flags: Some(NodeFlags { version: 1 }), connection_string: "node-a:8199" }]
node-c  | [2023-02-20T01:05:18.160Z INFO  ractor_cluster_integration_tests::tests::dist_connect] Transitive connections succeeded. Exiting
node-c  | [2023-02-20T01:05:18.160Z INFO  ractor_cluster_integration_tests::tests::dist_connect] Terminating test - code 0
...
```

Code coverage will likely be low given we're testing in integration tests which due to the docker environment don't support codecov metric collection. Coverage on ractor's core crate shouldn't have dropped at all