### PR TITLE
Add support for "stop and wait" and "kill and wait"

### DIFF
--- a/ractor/src/actor/mod.rs
+++ b/ractor/src/actor/mod.rs
@@ -477,13 +477,13 @@ where
             // notify supervisors of the actor's death
             myself.notify_supervisor(evt);
 
-            // set status to stopped
-            myself.set_status(ActorStatus::Stopped);
-
             // unlink superisors
             if let Some(sup) = supervisor {
                 myself.unlink(sup);
             }
+
+            // set status to stopped
+            myself.set_status(ActorStatus::Stopped);
         });
 
         Ok((myself_ret, handle))

--- a/ractor/src/concurrency.rs
+++ b/ractor/src/concurrency.rs
@@ -24,6 +24,11 @@ pub type MpscUnboundedSender<T> = tokio::sync::mpsc::UnboundedSender<T>;
 /// A bounded MP;SC receiver
 pub type MpscUnboundedReceiver<T> = tokio::sync::mpsc::UnboundedReceiver<T>;
 
+/// A bounded broadcast sender
+pub type BroadcastSender<T> = tokio::sync::broadcast::Sender<T>;
+/// A bounded broadcast receiver
+pub type BroadcastReceiver<T> = tokio::sync::broadcast::Receiver<T>;
+
 /// MPSC bounded channel
 pub fn mpsc_bounded<T>(buffer: usize) -> (MpscSender<T>, MpscReceiver<T>) {
     tokio::sync::mpsc::channel(buffer)
@@ -37,6 +42,11 @@ pub fn mpsc_unbounded<T>() -> (MpscUnboundedSender<T>, MpscUnboundedReceiver<T>)
 /// Oneshot channel
 pub fn oneshot<T>() -> (OneshotSender<T>, OneshotReceiver<T>) {
     tokio::sync::oneshot::channel()
+}
+
+/// Broadcast channel
+pub fn broadcast<T: Clone>(buffer: usize) -> (BroadcastSender<T>, BroadcastReceiver<T>) {
+    tokio::sync::broadcast::channel(buffer)
 }
 
 // =============== TOKIO =============== //

--- a/ractor_cluster/src/node/node_session/tests.rs
+++ b/ractor_cluster/src/node/node_session/tests.rs
@@ -741,7 +741,8 @@ async fn node_session_handle_control() {
             },
             session_ref.clone(),
         )
-        .await;
+        .await
+        .expect("Failed to process control message");
     assert_eq!(1, state.remote_actors.len());
 
     // check terminate cleans up a remote actor
@@ -755,7 +756,8 @@ async fn node_session_handle_control() {
             },
             session_ref.clone(),
         )
-        .await;
+        .await
+        .expect("Failed to process control message");
     assert_eq!(0, state.remote_actors.len());
 
     let group_name = "node_session_handle_control";
@@ -777,7 +779,8 @@ async fn node_session_handle_control() {
             },
             session_ref.clone(),
         )
-        .await;
+        .await
+        .expect("Failed to process control message");
     assert_eq!(1, state.remote_actors.len());
     let id_set = ractor::pg::get_members(&group_name.to_string())
         .into_iter()
@@ -805,7 +808,8 @@ async fn node_session_handle_control() {
             },
             session_ref.clone(),
         )
-        .await;
+        .await
+        .expect("Failed to process control message");
     assert_eq!(1, state.remote_actors.len());
     let id_set = ractor::pg::get_members(&group_name.to_string())
         .into_iter()
@@ -826,7 +830,8 @@ async fn node_session_handle_control() {
             },
             session_ref.clone(),
         )
-        .await;
+        .await
+        .expect("Failed to process control message");
 
     // TODO: ping? for healthchecks
 


### PR DESCRIPTION
This change adds support for stopping or killing an actor while waiting for the shutdown routine to complete. This is often useful to be assured an actor's shutdown routine has completed before trying to

1. respawn the same actor (potential name clashes/etc)
2. Exiting the process, which may "leak" memory if a thread is still alive without first waiting for proper actor shutdown.

This is often easier than waiting on the `JoinHandle` which is needed to be threaded and shutdown may not be executed by the same process which created/spawned the actor and recorded the `JoinHandle`.

Ideally the `JoinHandle`s wouldn't be necessary, and for ergonomics this would be enough.

Requires that #89 merge first and this be rebased on top of it (should only be last commit).

TODO: 
* [x] Tests still need to be added
* [x] Address #93 by waiting on actor shutdown which should remove the the races around duplicate registrations in the named registries CC @calebfletcher