### PR TITLE
Add `map` for RactorErr/MessagingErr<T>

### DIFF
--- a/ractor/src/actor/errors.rs
+++ b/ractor/src/actor/errors.rs
@@ -106,6 +106,21 @@ pub enum MessagingErr<T> {
     InvalidActorType,
 }
 
+impl<T> MessagingErr<T> {
+    /// Map any message embedded within the error type. This is primarily useful
+    /// for normalizing an error value if the message is not needed.
+    pub fn map<F, U>(self, mapper: F) -> MessagingErr<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        match self {
+            MessagingErr::SendErr(err) => MessagingErr::SendErr(mapper(err)),
+            MessagingErr::ChannelClosed => MessagingErr::ChannelClosed,
+            MessagingErr::InvalidActorType => MessagingErr::InvalidActorType,
+        }
+    }
+}
+
 unsafe impl<T> Sync for MessagingErr<T> {}
 
 impl<T> std::fmt::Debug for MessagingErr<T> {

--- a/ractor/src/actor/tests/mod.rs
+++ b/ractor/src/actor/tests/mod.rs
@@ -10,7 +10,7 @@ use std::sync::{
     Arc,
 };
 
-use crate::concurrency::Duration;
+use crate::{concurrency::Duration, MessagingErr, RactorErr};
 
 use crate::{
     Actor, ActorCell, ActorProcessingErr, ActorRef, ActorStatus, SpawnErr, SupervisionEvent,
@@ -871,4 +871,11 @@ async fn kill_and_wait() {
         .expect("Failed to wait for actor death");
     // the handle should be done and completed
     assert!(handle.is_finished());
+}
+
+#[test]
+fn test_err_map() {
+    let err: RactorErr<i32> = RactorErr::Messaging(MessagingErr::SendErr(123));
+
+    let _: RactorErr<()> = err.map(|_| ());
 }

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -220,6 +220,20 @@ impl<T> RactorErr<T> {
             None
         }
     }
+
+    /// Map any message embedded within the error type. This is primarily useful
+    /// for normalizing an error value if the message is not needed.
+    pub fn map<F, U>(self, mapper: F) -> RactorErr<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        match self {
+            RactorErr::Spawn(err) => RactorErr::Spawn(err),
+            RactorErr::Messaging(err) => RactorErr::Messaging(err.map(mapper)),
+            RactorErr::Actor(err) => RactorErr::Actor(err),
+            RactorErr::Timeout => RactorErr::Timeout,
+        }
+    }
 }
 
 impl<T> std::fmt::Debug for RactorErr<T> {


### PR DESCRIPTION
Sometimes the embedded message is not needed and we need to normalize a number of errors from different sources, so add a `map` function which allows `err.map(|_| ())`.