### PR TITLE
More tests + documentation

### DIFF
--- a/ractor_cluster/README.md
+++ b/ractor_cluster/README.md
@@ -1,5 +1,9 @@
 # ractor_cluster
 
+<p align="center">
+    <img src="https://raw.githubusercontent.com/slawlor/ractor/main/docs/ractor_logo.svg" width="20%" /> 
+</p>
+
 *A companion crate to `ractor` for supporting remote actors*
 
 [<img alt="github" src="https://img.shields.io/badge/github-slawlor/ractor-8da0cb?style=for-the-badge&labelColor=555555&logo=github" height="20">](https://github.com/slawlor/ractor)
@@ -9,11 +13,11 @@
 [![codecov](https://codecov.io/gh/slawlor/ractor/branch/main/graph/badge.svg?token=61AGYYPWBA)](https://codecov.io/gh/slawlor/ractor)
 ![ractor_cluster Downloads](https://img.shields.io/crates/d/ractor_cluster.svg)
 
-This crate contains extensions to `ractor`, a pure-Rust actor framework. Inspired from [Erlang's `gen_server`](https://www.erlang.org/doc/man/gen_server.html). 
+This crate contains extensions to `ractor`, a pure-Rust actor framework. Inspired from [Erlang's `gen_server`](https://www.erlang.org/doc/man/gen_server.html).
 
 ## About
 
-`ractor_cluster` expands upon `ractor` actors to support transmission over a network link and synchronization of actors on remote systems.
+`ractor_cluster` expands upon `ractor` actors to support transmission over a network link and synchronization of actors on networked clusters of actors.
 
 ## Installation
 
@@ -32,7 +36,7 @@ Ractor actors can be built in a network-distributed pool of actors, similar to [
 `ractor_cluster` has a single main type in it, namely the `NodeServer` which represents a host of a `node()` process. It additionally has some macros and a procedural macros to facilitate developer efficiency when building distributed actors. The `NodeServer` is responsible for:
 
 1. Managing all incoming and outgoing `NodeSession` actors which represent a remote node connected to this host.
-2. Managing the `TcpListener` which hosts the server socket to accept incoming session requests.
+2. Managing the `TcpListener` which hosts the server socket to accept incoming session requests (with or without encryption).
 
 The bulk of the logic for node interconnections however is held in the `NodeSession` which manages
 
@@ -51,6 +55,26 @@ Actor::spawn(Some("name".to_string()), MyActor).await
 ```
 
 pattern.
+
+### Quick-start
+
+The basics of setting up a networked cluster of actors lives in the `NodeServer` struct. This structure handles the low-level network ownership over a server port along with all of the lifecycle of cluster inter-connections. By spawning this single struct, you're able to accept incoming connections between hosts!
+
+Nodes in the network are authenticated to each other with a "magic cookie" following the Erlang specification in [Erlang's distribution protocol](https://www.erlang.org/doc/apps/erts/erl_dist_protocol.html). If you want to connect to another host, you need to
+
+1. Initialize your own `NodeServer`
+2. Execute a "client-connection" to the remote `NodeServer` you're trying to connect to like
+
+```rust
+let host = "1.2.3.4";
+let port = "4697";
+ractor_cluster::client_connect(
+    &actor,
+    format!("{host}:{port}"),
+)
+```
+
+Similarly there is a `client_connect_enc` to connect to a `NodeServer` which is utilizing encrypted communication. That's it! If your nodes are sharing a proper magic cookie value, they should authenticate to each other and you'll see remote actors spawned on your local system which you can communciate with through the various `pg` or `pid`-based registries.
 
 ### Designing remote-supported actors
 

--- a/ractor_cluster/src/macros.rs
+++ b/ractor_cluster/src/macros.rs
@@ -28,10 +28,31 @@ macro_rules! derive_serialization_for_prost_type {
 
 #[cfg(test)]
 mod test {
+    use ractor::BytesConvertable;
+
     use crate::derive_serialization_for_prost_type;
 
     #[test]
-    fn test_protobuf_message_compiles() {
+    fn test_protobuf_message_serialization() {
         derive_serialization_for_prost_type! {crate::protocol::NetworkMessage}
+
+        let original = crate::protocol::NetworkMessage {
+            message: Some(crate::protocol::meta::network_message::Message::Node(
+                crate::protocol::node::NodeMessage {
+                    msg: Some(crate::protocol::node::node_message::Msg::Cast(
+                        crate::protocol::node::Cast {
+                            to: 3,
+                            what: vec![0, 1, 2],
+                            variant: "something".to_string(),
+                            metadata: None,
+                        },
+                    )),
+                },
+            )),
+        };
+
+        let bytes = original.clone().into_bytes();
+        let decoded = <crate::protocol::NetworkMessage as BytesConvertable>::from_bytes(bytes);
+        assert_eq!(original, decoded);
     }
 }

--- a/ractor_cluster/src/node/mod.rs
+++ b/ractor_cluster/src/node/mod.rs
@@ -177,22 +177,23 @@ impl NodeServer {
     /// * `cookie` - The magic cookie for authentication between [NodeServer]s
     /// * `node_name` - The name of this node
     /// * `hostname` - The hostname of the machine
-    /// * `connection_mode` - Connection mode for peer nodes
+    /// * `encryption_mode`- (optional) Node socket encryption functionality (Default = [IncomingEncryptionMode::Raw])
+    /// * `connection_mode` - (optional) Connection mode for peer nodes (Default = [NodeConnectionMode::Isolated])
     pub fn new(
         port: crate::net::NetworkPort,
         cookie: String,
         node_name: String,
         hostname: String,
-        tls_config: IncomingEncryptionMode,
-        connection_mode: NodeConnectionMode,
+        encryption_mode: Option<IncomingEncryptionMode>,
+        connection_mode: Option<NodeConnectionMode>,
     ) -> Self {
         Self {
             port,
             cookie,
             node_name,
             hostname,
-            encryption_mode: tls_config,
-            connection_mode,
+            encryption_mode: encryption_mode.unwrap_or(IncomingEncryptionMode::Raw),
+            connection_mode: connection_mode.unwrap_or(NodeConnectionMode::Isolated),
         }
     }
 }

--- a/ractor_cluster/src/node/node_session/mod.rs
+++ b/ractor_cluster/src/node/node_session/mod.rs
@@ -728,9 +728,14 @@ impl NodeSession {
         match state.remote_actors.get(&actor_pid) {
             Some(actor) => Ok(actor.clone()),
             _ => {
-                let remote_actor_s: RemoteActor = myself.into();
-                let (remote_actor, _) = remote_actor_s
-                    .spawn_linked(actor_name, actor_pid, self.node_id, myself.get_cell())
+                let (remote_actor, _) = RemoteActor
+                    .spawn_linked(
+                        myself.clone(),
+                        actor_name,
+                        actor_pid,
+                        self.node_id,
+                        myself.get_cell(),
+                    )
                     .await?;
                 state.remote_actors.insert(actor_pid, remote_actor.clone());
                 Ok(remote_actor)

--- a/ractor_cluster/src/remote_actor/tests.rs
+++ b/ractor_cluster/src/remote_actor/tests.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use super::*;
+
+struct FakeNodeSession;
+
+impl FakeNodeSession {
+    async fn get_node_session() -> (ActorRef<crate::node::NodeSession>, JoinHandle<()>) {
+        let (r, h) = Actor::spawn(None, FakeNodeSession, ())
+            .await
+            .expect("Failed to start fake node session");
+        let cell: ractor::ActorCell = r.into();
+        (cell.into(), h)
+    }
+}
+
+#[async_trait::async_trait]
+impl Actor for FakeNodeSession {
+    type Msg = crate::node::NodeSessionMessage;
+    type State = ();
+    type Arguments = ();
+    async fn pre_start(
+        &self,
+        _: ActorRef<Self>,
+        _: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(())
+    }
+}
+
+#[ractor::concurrency::test]
+async fn remote_actor_serialized_message_handling() {
+    // setup
+    let (actor, handle) = FakeNodeSession::get_node_session().await;
+    let (remote_actor_ref, remote_actor_handle) = Actor::spawn(None, RemoteActor, actor.clone())
+        .await
+        .expect("Failed to spawn remote actor");
+
+    let remote_actor_instance = RemoteActor;
+    let mut remote_actor_state = RemoteActorState {
+        message_tag: 0,
+        pending_requests: HashMap::new(),
+        session: actor.clone(),
+    };
+
+    // act & verify
+    let bad_handler = remote_actor_instance
+        .handle(
+            remote_actor_ref.clone(),
+            RemoteActorMessage,
+            &mut remote_actor_state,
+        )
+        .await;
+    assert!(bad_handler.is_err());
+
+    let cast = SerializedMessage::Cast {
+        variant: "A".to_string(),
+        args: vec![1, 2, 3],
+        metadata: None,
+    };
+    let cast_output = remote_actor_instance
+        .handle_serialized(remote_actor_ref.clone(), cast, &mut remote_actor_state)
+        .await;
+    assert!(cast_output.is_ok());
+    // cast's don't have pending requests
+    assert_eq!(0, remote_actor_state.message_tag);
+
+    let (tx, _rx) = ractor::concurrency::oneshot();
+    let call = SerializedMessage::Call {
+        variant: "B".to_string(),
+        args: vec![1, 2, 3],
+        reply: tx.into(),
+        metadata: None,
+    };
+    let call_output = remote_actor_instance
+        .handle_serialized(remote_actor_ref.clone(), call, &mut remote_actor_state)
+        .await;
+    assert!(call_output.is_ok());
+    assert_eq!(1, remote_actor_state.message_tag);
+    assert!(remote_actor_state.pending_requests.get(&1).is_some());
+
+    let reply = SerializedMessage::CallReply(1, vec![3, 4, 5]);
+    let reply_output = remote_actor_instance
+        .handle_serialized(remote_actor_ref.clone(), reply, &mut remote_actor_state)
+        .await;
+    assert!(reply_output.is_ok());
+    assert!(remote_actor_state.pending_requests.get(&1).is_none());
+
+    // cleanup
+    remote_actor_ref.stop(None);
+    actor.stop(None);
+    remote_actor_handle.await.unwrap();
+    handle.await.unwrap();
+}

--- a/ractor_cluster_integration_tests/src/tests/auth_handshake.rs
+++ b/ractor_cluster_integration_tests/src/tests/auth_handshake.rs
@@ -33,8 +33,8 @@ pub async fn test(config: AuthHandshakeConfig) -> i32 {
         cookie,
         super::random_name(),
         hostname.clone(),
-        ractor_cluster::IncomingEncryptionMode::Raw,
-        ractor_cluster::node::NodeConnectionMode::Isolated,
+        None,
+        None,
     );
 
     log::info!("Starting NodeServer on port {}", config.server_port);

--- a/ractor_cluster_integration_tests/src/tests/dist_connect.rs
+++ b/ractor_cluster_integration_tests/src/tests/dist_connect.rs
@@ -33,11 +33,11 @@ pub async fn test(config: DistConnectConfig) -> i32 {
         cookie,
         super::random_name(),
         config.node_name.clone(),
-        ractor_cluster::IncomingEncryptionMode::Raw,
+        None,
         if config.node_name.as_str() == "node-c" {
-            ractor_cluster::node::NodeConnectionMode::Transitive
+            Some(ractor_cluster::node::NodeConnectionMode::Transitive)
         } else {
-            ractor_cluster::node::NodeConnectionMode::Isolated
+            Some(ractor_cluster::node::NodeConnectionMode::Isolated)
         },
     );
 

--- a/ractor_cluster_integration_tests/src/tests/encryption.rs
+++ b/ractor_cluster_integration_tests/src/tests/encryption.rs
@@ -103,8 +103,8 @@ pub async fn test(config: EncryptionConfig) -> i32 {
         cookie,
         super::random_name(),
         hostname.clone(),
-        ractor_cluster::IncomingEncryptionMode::Tls(acceptor),
-        ractor_cluster::node::NodeConnectionMode::Isolated,
+        Some(ractor_cluster::IncomingEncryptionMode::Tls(acceptor)),
+        None,
     );
 
     log::info!("Starting NodeServer on port {}", config.server_port);

--- a/ractor_cluster_integration_tests/src/tests/pg_groups.rs
+++ b/ractor_cluster_integration_tests/src/tests/pg_groups.rs
@@ -111,8 +111,8 @@ pub(crate) async fn test(config: PgGroupsConfig) -> i32 {
         cookie,
         super::random_name(),
         hostname,
-        ractor_cluster::IncomingEncryptionMode::Raw,
-        ractor_cluster::node::NodeConnectionMode::Isolated,
+        None,
+        None,
     );
 
     let (actor, handle) = Actor::spawn(None, server, ())

--- a/ractor_playground/src/distributed.rs
+++ b/ractor_playground/src/distributed.rs
@@ -28,16 +28,16 @@ pub(crate) async fn test_auth_handshake(port_a: u16, port_b: u16, valid_cookies:
         cookie_a,
         "node_a".to_string(),
         hostname.clone(),
-        ractor_cluster::IncomingEncryptionMode::Raw,
-        ractor_cluster::node::NodeConnectionMode::Isolated,
+        None,
+        None,
     );
     let server_b = ractor_cluster::NodeServer::new(
         port_b,
         cookie_b,
         "node_b".to_string(),
         hostname,
-        ractor_cluster::IncomingEncryptionMode::Raw,
-        ractor_cluster::node::NodeConnectionMode::Isolated,
+        None,
+        None,
     );
 
     let (actor_a, handle_a) = Actor::spawn(None, server_a, ())
@@ -136,14 +136,8 @@ pub(crate) async fn startup_ping_pong_test_node(port: u16, connect_client: Optio
     let cookie = "cookie".to_string();
     let hostname = "localhost".to_string();
 
-    let server = ractor_cluster::NodeServer::new(
-        port,
-        cookie,
-        "node_a".to_string(),
-        hostname,
-        ractor_cluster::IncomingEncryptionMode::Raw,
-        ractor_cluster::node::NodeConnectionMode::Isolated,
-    );
+    let server =
+        ractor_cluster::NodeServer::new(port, cookie, "node_a".to_string(), hostname, None, None);
 
     let (actor, handle) = Actor::spawn(None, server, ())
         .await


### PR DESCRIPTION
Additionally this cleans up some syntax for setting up some of the types in `ractor_cluster` but it's all essentially a no-op except a few small constructor calls.