### PR TITLE
Capturing send errors better

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Install `ractor` by adding the following to your Cargo.toml dependencies.
 
 ```toml
 [dependencies]
-ractor = "0.7"
+ractor = "0.8"
 ```
 
 ## Features

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/src/actor/actor_cell/actor_ref.rs
+++ b/ractor/src/actor/actor_cell/actor_ref.rs
@@ -90,7 +90,7 @@ where
     /// * `message` - The message to send
     ///
     /// Returns [Ok(())] on successful message send, [Err(MessagingErr)] otherwise
-    pub fn send_message(&self, message: TMessage) -> Result<(), MessagingErr> {
+    pub fn send_message(&self, message: TMessage) -> Result<(), MessagingErr<TMessage>> {
         self.inner.send_message::<TMessage>(message)
     }
 

--- a/ractor/src/actor/actor_cell/actor_ref.rs
+++ b/ractor/src/actor/actor_cell/actor_ref.rs
@@ -14,7 +14,10 @@ use super::ActorCell;
 
 /// An [ActorRef] is a strongly-typed wrapper over an [ActorCell]
 /// to provide some syntactic wrapping on the requirement to pass
-/// the actor type everywhere
+/// the actor's message type everywhere.
+///
+/// An [ActorRef] is the primary means of communication typically used
+/// when interfacing with [super::Actor]s
 pub struct ActorRef<TMessage>
 where
     TMessage: Message,

--- a/ractor/src/actor/actor_cell/mod.rs
+++ b/ractor/src/actor/actor_cell/mod.rs
@@ -30,7 +30,7 @@ pub use actor_ref::ActorRef;
 mod actor_properties;
 use actor_properties::ActorProperties;
 
-/// [ActorStatus] represents the status of an actor
+/// [ActorStatus] represents the status of an actor's lifecycle
 #[derive(Debug, Clone, Eq, PartialEq, Copy)]
 #[repr(u8)]
 pub enum ActorStatus {
@@ -150,8 +150,12 @@ impl ActorPortSet {
     }
 }
 
-/// A handy-dandy reference to and actor and their inner properties
-/// which can be cloned and passed around
+/// An [ActorCell] is a reference to an [Actor]'s communication channels
+/// and provides external access to send messages, stop, kill, and generally
+/// interactor with the underlying [Actor] process.
+///
+/// The input ports contained in the cell will return an error should the
+/// underlying actor have terminated and no longer exist.
 #[derive(Clone)]
 pub struct ActorCell {
     inner: Arc<ActorProperties>,
@@ -307,7 +311,7 @@ impl ActorCell {
 
     /// Link this [super::Actor] to the provided supervisor
     ///
-    /// * `supervisor` - The child to link this [super::Actor] to
+    /// * `supervisor` - The supervisor [super::Actor] of this actor
     pub fn link(&self, supervisor: ActorCell) {
         supervisor.inner.tree.insert_child(self.clone());
         self.inner.tree.set_supervisor(supervisor);

--- a/ractor/src/actor/errors.rs
+++ b/ractor/src/actor/errors.rs
@@ -92,10 +92,11 @@ pub enum MessagingErr<T> {
     /// If you're sending to an [crate::ActorCell] then that means the actor has died
     /// (failure or not).
     ///
-    /// Includes the message which failed to send
+    /// Includes the message which failed to send so the caller can perform another operation
+    /// with the message if they want to.
     SendErr(T),
 
-    /// The channel you're trying to receive from has had all the senders dropped likely
+    /// The channel you're trying to receive from has had all the senders dropped
     /// and is therefore closed
     ChannelClosed,
 

--- a/ractor/src/actor/mod.rs
+++ b/ractor/src/actor/mod.rs
@@ -612,6 +612,10 @@ where
                 // not possible. Treat like a channel closed
                 Ok((true, None))
             }
+            Err(MessagingErr::SendErr(_)) => {
+                // not possible. Treat like a channel closed
+                Ok((true, None))
+            }
         }
     }
 

--- a/ractor/src/actor/mod.rs
+++ b/ractor/src/actor/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! They are:
 //! [Actor]: The behavior definition for an actor's internal processing logic + state management
-//! [Actor]: Management structure processing the message handler, signals, and supervision events in a loop
+//! [ActorRuntime]: Management structure processing the message handler, signals, and supervision events in a loop
 
 use std::panic::AssertUnwindSafe;
 
@@ -22,7 +22,7 @@ use messages::*;
 
 pub mod actor_cell;
 pub mod errors;
-pub mod supervision;
+mod supervision;
 
 #[cfg(test)]
 mod tests;
@@ -224,8 +224,11 @@ pub trait Actor: Sized + Sync + Send + 'static {
     }
 }
 
-/// [ActorRuntime] is a struct which represents the actor. This struct is consumed by the
-/// `start` operation, but results in an [ActorRef] to communicate and operate with
+/// [ActorRuntime] is a struct which represents the processing actor.
+///
+///  This struct is consumed by the `start` operation, but results in an
+/// [ActorRef] to communicate and operate with along with the [JoinHandle]
+/// representing the actor's async processing loop.
 pub struct ActorRuntime<TActor>
 where
     TActor: Actor,

--- a/ractor/src/actor/supervision.rs
+++ b/ractor/src/actor/supervision.rs
@@ -72,34 +72,6 @@ impl SupervisionTree {
         self.children.clear();
     }
 
-    /// Terminate the supervised children after a given actor (including the specified actor).
-    /// This is necessary to support [Erlang's supervision model](https://www.erlang.org/doc/design_principles/sup_princ.html#flags),
-    /// specifically the `rest_for_one` strategy
-    ///
-    /// * `id` - The id of the actor to terminate + all those that follow
-    pub fn terminate_children_after(&self, id: ActorId) {
-        let mut reference_point = u64::MAX;
-        let mut id_map = std::collections::HashMap::new();
-
-        // keep the lock inside this scope on the map
-        {
-            for item in self.children.iter_mut() {
-                id_map.insert(item.value().0, *item.key());
-                if item.value().1.get_id() == id {
-                    reference_point = item.value().0;
-                    break;
-                }
-            }
-        }
-
-        // if there was a reference point, terminate children from that point on
-        if reference_point < u64::MAX {
-            for child in self.children.iter() {
-                child.1.terminate();
-            }
-        }
-    }
-
     /// Determine if the specified actor is a parent of this actor
     pub fn is_child_of(&self, id: ActorId) -> bool {
         if let Some(parent) = &*(self.supervisor.read().unwrap()) {

--- a/ractor/src/actor_id.rs
+++ b/ractor/src/actor_id.rs
@@ -4,7 +4,7 @@
 // LICENSE-MIT file in the root directory of this source tree.
 
 //! This module handles everything around actor id's. In the event you have a
-//! remote actor, this id will demonstrate that
+//! remote actor, this id will denote that
 
 use std::{fmt::Display, sync::atomic::AtomicU64};
 

--- a/ractor/src/factory/job.rs
+++ b/ractor/src/factory/job.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree.
 
-//! Specification for a job sent to a factory
+//! Specification for a [Job] sent to a factory
 
 use std::fmt::Debug;
 use std::{hash::Hash, time::SystemTime};
@@ -100,6 +100,10 @@ impl BytesConvertable for JobOptions {
 }
 
 /// Represents a job sent to a factory
+///
+/// Depending on the [super::Factory]'s routing scheme the
+/// [Job]'s `key` is utilized to dispatch the job to specific
+/// workers.
 pub struct Job<TKey, TMsg>
 where
     TKey: JobKey,
@@ -109,7 +113,8 @@ where
     pub key: TKey,
     /// The message of the job
     pub msg: TMsg,
-    /// The options of the job
+    /// The job's options, mainly related to timing
+    /// information of the job
     pub options: JobOptions,
 }
 

--- a/ractor/src/factory/worker.rs
+++ b/ractor/src/factory/worker.rs
@@ -192,7 +192,10 @@ where
 
     /// Enqueue a new job to this worker. If the discard threshold has been exceeded
     /// it will discard the oldest elements from the message queue
-    pub(crate) fn enqueue_job(&mut self, mut job: Job<TKey, TMsg>) -> Result<(), MessagingErr> {
+    pub(crate) fn enqueue_job(
+        &mut self,
+        mut job: Job<TKey, TMsg>,
+    ) -> Result<(), MessagingErr<WorkerMessage<TKey, TMsg>>> {
         // track per-job statistics
         self.stats.job_submitted();
 
@@ -223,7 +226,9 @@ where
     }
 
     /// Send a ping to the worker
-    pub(crate) fn send_factory_ping(&mut self) -> Result<(), MessagingErr> {
+    pub(crate) fn send_factory_ping(
+        &mut self,
+    ) -> Result<(), MessagingErr<WorkerMessage<TKey, TMsg>>> {
         if !self.is_ping_pending {
             self.is_ping_pending = true;
             self.actor.cast(WorkerMessage::FactoryPing(Instant::now()))
@@ -246,7 +251,7 @@ where
     pub(crate) fn worker_complete(
         &mut self,
         key: TKey,
-    ) -> Result<Option<JobOptions>, MessagingErr> {
+    ) -> Result<Option<JobOptions>, MessagingErr<WorkerMessage<TKey, TMsg>>> {
         // remove this pending job
         let options = self.curr_jobs.remove(&key);
         // maybe queue up the next job

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ractor = "0.7"
+//! ractor = "0.8"
 //! ```
 //!
 //! ## Getting started
@@ -109,12 +109,13 @@
 //! ## Supervision
 //!
 //! Actors in `ractor` also support supervision. This is done by "linking" actors together in a supervisor-child relationship.
-//! A supervisor is "responsible" for the child actor, and as such is notified when the actor starts, stops, and fails (panics).
+//! A supervisor is responsible for the life cycle of the child actor, and as such is notified when the actor starts,
+//! stops, and fails (panics).
 //!
-//! Supervision is presently left to the implementor, but you can see a suite of supervision tests in `crate::actor::tests::supervisor`
-//! for examples on the supported functionality.
+//! Supervision is presently left to the implementor to outline handling of supervision events, but you can see a suite of
+//! supervision tests in `crate::actor::tests::supervisor` for examples on the supported functionality.
 //!
-//! NOTE: panic's in `pre_start` of an actor will cause failures to spawn, rather than supervision notified failurs as the actor hasn't "linked"
+//! NOTE: panic's in `pre_start` of an actor will cause failures to spawn, rather than supervision notified failures as the actor hasn't "linked"
 //! to its supervisor yet. However failures in `post_start`, `handle`, `handle_supervisor_evt`, `post_stop` will notify the supervisor should a failure
 //! occur. See [crate::Actor] documentation for more information
 //!

--- a/ractor/src/macros.rs
+++ b/ractor/src/macros.rs
@@ -204,7 +204,9 @@ macro_rules! forward {
                     )),
                 }
             }
-            Err(e) => Err(e),
+            Err(_) => Err($crate::RactorErr::Messaging(
+                $crate::MessagingErr::ChannelClosed,
+            )),
         }
     }};
     ($actor:expr, $msg:expr, $forward:ident, $forward_mapping:expr, $timeout:expr) => {{
@@ -223,7 +225,9 @@ macro_rules! forward {
                     )),
                 }
             }
-            Err(e) => Err(e),
+            Err(_) => Err($crate::RactorErr::Messaging(
+                $crate::MessagingErr::ChannelClosed,
+            )),
         }
     }};
 }

--- a/ractor/src/port/mod.rs
+++ b/ractor/src/port/mod.rs
@@ -41,8 +41,8 @@ impl<TMsg> RpcReplyPort<TMsg> {
     /// * `msg` - The message to send
     ///
     /// Returns [Ok(())] if the message send was successful, [Err(MessagingErr)] otherwise
-    pub fn send(self, msg: TMsg) -> Result<(), MessagingErr> {
-        self.port.send(msg).map_err(|_| MessagingErr::ChannelClosed)
+    pub fn send(self, msg: TMsg) -> Result<(), MessagingErr<TMsg>> {
+        self.port.send(msg).map_err(|t| MessagingErr::SendErr(t))
     }
 
     /// Determine if the port is closed (i.e. the receiver has been dropped)

--- a/ractor/src/rpc/mod.rs
+++ b/ractor/src/rpc/mod.rs
@@ -26,7 +26,7 @@ mod tests;
 /// * `msg` - The message to send to the actor
 ///
 /// Returns [Ok(())] upon successful send, [Err(MessagingErr)] otherwise
-pub fn cast<TMessage>(actor: &ActorCell, msg: TMessage) -> Result<(), MessagingErr>
+pub fn cast<TMessage>(actor: &ActorCell, msg: TMessage) -> Result<(), MessagingErr<TMessage>>
 where
     TMessage: Message,
 {
@@ -47,7 +47,7 @@ pub async fn call<TMessage, TReply, TMsgBuilder>(
     actor: &ActorCell,
     msg_builder: TMsgBuilder,
     timeout_option: Option<Duration>,
-) -> Result<CallResult<TReply>, MessagingErr>
+) -> Result<CallResult<TReply>, MessagingErr<TMessage>>
 where
     TMessage: Message,
     TMsgBuilder: FnOnce(RpcReplyPort<TReply>) -> TMessage,
@@ -89,7 +89,7 @@ pub async fn multi_call<TMessage, TReply, TMsgBuilder>(
     actors: &[ActorCell],
     msg_builder: TMsgBuilder,
     timeout_option: Option<Duration>,
-) -> Result<Vec<CallResult<TReply>>, MessagingErr>
+) -> Result<Vec<CallResult<TReply>>, MessagingErr<TMessage>>
 where
     TMessage: Message,
     TReply: Send + 'static,
@@ -161,13 +161,14 @@ where
 ///
 /// Returns: A [JoinHandle<CallResult<()>>] which can be awaited to see if the
 /// forward was successful or ignored
+#[allow(clippy::type_complexity)]
 pub fn call_and_forward<TMessage, TForwardMessage, TReply, TMsgBuilder, FwdMapFn>(
     actor: &ActorCell,
     msg_builder: TMsgBuilder,
     response_forward: ActorCell,
     forward_mapping: FwdMapFn,
     timeout_option: Option<Duration>,
-) -> Result<JoinHandle<CallResult<Result<(), MessagingErr>>>, MessagingErr>
+) -> Result<JoinHandle<CallResult<Result<(), MessagingErr<TForwardMessage>>>>, MessagingErr<TMessage>>
 where
     TMessage: Message,
     TReply: Send + 'static,
@@ -205,7 +206,7 @@ where
     TMessage: Message,
 {
     /// Alias of [cast]
-    pub fn cast(&self, msg: TMessage) -> Result<(), MessagingErr> {
+    pub fn cast(&self, msg: TMessage) -> Result<(), MessagingErr<TMessage>> {
         cast::<TMessage>(&self.inner, msg)
     }
 
@@ -214,7 +215,7 @@ where
         &self,
         msg_builder: TMsgBuilder,
         timeout_option: Option<Duration>,
-    ) -> Result<CallResult<TReply>, MessagingErr>
+    ) -> Result<CallResult<TReply>, MessagingErr<TMessage>>
     where
         TMsgBuilder: FnOnce(RpcReplyPort<TReply>) -> TMessage,
     {
@@ -222,13 +223,17 @@ where
     }
 
     /// Alias of [call_and_forward]
+    #[allow(clippy::type_complexity)]
     pub fn call_and_forward<TReply, TForwardMessage, TMsgBuilder, TFwdMessageBuilder>(
         &self,
         msg_builder: TMsgBuilder,
         response_forward: &ActorRef<TForwardMessage>,
         forward_mapping: TFwdMessageBuilder,
         timeout_option: Option<Duration>,
-    ) -> Result<crate::concurrency::JoinHandle<CallResult<Result<(), MessagingErr>>>, MessagingErr>
+    ) -> Result<
+        crate::concurrency::JoinHandle<CallResult<Result<(), MessagingErr<TForwardMessage>>>>,
+        MessagingErr<TMessage>,
+    >
     where
         TReply: Send + 'static,
         TMsgBuilder: FnOnce(RpcReplyPort<TReply>) -> TMessage,

--- a/ractor/src/rpc/mod.rs
+++ b/ractor/src/rpc/mod.rs
@@ -5,7 +5,7 @@
 
 //! Remote procedure calls (RPC) are helpful communication primitives to communicate with actors
 //!
-//! There are generally 2 kinds of RPCs, cast and call, and their definition comes from the
+//! There are generally 2 kinds of RPCs, `cast` and `call`, and their definition comes from the
 //! standard [Erlang `gen_server`](https://www.erlang.org/doc/man/gen_server.html#cast-2).
 //! The tl;dr is that `cast` is an send without waiting on a reply while `call` is expecting
 //! a reply from the actor being communicated with.

--- a/ractor/src/rpc/tests.rs
+++ b/ractor/src/rpc/tests.rs
@@ -10,7 +10,8 @@ use std::sync::Arc;
 
 use crate::concurrency::Duration;
 
-use crate::{call, call_t, cast, forward, Actor, ActorRef};
+use crate::{call, call_t};
+use crate::{cast, forward, Actor, ActorRef};
 use crate::{rpc, ActorProcessingErr};
 
 #[crate::concurrency::test]

--- a/ractor/src/tests.rs
+++ b/ractor/src/tests.rs
@@ -10,25 +10,25 @@ use crate::RactorErr;
 #[test]
 fn test_error_conversions() {
     let spawn = crate::SpawnErr::StartupCancelled;
-    let ractor_err = RactorErr::from(crate::SpawnErr::StartupCancelled);
+    let ractor_err = RactorErr::<()>::from(crate::SpawnErr::StartupCancelled);
     assert_eq!(spawn.to_string(), ractor_err.to_string());
 
-    let messaging = crate::MessagingErr::InvalidActorType;
-    let ractor_err = RactorErr::from(crate::MessagingErr::InvalidActorType);
+    let messaging = crate::MessagingErr::<()>::InvalidActorType;
+    let ractor_err = RactorErr::<()>::from(crate::MessagingErr::InvalidActorType);
     assert_eq!(messaging.to_string(), ractor_err.to_string());
 
     let actor = crate::ActorErr::Cancelled;
-    let ractor_err = RactorErr::from(crate::ActorErr::Cancelled);
+    let ractor_err = RactorErr::<()>::from(crate::ActorErr::Cancelled);
     assert_eq!(actor.to_string(), ractor_err.to_string());
 
     let call_result = crate::rpc::CallResult::<()>::Timeout;
-    let other = format!("{:?}", RactorErr::from(call_result));
+    let other = format!("{:?}", RactorErr::<()>::from(call_result));
     assert_eq!("Timeout".to_string(), other);
 
     let call_result = crate::rpc::CallResult::<()>::SenderError;
-    let other = format!("{}", RactorErr::from(call_result));
+    let other = format!("{}", RactorErr::<()>::from(call_result));
     assert_eq!(
-        RactorErr::from(crate::MessagingErr::ChannelClosed).to_string(),
+        RactorErr::<()>::from(crate::MessagingErr::ChannelClosed).to_string(),
         other
     );
 }

--- a/ractor/src/time/mod.rs
+++ b/ractor/src/time/mod.rs
@@ -75,7 +75,7 @@ pub fn send_after<TMessage, F>(
     period: Duration,
     actor: ActorCell,
     msg: F,
-) -> JoinHandle<Result<(), MessagingErr>>
+) -> JoinHandle<Result<(), MessagingErr<TMessage>>>
 where
     TMessage: Message,
     F: Fn() -> TMessage + Send + 'static,
@@ -129,7 +129,11 @@ where
     }
 
     /// Alias of [send_after]
-    pub fn send_after<F>(&self, period: Duration, msg: F) -> JoinHandle<Result<(), MessagingErr>>
+    pub fn send_after<F>(
+        &self,
+        period: Duration,
+        msg: F,
+    ) -> JoinHandle<Result<(), MessagingErr<TMessage>>>
     where
         F: Fn() -> TMessage + Send + 'static,
     {

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"
@@ -24,7 +24,7 @@ bytes = { version = "1" }
 log = "0.4"
 prost = { version = "0.11" }
 prost-types = { version = "0.11" }
-ractor = { version = "0.8.0", features = ["cluster"], path = "../ractor" }
+ractor = { version = "0.8.1", features = ["cluster"], path = "../ractor" }
 ractor_cluster_derive = { version = "0.8.0", path = "../ractor_cluster_derive" }
 rand = "0.8"
 rustls = { version = "0.20" }

--- a/ractor_cluster/README.md
+++ b/ractor_cluster/README.md
@@ -27,8 +27,8 @@ Install `ractor_cluster` by adding the following to your Cargo.toml dependencies
 
 ```toml
 [dependencies]
-ractor = { version = "0.7", features = ["cluster"] }
-ractor_cluster = "0.7"
+ractor = { version = "0.8", features = ["cluster"] }
+ractor_cluster = "0.8"
 ```
 
 ## Ractor in distribucted clusters

--- a/ractor_cluster/src/node/client.rs
+++ b/ractor_cluster/src/node/client.rs
@@ -18,7 +18,7 @@ pub enum ClientConnectErr {
     Socket(tokio::io::Error),
     /// Error communicating to the [super::NodeServer] actor. Actor receiving port is
     /// closed
-    Messaging(MessagingErr),
+    Messaging(MessagingErr<super::NodeServerMessage>),
     /// Some error with encryption has occurred
     Encryption(tokio::io::Error),
 }
@@ -45,8 +45,8 @@ impl From<tokio::io::Error> for ClientConnectErr {
     }
 }
 
-impl From<MessagingErr> for ClientConnectErr {
-    fn from(value: MessagingErr) -> Self {
+impl From<MessagingErr<super::NodeServerMessage>> for ClientConnectErr {
+    fn from(value: MessagingErr<super::NodeServerMessage>) -> Self {
         Self::Messaging(value)
     }
 }

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
This PR makes it that send errors don't swallow the error up if they can't send a message to an actor, they will return the message which was unable to be sent in order to facilitate retries/cleaner error handling/etc.