### PR TITLE
Oversight when implementing the named registry lookup wrapper in ActorRef

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/src/actor/actor_cell/actor_ref.rs
+++ b/ractor/src/actor/actor_cell/actor_ref.rs
@@ -111,7 +111,7 @@ where
     pub fn where_is(name: ActorName) -> Option<ActorRef<TActor>> {
         if let Some(actor) = crate::registry::where_is(name) {
             // check the type id when pulling from the registry
-            if actor.inner.type_id == TypeId::of::<TActor>() {
+            if actor.inner.type_id == TypeId::of::<TActor::Msg>() {
                 Some(actor.into())
             } else {
                 None

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -34,6 +34,9 @@ async fn test_basic_registation() {
 
     assert!(crate::registry::where_is("my_actor".to_string()).is_some());
 
+    // Coverage for Issue #70
+    assert!(crate::ActorRef::<EmptyActor>::where_is("my_actor".to_string()).is_some());
+
     actor.stop(None);
     handle.await.expect("Failed to clean stop the actor");
 }

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"
@@ -24,7 +24,7 @@ bytes = { version = "1" }
 log = "0.4"
 prost = { version = "0.11" }
 prost-types = { version = "0.11" }
-ractor = { version = "0.7.4", features = ["cluster"], path = "../ractor" }
+ractor = { version = "0.7.5", features = ["cluster"], path = "../ractor" }
 ractor_cluster_derive = { version = "0.7.4", path = "../ractor_cluster_derive" }
 rand = "0.8"
 rustls = { version = "0.20" }

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION

Tl;dr; we were checking the wrong type id when resolving an actor from the named registry, it should have been the actor's message type not the full actor type itself.

Test coverage added which fails before the fix

```
failures:

---- registry::tests::test_basic_registation stdout ----
thread 'registry::tests::test_basic_registation' panicked at 'assertion failed: crate::ActorRef::<EmptyActor>::where_is(\"my_actor\".to_string()).is_some()', ractor/src/registry/tests.rs:38:5
```

and is resolved with the fix

```
test result: ok. 56 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.71s
```

Resolves #70