### PR TITLE
Add new website link to README(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A pure-Rust actor framework. Inspired from [Erlang's `gen_server`](https://www.e
 * `ractor`: ![ractor Downloads](https://img.shields.io/crates/d/ractor.svg)
 * `ractor_cluster`: ![ractor_cluster Downloads](https://img.shields.io/crates/d/ractor_cluster.svg)
 
+**Ractor has a new website!** We've opened a new website to have more general usage patterns (best practices) and helpful guides with actors. Api docs will still be available at [docs.rs](https://docs.rs/ractor) however this will be a supplimentary site for `ractor`. Try it out! <https://slawlor.github.io/ractor/>
+
 ## About
 
 `ractor` tries to solve the problem of building and maintaining an Erlang-like actor framework in Rust. It gives

--- a/ractor_cluster/README.md
+++ b/ractor_cluster/README.md
@@ -15,6 +15,8 @@
 
 This crate contains extensions to `ractor`, a pure-Rust actor framework. Inspired from [Erlang's `gen_server`](https://www.erlang.org/doc/man/gen_server.html).
 
+**Ractor has a new website!** We've opened a new website to have more general usage patterns (best practices) and helpful guides with actors. Api docs will still be available at [docs.rs](https://docs.rs/ractor) however this will be a supplimentary site for `ractor`. Try it out! <https://slawlor.github.io/ractor/>
+
 ## About
 
 `ractor_cluster` expands upon `ractor` actors to support transmission over a network link and synchronization of actors on networked clusters of actors.


### PR DESCRIPTION
Ractor has a website on github pages which is hosted at 

https://slawlor.github.io/ractor

where general best-practices, quickstarts, and non api-doc information will be hosted