### PR TITLE
Adding a helper extraction method to RactorErr to quickly extract the message, if present

### DIFF
--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -199,6 +199,29 @@ pub enum RactorErr<T> {
     Timeout,
 }
 
+impl<T> RactorErr<T> {
+    /// Identify if the error has a message payload contained. If [true],
+    /// You can utilize `try_get_message` to consume the error and extract the message payload
+    /// quickly.
+    ///
+    /// Returns [true] if the error contains a message payload of type `T`, [false] otherwise.
+    pub fn has_message(&self) -> bool {
+        matches!(self, Self::Messaging(MessagingErr::SendErr(_)))
+    }
+    /// Try and extract the message payload from the contained error. This consumes the
+    /// [RactorErr] instance in order to not have require cloning the message payload.
+    /// Should be used in conjunction with `has_message` to not consume the error if not wanted
+    ///
+    /// Returns [Some(`T`)] if there is a message payload, [None] otherwise.
+    pub fn try_get_message(self) -> Option<T> {
+        if let Self::Messaging(MessagingErr::SendErr(msg)) = self {
+            Some(msg)
+        } else {
+            None
+        }
+    }
+}
+
 impl<T> std::fmt::Debug for RactorErr<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/ractor/src/tests.rs
+++ b/ractor/src/tests.rs
@@ -5,6 +5,10 @@
 
 //! Basic tests of errors, error conversions, etc
 
+use crate::Actor;
+use crate::ActorCell;
+use crate::ActorProcessingErr;
+use crate::ActorRef;
 use crate::RactorErr;
 
 #[test]
@@ -31,4 +35,42 @@ fn test_error_conversions() {
         RactorErr::<()>::from(crate::MessagingErr::ChannelClosed).to_string(),
         other
     );
+}
+
+#[crate::concurrency::test]
+async fn test_error_message_extraction() {
+    struct TestActor;
+
+    #[async_trait::async_trait]
+    impl Actor for TestActor {
+        type Msg = ();
+        type State = ();
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _: ActorRef<Self::Msg>,
+            _: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+    }
+
+    let (actor, handle) = Actor::spawn(None, TestActor, ())
+        .await
+        .expect("Failed to start test actor");
+    // stop the actor, and wait for death which will free the message channels
+    actor.stop(None);
+    handle.await.unwrap();
+
+    let err = crate::cast!(actor, ()).expect_err("Not an error!");
+    assert!(err.has_message());
+    assert!(err.try_get_message().is_some());
+
+    let cell: ActorCell = actor.into();
+    let bad_message_actor: ActorRef<u32> = cell.into();
+
+    let err = crate::cast!(bad_message_actor, 0u32).expect_err("Not an error!");
+    assert!(!err.has_message());
+    assert!(err.try_get_message().is_none());
 }


### PR DESCRIPTION
This will help avoid nested destructoring pattern matching when trying to extract the message payload from a RactorErr.

New tests added covering error flows