### PR TITLE
Move ActorRef<Actor> -> ActorRef<Message>

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ impl Actor for PingPong {
     // example)
     async fn pre_start(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         // startup the event processing
@@ -138,7 +138,7 @@ impl Actor for PingPong {
     // This is our main message handler
     async fn handle(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.7.6"
+version = "0.8.0"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/benches/actor.rs
+++ b/ractor/benches/actor.rs
@@ -27,7 +27,7 @@ impl Actor for BenchActor {
 
     async fn pre_start(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         let _ = myself.cast(BenchActorMessage);
@@ -36,7 +36,7 @@ impl Actor for BenchActor {
 
     async fn handle(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         _message: Self::Msg,
         _state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
@@ -162,7 +162,7 @@ fn process_messages(c: &mut Criterion) {
 
         async fn pre_start(
             &self,
-            myself: ActorRef<Self>,
+            myself: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             let _ = myself.cast(BenchActorMessage);
@@ -171,7 +171,7 @@ fn process_messages(c: &mut Criterion) {
 
         async fn handle(
             &self,
-            myself: ActorRef<Self>,
+            myself: ActorRef<Self::Msg>,
             _message: Self::Msg,
             state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {

--- a/ractor/examples/counter.rs
+++ b/ractor/examples/counter.rs
@@ -40,7 +40,7 @@ impl Actor for Counter {
 
     async fn pre_start(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         // create the initial state
@@ -49,7 +49,7 @@ impl Actor for Counter {
 
     async fn handle(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {

--- a/ractor/examples/monte_carlo.rs
+++ b/ractor/examples/monte_carlo.rs
@@ -58,7 +58,7 @@ impl GameState {
 }
 
 struct Game;
-struct GameMessage(ActorRef<GameManager>);
+struct GameMessage(ActorRef<GameManagerMessage>);
 #[cfg(feature = "cluster")]
 impl ractor::Message for GameMessage {}
 
@@ -72,7 +72,7 @@ impl Actor for Game {
 
     async fn pre_start(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         Ok(GameState::default())
@@ -80,7 +80,7 @@ impl Actor for Game {
 
     async fn handle(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
@@ -149,7 +149,7 @@ impl Actor for GameManager {
 
     async fn pre_start(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         num_games: u32,
     ) -> Result<Self::State, ActorProcessingErr> {
         // This is the first code that will run in the actor. It spawns the Game actors,
@@ -173,7 +173,7 @@ impl Actor for GameManager {
 
     async fn handle(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {

--- a/ractor/examples/output_port.rs
+++ b/ractor/examples/output_port.rs
@@ -40,7 +40,7 @@ impl Actor for Publisher {
 
     async fn pre_start(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         port: Arc<OutputPort<Output>>,
     ) -> Result<Self::State, ActorProcessingErr> {
         Ok(port)
@@ -48,7 +48,7 @@ impl Actor for Publisher {
 
     async fn handle(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
@@ -79,7 +79,7 @@ impl Actor for Subscriber {
 
     async fn pre_start(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         Ok(())
@@ -87,7 +87,7 @@ impl Actor for Subscriber {
 
     async fn handle(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         _state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {

--- a/ractor/examples/ping_pong.rs
+++ b/ractor/examples/ping_pong.rs
@@ -51,7 +51,7 @@ impl Actor for PingPong {
 
     async fn pre_start(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         // startup the event processing
@@ -62,7 +62,7 @@ impl Actor for PingPong {
 
     async fn handle(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {

--- a/ractor/examples/supervisor.rs
+++ b/ractor/examples/supervisor.rs
@@ -75,7 +75,7 @@ impl Actor for LeafActor {
     type Arguments = ();
     async fn pre_start(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         Ok(LeafActorState {})
@@ -91,7 +91,7 @@ impl Actor for LeafActor {
 
     async fn handle(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         _state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
@@ -122,11 +122,11 @@ struct MidLevelActor;
 
 #[derive(Clone)]
 struct MidLevelActorState {
-    leaf_actor: ActorRef<LeafActor>,
+    leaf_actor: ActorRef<LeafActorMessage>,
 }
 
 enum MidLevelActorMessage {
-    GetLeaf(RpcReplyPort<ActorRef<LeafActor>>),
+    GetLeaf(RpcReplyPort<ActorRef<LeafActorMessage>>),
 }
 #[cfg(feature = "cluster")]
 impl ractor::Message for MidLevelActorMessage {}
@@ -139,7 +139,7 @@ impl Actor for MidLevelActor {
 
     async fn pre_start(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         let (leaf_actor, _) =
@@ -157,7 +157,7 @@ impl Actor for MidLevelActor {
 
     async fn handle(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
@@ -173,7 +173,7 @@ impl Actor for MidLevelActor {
 
     async fn handle_supervisor_evt(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         message: SupervisionEvent,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
@@ -202,11 +202,11 @@ struct RootActor;
 
 #[derive(Clone)]
 struct RootActorState {
-    mid_level_actor: ActorRef<MidLevelActor>,
+    mid_level_actor: ActorRef<MidLevelActorMessage>,
 }
 
 enum RootActorMessage {
-    GetMidLevel(RpcReplyPort<ActorRef<MidLevelActor>>),
+    GetMidLevel(RpcReplyPort<ActorRef<MidLevelActorMessage>>),
 }
 #[cfg(feature = "cluster")]
 impl ractor::Message for RootActorMessage {}
@@ -219,7 +219,7 @@ impl Actor for RootActor {
 
     async fn pre_start(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         println!("RootActor: Started {myself:?}");
@@ -243,7 +243,7 @@ impl Actor for RootActor {
 
     async fn handle(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
@@ -259,7 +259,7 @@ impl Actor for RootActor {
 
     async fn handle_supervisor_evt(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         message: SupervisionEvent,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {

--- a/ractor/src/actor/actor_cell/actor_properties.rs
+++ b/ractor/src/actor/actor_cell/actor_properties.rs
@@ -111,13 +111,13 @@ impl ActorProperties {
         self.supervision.send(message).map_err(|e| e.into())
     }
 
-    pub fn send_message<TActor>(&self, message: TActor::Msg) -> Result<(), MessagingErr>
+    pub fn send_message<TMessage>(&self, message: TMessage) -> Result<(), MessagingErr>
     where
-        TActor: Actor,
+        TMessage: Message,
     {
         // Only type-check messages of local actors, remote actors send serialized
         // payloads
-        if self.id.is_local() && self.type_id != std::any::TypeId::of::<TActor::Msg>() {
+        if self.id.is_local() && self.type_id != std::any::TypeId::of::<TMessage>() {
             return Err(MessagingErr::InvalidActorType);
         }
 

--- a/ractor/src/actor/actor_cell/mod.rs
+++ b/ractor/src/actor/actor_cell/mod.rs
@@ -20,8 +20,8 @@ use crate::concurrency::{
 use crate::message::BoxedMessage;
 #[cfg(feature = "cluster")]
 use crate::message::SerializedMessage;
-use crate::ActorId;
 use crate::{Actor, ActorName, SpawnErr};
+use crate::{ActorId, Message};
 
 pub mod actor_ref;
 pub use actor_ref::ActorRef;
@@ -359,11 +359,11 @@ impl ActorCell {
     /// * `message` - The message to send
     ///
     /// Returns [Ok(())] on successful message send, [Err(MessagingErr)] otherwise
-    pub fn send_message<TActor>(&self, message: TActor::Msg) -> Result<(), MessagingErr>
+    pub fn send_message<TMessage>(&self, message: TMessage) -> Result<(), MessagingErr>
     where
-        TActor: Actor,
+        TMessage: Message,
     {
-        self.inner.send_message::<TActor>(message)
+        self.inner.send_message::<TMessage>(message)
     }
 
     /// Send a serialized binary message to the actor.
@@ -379,11 +379,8 @@ impl ActorCell {
     /// Notify the supervisors that a supervision event occurred
     ///
     /// * `evt` - The event to send to this [super::Actor]'s supervisors
-    pub fn notify_supervisor<TActor>(&self, evt: SupervisionEvent)
-    where
-        TActor: Actor,
-    {
-        self.inner.tree.notify_supervisor::<TActor>(evt)
+    pub fn notify_supervisor(&self, evt: SupervisionEvent) {
+        self.inner.tree.notify_supervisor(evt)
     }
 
     // ================== Test Utilities ================== //

--- a/ractor/src/actor/supervision.rs
+++ b/ractor/src/actor/supervision.rs
@@ -23,7 +23,7 @@ use std::sync::{
 use dashmap::DashMap;
 
 use super::{actor_cell::ActorCell, messages::SupervisionEvent};
-use crate::{Actor, ActorId};
+use crate::ActorId;
 
 /// A supervision tree
 #[derive(Default)]
@@ -110,10 +110,7 @@ impl SupervisionTree {
     }
 
     /// Send a notification to all supervisors
-    pub fn notify_supervisor<TActor>(&self, evt: SupervisionEvent)
-    where
-        TActor: Actor,
-    {
+    pub fn notify_supervisor(&self, evt: SupervisionEvent) {
         if let Some(parent) = &*(self.supervisor.read().unwrap()) {
             let _ = parent.send_supervisor_evt(evt);
         }

--- a/ractor/src/actor/tests/mod.rs
+++ b/ractor/src/actor/tests/mod.rs
@@ -34,7 +34,7 @@ async fn test_panic_on_start_captured() {
 
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             panic!("Boom!");
@@ -57,7 +57,7 @@ async fn test_error_on_start_captured() {
 
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Err(From::from("boom"))
@@ -84,7 +84,7 @@ async fn test_stop_higher_priority_over_messages() {
 
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -92,7 +92,7 @@ async fn test_stop_higher_priority_over_messages() {
 
         async fn handle(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -158,7 +158,7 @@ async fn test_kill_terminates_work() {
 
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -166,7 +166,7 @@ async fn test_kill_terminates_work() {
 
         async fn handle(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -203,7 +203,7 @@ async fn test_stop_does_not_terminate_async_work() {
 
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -211,7 +211,7 @@ async fn test_stop_does_not_terminate_async_work() {
 
         async fn handle(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -255,7 +255,7 @@ async fn test_kill_terminates_supervision_work() {
 
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -263,7 +263,7 @@ async fn test_kill_terminates_supervision_work() {
 
         async fn handle_supervisor_evt(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _message: SupervisionEvent,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -303,7 +303,7 @@ async fn test_sending_message_to_invalid_actor_type() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -320,7 +320,7 @@ async fn test_sending_message_to_invalid_actor_type() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -337,7 +337,7 @@ async fn test_sending_message_to_invalid_actor_type() {
     // check that actor 2 can't receive a message for actor 1 type
     assert!(actor2
         .get_cell()
-        .send_message::<TestActor1>(TestMessage1)
+        .send_message::<TestMessage1>(TestMessage1)
         .is_err());
 
     actor1.stop(None);
@@ -359,7 +359,7 @@ async fn test_sending_message_to_dead_actor() {
 
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -415,7 +415,7 @@ async fn test_serialized_cast() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -423,7 +423,7 @@ async fn test_serialized_cast() {
 
         async fn handle(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _message: TestMessage,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -542,7 +542,7 @@ async fn test_serialized_rpc() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -550,7 +550,7 @@ async fn test_serialized_rpc() {
 
         async fn handle(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             message: TestMessage,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -613,7 +613,7 @@ async fn test_remote_actor() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -648,7 +648,7 @@ async fn test_remote_actor() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -656,7 +656,7 @@ async fn test_remote_actor() {
 
         async fn handle(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _message: TestRemoteMessage,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -665,7 +665,7 @@ async fn test_remote_actor() {
 
         async fn handle_serialized(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _message: SerializedMessage,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -718,7 +718,7 @@ async fn spawning_local_actor_as_remote_fails() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -733,7 +733,7 @@ async fn spawning_local_actor_as_remote_fails() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -772,7 +772,7 @@ async fn instant_spawns() {
         type Arguments = Arc<AtomicU8>;
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             counter: Arc<AtomicU8>,
         ) -> Result<Self::State, ActorProcessingErr> {
             // delay startup by some amount
@@ -782,7 +782,7 @@ async fn instant_spawns() {
 
         async fn handle(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _message: String,
             state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {

--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -28,14 +28,14 @@ async fn test_supervision_panic_in_post_startup() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn post_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
             panic!("Boom");
@@ -49,14 +49,14 @@ async fn test_supervision_panic_in_post_startup() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -65,7 +65,7 @@ async fn test_supervision_panic_in_post_startup() {
 
         async fn handle_supervisor_evt(
             &self,
-            this_actor: ActorRef<Self>,
+            this_actor: ActorRef<Self::Msg>,
             message: SupervisionEvent,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -115,14 +115,14 @@ async fn test_supervision_error_in_post_startup() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn post_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
             Err(From::from("boom"))
@@ -136,14 +136,14 @@ async fn test_supervision_error_in_post_startup() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -152,7 +152,7 @@ async fn test_supervision_error_in_post_startup() {
 
         async fn handle_supervisor_evt(
             &self,
-            this_actor: ActorRef<Self>,
+            this_actor: ActorRef<Self::Msg>,
             message: SupervisionEvent,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -202,14 +202,14 @@ async fn test_supervision_panic_in_handle() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -224,14 +224,14 @@ async fn test_supervision_panic_in_handle() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -240,7 +240,7 @@ async fn test_supervision_panic_in_handle() {
 
         async fn handle_supervisor_evt(
             &self,
-            this_actor: ActorRef<Self>,
+            this_actor: ActorRef<Self::Msg>,
             message: SupervisionEvent,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -298,14 +298,14 @@ async fn test_supervision_error_in_handle() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -320,14 +320,14 @@ async fn test_supervision_error_in_handle() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -336,7 +336,7 @@ async fn test_supervision_error_in_handle() {
 
         async fn handle_supervisor_evt(
             &self,
-            this_actor: ActorRef<Self>,
+            this_actor: ActorRef<Self::Msg>,
             message: SupervisionEvent,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -394,7 +394,7 @@ async fn test_supervision_panic_in_post_stop() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            myself: ActorRef<Self>,
+            myself: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             // trigger stop, which starts shutdown
@@ -403,7 +403,7 @@ async fn test_supervision_panic_in_post_stop() {
         }
         async fn post_stop(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
             panic!("Boom");
@@ -417,14 +417,14 @@ async fn test_supervision_panic_in_post_stop() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle_supervisor_evt(
             &self,
-            this_actor: ActorRef<Self>,
+            this_actor: ActorRef<Self::Msg>,
             message: SupervisionEvent,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -474,7 +474,7 @@ async fn test_supervision_error_in_post_stop() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            myself: ActorRef<Self>,
+            myself: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             // trigger stop, which starts shutdown
@@ -483,7 +483,7 @@ async fn test_supervision_error_in_post_stop() {
         }
         async fn post_stop(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
             Err(From::from("boom"))
@@ -497,14 +497,14 @@ async fn test_supervision_error_in_post_stop() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle_supervisor_evt(
             &self,
-            this_actor: ActorRef<Self>,
+            this_actor: ActorRef<Self::Msg>,
             message: SupervisionEvent,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -557,14 +557,14 @@ async fn test_supervision_panic_in_supervisor_handle() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -579,14 +579,14 @@ async fn test_supervision_panic_in_supervisor_handle() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle_supervisor_evt(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: SupervisionEvent,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -604,14 +604,14 @@ async fn test_supervision_panic_in_supervisor_handle() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -620,7 +620,7 @@ async fn test_supervision_panic_in_supervisor_handle() {
 
         async fn handle_supervisor_evt(
             &self,
-            this_actor: ActorRef<Self>,
+            this_actor: ActorRef<Self::Msg>,
             message: SupervisionEvent,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -698,14 +698,14 @@ async fn test_supervision_error_in_supervisor_handle() {
         type State = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -720,14 +720,14 @@ async fn test_supervision_error_in_supervisor_handle() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle_supervisor_evt(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: SupervisionEvent,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -745,14 +745,14 @@ async fn test_supervision_error_in_supervisor_handle() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -761,7 +761,7 @@ async fn test_supervision_error_in_supervisor_handle() {
 
         async fn handle_supervisor_evt(
             &self,
-            this_actor: ActorRef<Self>,
+            this_actor: ActorRef<Self::Msg>,
             message: SupervisionEvent,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -834,7 +834,7 @@ async fn test_killing_a_supervisor_terminates_children() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -848,14 +848,14 @@ async fn test_killing_a_supervisor_terminates_children() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -904,13 +904,13 @@ async fn instant_supervised_spawns() {
         type Msg = ();
         type State = ();
         type Arguments = ();
-        async fn pre_start(&self, _: ActorRef<Self>, _: ()) -> Result<(), ActorProcessingErr> {
+        async fn pre_start(&self, _: ActorRef<Self::Msg>, _: ()) -> Result<(), ActorProcessingErr> {
             Ok(())
         }
 
         async fn handle_supervisor_evt(
             &self,
-            _: ActorRef<Self>,
+            _: ActorRef<Self::Msg>,
             _: SupervisionEvent,
             _: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -928,7 +928,7 @@ async fn instant_supervised_spawns() {
         type Arguments = Arc<AtomicU8>;
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             counter: Arc<AtomicU8>,
         ) -> Result<Self::State, ActorProcessingErr> {
             // delay startup by some amount
@@ -938,7 +938,7 @@ async fn instant_supervised_spawns() {
 
         async fn handle(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _message: String,
             state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -998,14 +998,14 @@ async fn test_supervisor_captures_dead_childs_state() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(1)
         }
         async fn post_start(
             &self,
-            myself: ActorRef<Self>,
+            myself: ActorRef<Self::Msg>,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
             myself.stop(None);
@@ -1020,14 +1020,14 @@ async fn test_supervisor_captures_dead_childs_state() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -1036,7 +1036,7 @@ async fn test_supervisor_captures_dead_childs_state() {
 
         async fn handle_supervisor_evt(
             &self,
-            this_actor: ActorRef<Self>,
+            this_actor: ActorRef<Self::Msg>,
             message: SupervisionEvent,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {

--- a/ractor/src/factory/tests.rs
+++ b/ractor/src/factory/tests.rs
@@ -54,11 +54,11 @@ struct TestWorker {
 impl Actor for TestWorker {
     type Msg = super::WorkerMessage<TestKey, TestMessage>;
     type State = Self::Arguments;
-    type Arguments = WorkerStartContext<TestKey, TestMessage, Self>;
+    type Arguments = WorkerStartContext<TestKey, TestMessage>;
 
     async fn pre_start(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         startup_context: Self::Arguments,
     ) -> Result<Self::State, ActorProcessingErr> {
         Ok(startup_context)
@@ -66,7 +66,7 @@ impl Actor for TestWorker {
 
     async fn handle(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
@@ -545,11 +545,11 @@ struct StuckWorker {
 impl Actor for StuckWorker {
     type Msg = super::WorkerMessage<TestKey, TestMessage>;
     type State = Self::Arguments;
-    type Arguments = WorkerStartContext<TestKey, TestMessage, Self>;
+    type Arguments = WorkerStartContext<TestKey, TestMessage>;
 
     async fn pre_start(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         startup_context: Self::Arguments,
     ) -> Result<Self::State, ActorProcessingErr> {
         self.counter.fetch_add(1, Ordering::Relaxed);
@@ -558,7 +558,7 @@ impl Actor for StuckWorker {
 
     async fn handle(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -67,7 +67,7 @@
 //!     // Initially we need to create our state, and potentially
 //!     // start some internal processing (by posting a message for
 //!     // example)
-//!     async fn pre_start(&self, myself: ActorRef<Self>, _: ()) -> Result<Self::State, ActorProcessingErr> {
+//!     async fn pre_start(&self, myself: ActorRef<Self::Msg>, _: ()) -> Result<Self::State, ActorProcessingErr> {
 //!         // startup the event processing
 //!         myself.send_message(Message::Ping).unwrap();
 //!         Ok(0u8)
@@ -76,7 +76,7 @@
 //!     // This is our main message handler
 //!     async fn handle(
 //!         &self,
-//!         myself: ActorRef<Self>,
+//!         myself: ActorRef<Self::Msg>,
 //!         message: Self::Msg,
 //!         state: &mut Self::State,
 //!     ) -> Result<(), ActorProcessingErr> {

--- a/ractor/src/macros.rs
+++ b/ractor/src/macros.rs
@@ -39,13 +39,13 @@ macro_rules! cast {
 ///     type Arguments = ();
 ///     type State = ();
 ///
-///     async fn pre_start(&self, _this_actor: ActorRef<Self>, _: ()) -> Result<Self::State, ActorProcessingErr> {
+///     async fn pre_start(&self, _this_actor: ActorRef<Self::Msg>, _: ()) -> Result<Self::State, ActorProcessingErr> {
 ///         Ok(())
 ///     }
 ///
 ///     async fn handle(
 ///         &self,
-///         _this_actor: ActorRef<Self>,
+///         _this_actor: ActorRef<Self::Msg>,
 ///         message: Self::Msg,
 ///         _state: &mut Self::State,
 ///     ) -> Result<(), ActorProcessingErr> {
@@ -120,13 +120,13 @@ macro_rules! call {
 ///     type Arguments = ();
 ///     type State = ();
 ///
-///     async fn pre_start(&self, _this_actor: ActorRef<Self>, _: ()) -> Result<Self::State, ActorProcessingErr> {
+///     async fn pre_start(&self, _this_actor: ActorRef<Self::Msg>, _: ()) -> Result<Self::State, ActorProcessingErr> {
 ///         Ok(())
 ///     }
 ///
 ///     async fn handle(
 ///         &self,
-///         _this_actor: ActorRef<Self>,
+///         _this_actor: ActorRef<Self::Msg>,
 ///         message: Self::Msg,
 ///         _state: &mut Self::State,
 ///     ) -> Result<(), ActorProcessingErr> {

--- a/ractor/src/message.rs
+++ b/ractor/src/message.rs
@@ -77,7 +77,7 @@ pub struct BoxedMessage {
 ///     PrintName,
 /// }
 /// ```
-pub trait Message: Any + Send + Sized + 'static {
+pub trait Message: Any + Send + Sync + Sized + 'static {
     /// Convert a [BoxedMessage] to this concrete type
     #[cfg(feature = "cluster")]
     fn from_boxed(mut m: BoxedMessage) -> Result<Self, BoxedDowncastErr> {
@@ -168,12 +168,14 @@ pub trait Message: Any + Send + Sized + 'static {
 // Auto-Implement the [Message] trait for all types when NOT in the `cluster` configuration
 // since there's no need for an override
 #[cfg(not(feature = "cluster"))]
-impl<T: Any + Send + Sized + 'static> Message for T {}
+impl<T: Any + Send + Sync + Sized + 'static> Message for T {}
 
 // Blanket implementation for basic types which are directly bytes serializable which
 // are all to be CAST operations
 #[cfg(feature = "cluster")]
-impl<T: Any + Send + Sized + 'static + crate::serialization::BytesConvertable> Message for T {
+impl<T: Any + Send + Sync + Sized + 'static + crate::serialization::BytesConvertable> Message
+    for T
+{
     fn serializable() -> bool {
         true
     }

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -23,7 +23,7 @@ impl Actor for TestActor {
 
     async fn pre_start(
         &self,
-        _this_actor: crate::ActorRef<Self>,
+        _this_actor: crate::ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         Ok(())
@@ -208,7 +208,7 @@ async fn test_pg_monitoring() {
 
         async fn pre_start(
             &self,
-            myself: crate::ActorRef<Self>,
+            myself: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             pg::join(self.pg_group.clone(), vec![myself.into()]);
@@ -229,7 +229,7 @@ async fn test_pg_monitoring() {
 
         async fn pre_start(
             &self,
-            myself: crate::ActorRef<Self>,
+            myself: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             pg::monitor(self.pg_group.clone(), myself.into());
@@ -238,7 +238,7 @@ async fn test_pg_monitoring() {
 
         async fn handle_supervisor_evt(
             &self,
-            _myself: crate::ActorRef<Self>,
+            _myself: crate::ActorRef<Self::Msg>,
             message: SupervisionEvent,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -304,7 +304,7 @@ async fn local_vs_remote_pg_members() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())

--- a/ractor/src/port/output/tests.rs
+++ b/ractor/src/port/output/tests.rs
@@ -30,7 +30,7 @@ async fn test_single_forward() {
 
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(0u8)
@@ -38,7 +38,7 @@ async fn test_single_forward() {
 
         async fn handle(
             &self,
-            myself: ActorRef<Self>,
+            myself: ActorRef<Self::Msg>,
             message: Self::Msg,
             state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -93,7 +93,7 @@ async fn test_50_receivers() {
 
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(0u8)
@@ -101,7 +101,7 @@ async fn test_50_receivers() {
 
         async fn handle(
             &self,
-            myself: ActorRef<Self>,
+            myself: ActorRef<Self::Msg>,
             message: Self::Msg,
             state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -118,7 +118,7 @@ async fn test_50_receivers() {
         }
     }
 
-    let handles: Vec<(ActorRef<TestActor>, JoinHandle<()>)> =
+    let handles: Vec<(ActorRef<TestActorMessage>, JoinHandle<()>)> =
         join_all((0..50).map(|_| async move {
             Actor::spawn(None, TestActor, ())
                 .await

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -21,7 +21,7 @@ async fn test_basic_registation() {
 
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -35,7 +35,7 @@ async fn test_basic_registation() {
     assert!(crate::registry::where_is("my_actor".to_string()).is_some());
 
     // Coverage for Issue #70
-    assert!(crate::ActorRef::<EmptyActor>::where_is("my_actor".to_string()).is_some());
+    assert!(crate::ActorRef::<()>::where_is("my_actor".to_string()).is_some());
 
     actor.stop(None);
     handle.await.expect("Failed to clean stop the actor");
@@ -53,7 +53,7 @@ async fn test_duplicate_registration() {
 
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -100,7 +100,7 @@ async fn test_actor_registry_unenrollment() {
 
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -146,7 +146,7 @@ mod pid_registry_tests {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: crate::ActorRef<Self>,
+            _this_actor: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -163,7 +163,7 @@ mod pid_registry_tests {
             type Arguments = ();
             async fn pre_start(
                 &self,
-                _this_actor: crate::ActorRef<Self>,
+                _this_actor: crate::ActorRef<Self::Msg>,
                 _: (),
             ) -> Result<Self::State, ActorProcessingErr> {
                 Ok(())
@@ -210,7 +210,7 @@ mod pid_registry_tests {
 
             async fn pre_start(
                 &self,
-                _this_actor: crate::ActorRef<Self>,
+                _this_actor: crate::ActorRef<Self::Msg>,
                 _: (),
             ) -> Result<Self::State, ActorProcessingErr> {
                 Ok(())
@@ -243,7 +243,7 @@ mod pid_registry_tests {
 
             async fn pre_start(
                 &self,
-                _this_actor: crate::ActorRef<Self>,
+                _this_actor: crate::ActorRef<Self::Msg>,
                 _: (),
             ) -> Result<Self::State, ActorProcessingErr> {
                 Ok(())
@@ -286,7 +286,7 @@ mod pid_registry_tests {
 
             async fn pre_start(
                 &self,
-                _myself: crate::ActorRef<Self>,
+                _myself: crate::ActorRef<Self::Msg>,
                 _: (),
             ) -> Result<Self::State, ActorProcessingErr> {
                 Ok(())
@@ -305,7 +305,7 @@ mod pid_registry_tests {
 
             async fn pre_start(
                 &self,
-                myself: crate::ActorRef<Self>,
+                myself: crate::ActorRef<Self::Msg>,
                 _: (),
             ) -> Result<Self::State, ActorProcessingErr> {
                 monitor(myself.into());
@@ -314,7 +314,7 @@ mod pid_registry_tests {
 
             async fn handle_supervisor_evt(
                 &self,
-                _myself: crate::ActorRef<Self>,
+                _myself: crate::ActorRef<Self::Msg>,
                 message: SupervisionEvent,
                 _state: &mut Self::State,
             ) -> Result<(), ActorProcessingErr> {

--- a/ractor/src/rpc/tests.rs
+++ b/ractor/src/rpc/tests.rs
@@ -29,7 +29,7 @@ async fn test_rpc_cast() {
 
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -37,7 +37,7 @@ async fn test_rpc_cast() {
 
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -89,7 +89,7 @@ async fn test_rpc_call() {
 
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -97,7 +97,7 @@ async fn test_rpc_call() {
 
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -182,7 +182,7 @@ async fn test_rpc_call_forwarding() {
 
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -190,7 +190,7 @@ async fn test_rpc_call_forwarding() {
 
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -226,7 +226,7 @@ async fn test_rpc_call_forwarding() {
 
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -234,7 +234,7 @@ async fn test_rpc_call_forwarding() {
 
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {

--- a/ractor/src/time/tests.rs
+++ b/ractor/src/time/tests.rs
@@ -29,14 +29,14 @@ async fn test_intervals() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(self.counter.clone())
         }
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -91,14 +91,14 @@ async fn test_send_after() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(self.counter.clone())
         }
         async fn handle(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _message: Self::Msg,
             state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -149,7 +149,7 @@ async fn test_exit_after() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -179,14 +179,14 @@ async fn test_kill_after() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _this_actor: ActorRef<Self>,
+            _this_actor: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
         }
         async fn handle(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _message: Self::Msg,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.7.6"
+version = "0.8.0"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"
@@ -24,8 +24,8 @@ bytes = { version = "1" }
 log = "0.4"
 prost = { version = "0.11" }
 prost-types = { version = "0.11" }
-ractor = { version = "0.7.6", features = ["cluster"], path = "../ractor" }
-ractor_cluster_derive = { version = "0.7.4", path = "../ractor_cluster_derive" }
+ractor = { version = "0.8.0", features = ["cluster"], path = "../ractor" }
+ractor_cluster_derive = { version = "0.8.0", path = "../ractor_cluster_derive" }
 rand = "0.8"
 rustls = { version = "0.20" }
 sha2 = "0.10"

--- a/ractor_cluster/src/net/listener.rs
+++ b/ractor_cluster/src/net/listener.rs
@@ -19,7 +19,7 @@ use crate::node::NodeServerMessage;
 /// connects and disconnects as well as tracking the current open [super::session::Session] actors.
 pub struct Listener {
     port: super::NetworkPort,
-    session_manager: ActorRef<crate::node::NodeServer>,
+    session_manager: ActorRef<crate::node::NodeServerMessage>,
     encryption: IncomingEncryptionMode,
 }
 
@@ -27,7 +27,7 @@ impl Listener {
     /// Create a new `Listener`
     pub fn new(
         port: super::NetworkPort,
-        session_manager: ActorRef<crate::node::NodeServer>,
+        session_manager: ActorRef<crate::node::NodeServerMessage>,
         encryption: IncomingEncryptionMode,
     ) -> Self {
         Self {
@@ -54,7 +54,7 @@ impl Actor for Listener {
 
     async fn pre_start(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         let addr = format!("0.0.0.0:{}", self.port);
@@ -76,7 +76,7 @@ impl Actor for Listener {
 
     async fn post_stop(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
         // close the listener properly, in case anyone else has handles to the actor stopping
@@ -87,7 +87,7 @@ impl Actor for Listener {
 
     async fn handle(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         _message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {

--- a/ractor_cluster/src/node/client.rs
+++ b/ractor_cluster/src/node/client.rs
@@ -59,7 +59,7 @@ impl From<MessagingErr> for ClientConnectErr {
 /// Returns: [Ok(())] if the connection was successful and the [super::NodeSession] was started. Handshake will continue
 /// automatically. Results in a [Err(ClientConnectError)] if any part of the process failed to initiate
 pub async fn connect<T>(
-    node_server: &ActorRef<super::NodeServer>,
+    node_server: &ActorRef<super::NodeServerMessage>,
     address: T,
 ) -> Result<(), ClientConnectErr>
 where
@@ -95,7 +95,7 @@ where
 /// Returns: [Ok(())] if the connection was successful and the [super::NodeSession] was started. Handshake will continue
 /// automatically. Results in a [Err(ClientConnectError)] if any part of the process failed to initiate
 pub async fn connect_enc<T>(
-    node_server: &ActorRef<super::NodeServer>,
+    node_server: &ActorRef<super::NodeServerMessage>,
     address: T,
     encryption_settings: tokio_rustls::TlsConnector,
     domain: rustls::ServerName,

--- a/ractor_cluster/src/node/mod.rs
+++ b/ractor_cluster/src/node/mod.rs
@@ -202,7 +202,7 @@ impl NodeServer {
 #[derive(Clone)]
 pub struct NodeServerSessionInformation {
     /// The NodeSession actor
-    pub actor: ActorRef<NodeSession>,
+    pub actor: ActorRef<NodeSessionMessage>,
     /// This peer's name (if set)
     pub peer_name: Option<auth_protocol::NameMessage>,
     /// Is server-incoming connection
@@ -215,7 +215,7 @@ pub struct NodeServerSessionInformation {
 
 impl NodeServerSessionInformation {
     fn new(
-        actor: ActorRef<NodeSession>,
+        actor: ActorRef<NodeSessionMessage>,
         is_server: bool,
         node_id: NodeId,
         peer_addr: String,
@@ -236,7 +236,7 @@ impl NodeServerSessionInformation {
 
 /// The state of the node server
 pub struct NodeServerState {
-    listener: ActorRef<crate::net::listener::Listener>,
+    listener: ActorRef<crate::net::listener::ListenerMessage>,
     node_sessions: HashMap<ActorId, NodeServerSessionInformation>,
     node_id_counter: NodeId,
     this_node_name: auth_protocol::NameMessage,
@@ -282,7 +282,7 @@ impl Actor for NodeServer {
     type Arguments = ();
     async fn pre_start(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         let listener = crate::net::listener::Listener::new(
@@ -309,7 +309,7 @@ impl Actor for NodeServer {
 
     async fn handle(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
@@ -368,7 +368,7 @@ impl Actor for NodeServer {
 
     async fn handle_supervisor_evt(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         message: SupervisionEvent,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {

--- a/ractor_cluster/src/node/node_session/tests.rs
+++ b/ractor_cluster/src/node/node_session/tests.rs
@@ -13,6 +13,7 @@ use std::sync::{
 use ractor::concurrency::sleep;
 
 use crate::node::NodeConnectionMode;
+use crate::NodeSessionMessage;
 
 use super::*;
 
@@ -24,14 +25,14 @@ impl Actor for DummyNodeServer {
     type Arguments = ();
     async fn pre_start(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         Ok(())
     }
     async fn handle(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         _state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
@@ -63,14 +64,14 @@ impl Actor for DummyNodeSession {
     type Arguments = ();
     async fn pre_start(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         Ok(())
     }
     async fn handle(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         _message: Self::Msg,
         _state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
@@ -87,8 +88,8 @@ async fn node_sesison_client_auth_success() {
         .await
         .expect("Failed to start dummy node session");
 
-    let server_ref: ActorRef<super::NodeServer> = dummy_server.get_cell().into();
-    let session_ref: ActorRef<super::NodeSession> = dummy_session.get_cell().into();
+    let server_ref: ActorRef<super::NodeServerMessage> = dummy_server.get_cell().into();
+    let session_ref: ActorRef<NodeSessionMessage> = dummy_session.get_cell().into();
 
     // Do NOT do what we do here, converting the ActorRef -> ActorCell -> ActorRef on wrong struct but with correct message type. This will work
     // but is very dangerous outside of tests
@@ -231,8 +232,8 @@ async fn node_session_client_auth_session_state_failures() {
         .await
         .expect("Failed to start dummy node session");
 
-    let server_ref: ActorRef<super::NodeServer> = dummy_server.get_cell().into();
-    let session_ref: ActorRef<super::NodeSession> = dummy_session.get_cell().into();
+    let server_ref: ActorRef<super::NodeServerMessage> = dummy_server.get_cell().into();
+    let session_ref: ActorRef<NodeSessionMessage> = dummy_session.get_cell().into();
 
     // Do NOT do what we do here, converting the ActorRef -> ActorCell -> ActorRef on wrong struct but with correct message type. This will work
     // but is very dangerous outside of tests
@@ -359,8 +360,8 @@ async fn node_session_server_auth_success() {
         .await
         .expect("Failed to start dummy node session");
 
-    let server_ref: ActorRef<super::NodeServer> = dummy_server.get_cell().into();
-    let session_ref: ActorRef<super::NodeSession> = dummy_session.get_cell().into();
+    let server_ref: ActorRef<super::NodeServerMessage> = dummy_server.get_cell().into();
+    let session_ref: ActorRef<NodeSessionMessage> = dummy_session.get_cell().into();
 
     // Do NOT do what we do here, converting the ActorRef -> ActorCell -> ActorRef on wrong struct but with correct message type. This will work
     // but is very dangerous outside of tests
@@ -453,8 +454,8 @@ async fn node_session_server_auth_session_state_failures() {
         .await
         .expect("Failed to start dummy node session");
 
-    let server_ref: ActorRef<super::NodeServer> = dummy_server.get_cell().into();
-    let session_ref: ActorRef<super::NodeSession> = dummy_session.get_cell().into();
+    let server_ref: ActorRef<super::NodeServerMessage> = dummy_server.get_cell().into();
+    let session_ref: ActorRef<NodeSessionMessage> = dummy_session.get_cell().into();
 
     // Do NOT do what we do here, converting the ActorRef -> ActorCell -> ActorRef on wrong struct but with correct message type. This will work
     // but is very dangerous outside of tests
@@ -546,7 +547,7 @@ async fn node_session_handle_node_msg() {
         type Arguments = ();
         async fn pre_start(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
             Ok(())
@@ -554,7 +555,7 @@ async fn node_session_handle_node_msg() {
 
         async fn handle_serialized(
             &self,
-            _myself: ActorRef<Self>,
+            _myself: ActorRef<Self::Msg>,
             message: SerializedMessage,
             _state: &mut Self::State,
         ) -> Result<(), ActorProcessingErr> {
@@ -583,8 +584,8 @@ async fn node_session_handle_node_msg() {
         .await
         .expect("Failed to start dummy node session");
 
-    let server_ref: ActorRef<super::NodeServer> = dummy_server.get_cell().into();
-    let session_ref: ActorRef<super::NodeSession> = dummy_session.get_cell().into();
+    let server_ref: ActorRef<super::NodeServerMessage> = dummy_server.get_cell().into();
+    let session_ref: ActorRef<NodeSessionMessage> = dummy_session.get_cell().into();
 
     let test_pid = ActorId::Remote {
         node_id: 1,
@@ -697,8 +698,8 @@ async fn node_session_handle_control() {
         .await
         .expect("Failed to start dummy node session");
 
-    let server_ref: ActorRef<super::NodeServer> = dummy_server.get_cell().into();
-    let session_ref: ActorRef<super::NodeSession> = dummy_session.get_cell().into();
+    let server_ref: ActorRef<super::NodeServerMessage> = dummy_server.get_cell().into();
+    let session_ref: ActorRef<NodeSessionMessage> = dummy_session.get_cell().into();
 
     // Do NOT do what we do here, converting the ActorRef -> ActorCell -> ActorRef on wrong struct but with correct message type. This will work
     // but is very dangerous outside of tests

--- a/ractor_cluster/src/remote_actor/tests.rs
+++ b/ractor_cluster/src/remote_actor/tests.rs
@@ -8,7 +8,7 @@ use super::*;
 struct FakeNodeSession;
 
 impl FakeNodeSession {
-    async fn get_node_session() -> (ActorRef<crate::node::NodeSession>, JoinHandle<()>) {
+    async fn get_node_session() -> (ActorRef<crate::node::NodeSessionMessage>, JoinHandle<()>) {
         let (r, h) = Actor::spawn(None, FakeNodeSession, ())
             .await
             .expect("Failed to start fake node session");
@@ -24,7 +24,7 @@ impl Actor for FakeNodeSession {
     type Arguments = ();
     async fn pre_start(
         &self,
-        _: ActorRef<Self>,
+        _: ActorRef<Self::Msg>,
         _: Self::Arguments,
     ) -> Result<Self::State, ActorProcessingErr> {
         Ok(())

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.7.6"
+version = "0.8.0"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"

--- a/ractor_cluster_integration_tests/src/tests/pg_groups.rs
+++ b/ractor_cluster_integration_tests/src/tests/pg_groups.rs
@@ -45,7 +45,7 @@ impl Actor for PingPongActor {
 
     async fn pre_start(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         ractor::pg::join("test".to_string(), vec![myself.get_cell()]);
@@ -57,7 +57,7 @@ impl Actor for PingPongActor {
 
     async fn handle(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
@@ -65,7 +65,7 @@ impl Actor for PingPongActor {
         let remote_actors = ractor::pg::get_members(&group)
             .into_iter()
             .filter(|actor| !actor.get_id().is_local())
-            .map(ActorRef::<Self>::from)
+            .map(ActorRef::<Self::Msg>::from)
             .collect::<Vec<_>>();
         match message {
             Self::Msg::Ping => {

--- a/ractor_playground/src/distributed.rs
+++ b/ractor_playground/src/distributed.rs
@@ -84,7 +84,7 @@ impl Actor for PingPongActor {
 
     async fn pre_start(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         ractor::pg::join("test".to_string(), vec![myself.get_cell()]);
@@ -93,7 +93,7 @@ impl Actor for PingPongActor {
 
     async fn handle(
         &self,
-        _myself: ActorRef<Self>,
+        _myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         _state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
@@ -101,7 +101,7 @@ impl Actor for PingPongActor {
         let remote_actors = ractor::pg::get_members(&group)
             .into_iter()
             .filter(|actor| !actor.get_id().is_local())
-            .map(ActorRef::<Self>::from)
+            .map(ActorRef::<Self::Msg>::from)
             .collect::<Vec<_>>();
         match message {
             Self::Msg::Ping => {

--- a/ractor_playground/src/ping_pong.rs
+++ b/ractor_playground/src/ping_pong.rs
@@ -40,7 +40,7 @@ impl Actor for PingPong {
 
     async fn pre_start(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         println!("pre_start called");
@@ -52,7 +52,7 @@ impl Actor for PingPong {
 
     async fn post_start(
         &self,
-        _this_actor: ActorRef<Self>,
+        _this_actor: ActorRef<Self::Msg>,
         _state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
         println!("post_start called");
@@ -62,7 +62,7 @@ impl Actor for PingPong {
     /// Invoked after an actor has been stopped.
     async fn post_stop(
         &self,
-        _this_actor: ActorRef<Self>,
+        _this_actor: ActorRef<Self::Msg>,
         _state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
         println!("post_stop called");
@@ -71,7 +71,7 @@ impl Actor for PingPong {
 
     async fn handle(
         &self,
-        myself: ActorRef<Self>,
+        myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {


### PR DESCRIPTION
This is an RFC PR, because it's a relatively major breaking change on the API, however prevents leaking a lot of other types where only the message type is necessary.

CC: @jsgf