### PR TITLE
Address some bugs

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/src/actor/actor_cell/mod.rs
+++ b/ractor/src/actor/actor_cell/mod.rs
@@ -312,12 +312,17 @@ impl ActorCell {
     /// Unlink this [super::Actor] from the supervisor if it's
     /// currently linked (if self's supervisor is `supervisor`)
     ///
-    /// * `supervisor` - The child to unlink this [super::Actor] from
+    /// * `supervisor` - The supervisor to unlink this [super::Actor] from
     pub fn unlink(&self, supervisor: ActorCell) {
         if self.inner.tree.is_child_of(supervisor.get_id()) {
             supervisor.inner.tree.remove_child(self.get_id());
             self.inner.tree.clear_supervisor();
         }
+    }
+
+    /// Clear the supervisor field
+    pub(crate) fn clear_supervisor(&self) {
+        self.inner.tree.clear_supervisor();
     }
 
     /// Kill this [super::Actor] forcefully (terminates async work)

--- a/ractor/src/actor/supervision.rs
+++ b/ractor/src/actor/supervision.rs
@@ -60,11 +60,16 @@ impl SupervisionTree {
         *(self.supervisor.write().unwrap()) = None;
     }
 
-    /// Terminate all your supervised children
+    /// Terminate all your supervised children and unlink them
+    /// from the supervision tree since the supervisor is shutting down
+    /// and can't deal with superivison events anyways
     pub fn terminate_all_children(&self) {
         for kvp in self.children.iter() {
-            kvp.value().1.terminate();
+            let child = &kvp.value().1;
+            child.terminate();
+            child.clear_supervisor();
         }
+        self.children.clear();
     }
 
     /// Terminate the supervised children after a given actor (including the specified actor).

--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -74,7 +74,7 @@ async fn test_supervision_panic_in_post_startup() {
             // check that the panic was captured
             if let SupervisionEvent::ActorPanicked(dead_actor, _panic_msg) = message {
                 self.flag
-                    .store(dead_actor.get_id().get_pid(), Ordering::Relaxed);
+                    .store(dead_actor.get_id().pid(), Ordering::Relaxed);
                 this_actor.stop(None);
             }
             Ok(())
@@ -95,7 +95,7 @@ async fn test_supervision_panic_in_post_startup() {
 
     let (_, _) = tokio::join!(s_handle, c_handle);
 
-    assert_eq!(child_ref.get_id().get_pid(), flag.load(Ordering::Relaxed));
+    assert_eq!(child_ref.get_id().pid(), flag.load(Ordering::Relaxed));
 
     // supervisor relationship cleaned up correctly
     assert_eq!(0, supervisor_ref.get_num_children());
@@ -161,7 +161,7 @@ async fn test_supervision_error_in_post_startup() {
             // check that the panic was captured
             if let SupervisionEvent::ActorPanicked(dead_actor, _panic_msg) = message {
                 self.flag
-                    .store(dead_actor.get_id().get_pid(), Ordering::Relaxed);
+                    .store(dead_actor.get_id().pid(), Ordering::Relaxed);
                 this_actor.stop(None);
             }
             Ok(())
@@ -182,7 +182,7 @@ async fn test_supervision_error_in_post_startup() {
 
     let (_, _) = tokio::join!(s_handle, c_handle);
 
-    assert_eq!(child_ref.get_id().get_pid(), flag.load(Ordering::Relaxed));
+    assert_eq!(child_ref.get_id().pid(), flag.load(Ordering::Relaxed));
 
     // supervisor relationship cleaned up correctly
     assert_eq!(0, supervisor_ref.get_num_children());
@@ -249,7 +249,7 @@ async fn test_supervision_panic_in_handle() {
             // check that the panic was captured
             if let SupervisionEvent::ActorPanicked(dead_actor, _panic_msg) = message {
                 self.flag
-                    .store(dead_actor.get_id().get_pid(), Ordering::Relaxed);
+                    .store(dead_actor.get_id().pid(), Ordering::Relaxed);
                 this_actor.stop(None);
             }
             Ok(())
@@ -278,7 +278,7 @@ async fn test_supervision_panic_in_handle() {
     let _ = s_handle.await;
     let _ = c_handle.await;
 
-    assert_eq!(child_ref.get_id().get_pid(), flag.load(Ordering::Relaxed));
+    assert_eq!(child_ref.get_id().pid(), flag.load(Ordering::Relaxed));
 
     // supervisor relationship cleaned up correctly
     assert_eq!(0, supervisor_ref.get_num_children());
@@ -345,7 +345,7 @@ async fn test_supervision_error_in_handle() {
             // check that the panic was captured
             if let SupervisionEvent::ActorPanicked(dead_actor, _panic_msg) = message {
                 self.flag
-                    .store(dead_actor.get_id().get_pid(), Ordering::Relaxed);
+                    .store(dead_actor.get_id().pid(), Ordering::Relaxed);
                 this_actor.stop(None);
             }
             Ok(())
@@ -374,7 +374,7 @@ async fn test_supervision_error_in_handle() {
     let _ = s_handle.await;
     let _ = c_handle.await;
 
-    assert_eq!(child_ref.get_id().get_pid(), flag.load(Ordering::Relaxed));
+    assert_eq!(child_ref.get_id().pid(), flag.load(Ordering::Relaxed));
 
     // supervisor relationship cleaned up correctly
     assert_eq!(0, supervisor_ref.get_num_children());
@@ -433,7 +433,7 @@ async fn test_supervision_panic_in_post_stop() {
             // check that the panic was captured
             if let SupervisionEvent::ActorPanicked(dead_actor, _panic_msg) = message {
                 self.flag
-                    .store(dead_actor.get_id().get_pid(), Ordering::Relaxed);
+                    .store(dead_actor.get_id().pid(), Ordering::Relaxed);
                 this_actor.stop(None);
             }
 
@@ -454,7 +454,7 @@ async fn test_supervision_panic_in_post_stop() {
     let _ = s_handle.await;
     let _ = c_handle.await;
 
-    assert_eq!(child_ref.get_id().get_pid(), flag.load(Ordering::Relaxed));
+    assert_eq!(child_ref.get_id().pid(), flag.load(Ordering::Relaxed));
 
     // supervisor relationship cleaned up correctly
     assert_eq!(0, supervisor_ref.get_num_children());
@@ -513,7 +513,7 @@ async fn test_supervision_error_in_post_stop() {
             // check that the panic was captured
             if let SupervisionEvent::ActorPanicked(dead_actor, _panic_msg) = message {
                 self.flag
-                    .store(dead_actor.get_id().get_pid(), Ordering::Relaxed);
+                    .store(dead_actor.get_id().pid(), Ordering::Relaxed);
                 this_actor.stop(None);
             }
 
@@ -534,7 +534,7 @@ async fn test_supervision_error_in_post_stop() {
     let _ = s_handle.await;
     let _ = c_handle.await;
 
-    assert_eq!(child_ref.get_id().get_pid(), flag.load(Ordering::Relaxed));
+    assert_eq!(child_ref.get_id().pid(), flag.load(Ordering::Relaxed));
 
     // supervisor relationship cleaned up correctly
     assert_eq!(0, supervisor_ref.get_num_children());
@@ -629,7 +629,7 @@ async fn test_supervision_panic_in_supervisor_handle() {
             // check that the panic was captured
             if let SupervisionEvent::ActorPanicked(dead_actor, _panic_msg) = message {
                 self.flag
-                    .store(dead_actor.get_id().get_pid(), Ordering::Relaxed);
+                    .store(dead_actor.get_id().pid(), Ordering::Relaxed);
                 this_actor.stop(None);
             }
             Ok(())
@@ -673,7 +673,7 @@ async fn test_supervision_panic_in_supervisor_handle() {
 
     // check that we got the midpoint's ref id
     assert_eq!(
-        midpoint_ref_clone.get_id().get_pid(),
+        midpoint_ref_clone.get_id().pid(),
         flag.load(Ordering::Relaxed)
     );
 
@@ -770,7 +770,7 @@ async fn test_supervision_error_in_supervisor_handle() {
             // check that the panic was captured
             if let SupervisionEvent::ActorPanicked(dead_actor, _panic_msg) = message {
                 self.flag
-                    .store(dead_actor.get_id().get_pid(), Ordering::Relaxed);
+                    .store(dead_actor.get_id().pid(), Ordering::Relaxed);
                 this_actor.stop(None);
             }
             Ok(())
@@ -814,7 +814,7 @@ async fn test_supervision_error_in_supervisor_handle() {
 
     // check that we got the midpoint's ref id
     assert_eq!(
-        midpoint_ref_clone.get_id().get_pid(),
+        midpoint_ref_clone.get_id().pid(),
         flag.load(Ordering::Relaxed)
     );
 
@@ -1051,7 +1051,7 @@ async fn test_supervisor_captures_dead_childs_state() {
             {
                 if let Ok(1) = boxed_state.take::<u64>() {
                     self.flag
-                        .store(dead_actor.get_id().get_pid(), Ordering::Relaxed);
+                        .store(dead_actor.get_id().pid(), Ordering::Relaxed);
                     this_actor.stop(None);
                 }
             }
@@ -1079,7 +1079,7 @@ async fn test_supervisor_captures_dead_childs_state() {
 
     let (_, _) = tokio::join!(s_handle, c_handle);
 
-    assert_eq!(child_ref.get_id().get_pid(), flag.load(Ordering::Relaxed));
+    assert_eq!(child_ref.get_id().pid(), flag.load(Ordering::Relaxed));
 
     // supervisor relationship cleaned up correctly
     assert_eq!(0, supervisor_ref.get_num_children());

--- a/ractor/src/actor_id.rs
+++ b/ractor/src/actor_id.rs
@@ -57,29 +57,19 @@ pub(crate) fn get_new_local_id() -> ActorId {
     ActorId::Local(ACTOR_ID_ALLOCATOR.fetch_add(1, std::sync::atomic::Ordering::AcqRel))
 }
 
-impl ActorId {
-    /// Retrieve the PID of the actor, ignoring local/remote properties
-    pub fn get_pid(&self) -> u64 {
-        match self {
-            ActorId::Local(pid) => *pid,
-            ActorId::Remote { pid, .. } => *pid,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_get_pid() {
+    fn test_pid() {
         let actor_id = ActorId::Local(123);
-        assert_eq!(123, actor_id.get_pid());
+        assert_eq!(123, actor_id.pid());
         let actor_id = ActorId::Remote {
             node_id: 1,
             pid: 123,
         };
-        assert_eq!(123, actor_id.get_pid());
+        assert_eq!(123, actor_id.pid());
     }
 
     #[test]

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"
@@ -24,7 +24,7 @@ bytes = { version = "1" }
 log = "0.4"
 prost = { version = "0.11" }
 prost-types = { version = "0.11" }
-ractor = { version = "0.7.5", features = ["cluster"], path = "../ractor" }
+ractor = { version = "0.7.6", features = ["cluster"], path = "../ractor" }
 ractor_cluster_derive = { version = "0.7.4", path = "../ractor_cluster_derive" }
 rand = "0.8"
 rustls = { version = "0.20" }

--- a/ractor_cluster/src/node/node_session/mod.rs
+++ b/ractor_cluster/src/node/node_session/mod.rs
@@ -698,7 +698,7 @@ impl NodeSession {
                 .filter(|v| v.supports_remoting())
                 .map(|act| control_protocol::Actor {
                     name: act.get_name(),
-                    pid: act.get_id().get_pid(),
+                    pid: act.get_id().pid(),
                 })
                 .collect::<Vec<_>>();
             if !local_members.is_empty() {
@@ -953,7 +953,7 @@ impl Actor for NodeSession {
                         msg
                     );
                     myself.stop(Some("tcp_session_err".to_string()));
-                } else if let Some(actor) = state.remote_actors.remove(&actor.get_id().get_pid()) {
+                } else if let Some(actor) = state.remote_actors.remove(&actor.get_id().pid()) {
                     log::warn!(
                         "Node session {:?} had a remote actor ({}) panic with {}",
                         state.name,
@@ -965,7 +965,7 @@ impl Actor for NodeSession {
                     // NOTE: This is a legitimate panic of the `RemoteActor`, not the actor on the remote machine panicking (which
                     // is handled by the remote actor's supervisor). Therefore we should re-spawn the actor, and if we can't we
                     // should ourself die. Something is seriously wrong...
-                    let pid = actor.get_id().get_pid();
+                    let pid = actor.get_id().pid();
                     let name = actor.get_name();
                     let _ = self
                         .get_or_spawn_remote_actor(&myself, name, pid, state)
@@ -983,7 +983,7 @@ impl Actor for NodeSession {
                     log::info!("NodeSession {:?} connection closed", state.name);
                     myself.stop(Some("tcp_session_closed".to_string()));
                     // TODO: resilient connection?
-                } else if let Some(actor) = state.remote_actors.remove(&actor.get_id().get_pid()) {
+                } else if let Some(actor) = state.remote_actors.remove(&actor.get_id().pid()) {
                     log::debug!(
                         "NodeSession {:?} received a child exit with reason '{:?}'",
                         state.name,
@@ -1006,7 +1006,7 @@ impl Actor for NodeSession {
                         .filter(|act| act.supports_remoting())
                         .map(|act| control_protocol::Actor {
                             name: act.get_name(),
-                            pid: act.get_id().get_pid(),
+                            pid: act.get_id().pid(),
                         })
                         .collect::<Vec<_>>();
                     if !filtered.is_empty() {
@@ -1027,7 +1027,7 @@ impl Actor for NodeSession {
                         .filter(|act| act.supports_remoting())
                         .map(|act| control_protocol::Actor {
                             name: act.get_name(),
-                            pid: act.get_id().get_pid(),
+                            pid: act.get_id().pid(),
                         })
                         .collect::<Vec<_>>();
                     if !filtered.is_empty() {
@@ -1050,7 +1050,7 @@ impl Actor for NodeSession {
                             msg: Some(control_protocol::control_message::Msg::Spawn(
                                 control_protocol::Spawn {
                                     actors: vec![control_protocol::Actor {
-                                        pid: who.get_id().get_pid(),
+                                        pid: who.get_id().pid(),
                                         name: who.get_name(),
                                     }],
                                 },
@@ -1064,7 +1064,7 @@ impl Actor for NodeSession {
                         let msg = control_protocol::ControlMessage {
                             msg: Some(control_protocol::control_message::Msg::Terminate(
                                 control_protocol::Terminate {
-                                    ids: vec![who.get_id().get_pid()],
+                                    ids: vec![who.get_id().pid()],
                                 },
                             )),
                         };

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
1. Hold the worker lifecycle handle for the life of the factory and upon factory shutdown wait for workers to exit too. #85
2. Remove the redundant `get_pid()` call on `ActorId` in favor of `pid()`