### PR TITLE
Adjust trait bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A pure-Rust actor framework. Inspired from [Erlang's `gen_server`](https://www.e
 a set of generic primitives and helps automate the supervision tree and management of our actors along with the traditional actor message processing logic. It's built *heavily* on `tokio` which is a
 hard requirement for `ractor` (today).
 
-`ractor` is a modern actor framework written in 100% rust with no additional `unsafe` code.
+`ractor` is a modern actor framework written in 100% Rust.
 
 Additionally `ractor` has a companion library, `ractor_cluster` which is needed for `ractor` to be deployed in a distributed (cluster-like) scenario. `ractor_cluster` shouldn't be considered production ready, but it is relatively stable and we'd love your feedback!
 

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/src/actor/actor_cell/actor_ref.rs
+++ b/ractor/src/actor/actor_cell/actor_ref.rs
@@ -19,16 +19,12 @@ use super::ActorCell;
 /// An [ActorRef] is the primary means of communication typically used
 /// when interfacing with [super::Actor]s
 pub struct ActorRef<TMessage>
-where
-    TMessage: Message,
 {
     pub(crate) inner: ActorCell,
     _tactor: PhantomData<TMessage>,
 }
 
 impl<TMessage> Clone for ActorRef<TMessage>
-where
-    TMessage: Message,
 {
     fn clone(&self) -> Self {
         ActorRef {
@@ -39,8 +35,6 @@ where
 }
 
 impl<TMessage> std::ops::Deref for ActorRef<TMessage>
-where
-    TMessage: Message,
 {
     type Target = ActorCell;
 
@@ -50,8 +44,6 @@ where
 }
 
 impl<TMessage> From<ActorCell> for ActorRef<TMessage>
-where
-    TMessage: Message,
 {
     fn from(value: ActorCell) -> Self {
         Self {
@@ -62,8 +54,6 @@ where
 }
 
 impl<TActor> From<ActorRef<TActor>> for ActorCell
-where
-    TActor: Message,
 {
     fn from(value: ActorRef<TActor>) -> Self {
         value.inner
@@ -71,30 +61,16 @@ where
 }
 
 impl<TMessage> std::fmt::Debug for ActorRef<TMessage>
-where
-    TMessage: Message,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.inner)
     }
 }
 
-impl<TMessage> ActorRef<TMessage>
-where
-    TMessage: Message,
-{
+impl <TMessage> ActorRef<TMessage> {
     /// Retrieve a cloned [ActorCell] representing this [ActorRef]
     pub fn get_cell(&self) -> ActorCell {
         self.inner.clone()
-    }
-
-    /// Send a strongly-typed message, constructing the boxed message on the fly
-    ///
-    /// * `message` - The message to send
-    ///
-    /// Returns [Ok(())] on successful message send, [Err(MessagingErr)] otherwise
-    pub fn send_message(&self, message: TMessage) -> Result<(), MessagingErr<TMessage>> {
-        self.inner.send_message::<TMessage>(message)
     }
 
     /// Notify the supervisors that a supervision event occurred
@@ -102,6 +78,20 @@ where
     /// * `evt` - The event to send to this [crate::Actor]'s supervisors
     pub fn notify_supervisor(&self, evt: SupervisionEvent) {
         self.inner.notify_supervisor(evt)
+    }
+}
+
+impl<TMessage> ActorRef<TMessage>
+where
+    TMessage: Message,
+{
+    /// Send a strongly-typed message, constructing the boxed message on the fly
+    ///
+    /// * `message` - The message to send
+    ///
+    /// Returns [Ok(())] on successful message send, [Err(MessagingErr)] otherwise
+    pub fn send_message(&self, message: TMessage) -> Result<(), MessagingErr<TMessage>> {
+        self.inner.send_message::<TMessage>(message)
     }
 
     // ========================== General Actor Operation Aliases ========================== //

--- a/ractor/src/actor/errors.rs
+++ b/ractor/src/actor/errors.rs
@@ -106,6 +106,8 @@ pub enum MessagingErr<T> {
     InvalidActorType,
 }
 
+unsafe impl<T> Sync for MessagingErr<T> {}
+
 impl<T> std::fmt::Debug for MessagingErr<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -136,7 +136,7 @@
 
 #![deny(warnings)]
 #![warn(unused_imports)]
-#![warn(unsafe_code)]
+// #![warn(unsafe_code)]
 #![warn(missing_docs)]
 #![warn(unused_crate_dependencies)]
 // #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/ractor/src/message.rs
+++ b/ractor/src/message.rs
@@ -77,7 +77,7 @@ pub struct BoxedMessage {
 ///     PrintName,
 /// }
 /// ```
-pub trait Message: Any + Send + Sync + Sized + 'static {
+pub trait Message: Any + Send + Sized + 'static {
     /// Convert a [BoxedMessage] to this concrete type
     #[cfg(feature = "cluster")]
     fn from_boxed(mut m: BoxedMessage) -> Result<Self, BoxedDowncastErr> {
@@ -168,14 +168,12 @@ pub trait Message: Any + Send + Sync + Sized + 'static {
 // Auto-Implement the [Message] trait for all types when NOT in the `cluster` configuration
 // since there's no need for an override
 #[cfg(not(feature = "cluster"))]
-impl<T: Any + Send + Sync + Sized + 'static> Message for T {}
+impl<T: Any + Send + Sized + 'static> Message for T {}
 
 // Blanket implementation for basic types which are directly bytes serializable which
 // are all to be CAST operations
 #[cfg(feature = "cluster")]
-impl<T: Any + Send + Sync + Sized + 'static + crate::serialization::BytesConvertable> Message
-    for T
-{
+impl<T: Any + Send + Sized + 'static + crate::serialization::BytesConvertable> Message for T {
     fn serializable() -> bool {
         true
     }

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
This PR adjusts a few trait bounds in `ractor` to

1. Remove the need to implement `Message` on `ActorRef` except for the implementation where it's required. 
2. Add `Sync` manually on `ActorRef` in order to remove the necessity for `Message` to be `Sync`.

The more important change here is point (2) which is helpful because the underlying message type **does not need to be `Sync`**. Because we use channels under the hood, we don't need `Sync` for message types, but `ActorRef` won't then automatically get that trait auto implemented by the compiler because the message type isn't `Sync`.