### PR TITLE
Add better formatting of error types which propogates the inner error information (if present)

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/src/actor/errors.rs
+++ b/ractor/src/actor/errors.rs
@@ -25,13 +25,24 @@ pub enum SpawnErr {
     ActorAlreadyRegistered(ActorName),
 }
 
-impl std::error::Error for SpawnErr {}
+impl std::error::Error for SpawnErr {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self {
+            Self::StartupPanic(inner) => Some(inner.as_ref()),
+            _ => None,
+        }
+    }
+}
 
 impl Display for SpawnErr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::StartupPanic(panic_msg) => {
-                write!(f, "Actor panicked during startup '{panic_msg}'")
+                if f.alternate() {
+                    write!(f, "Actor panicked during startup '{panic_msg:#}'")
+                } else {
+                    write!(f, "Actor panicked during startup '{panic_msg}'")
+                }
             }
             Self::StartupCancelled => {
                 write!(
@@ -71,13 +82,24 @@ pub enum ActorErr {
     Panic(ActorProcessingErr),
 }
 
-impl std::error::Error for ActorErr {}
+impl std::error::Error for ActorErr {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self {
+            Self::Panic(inner) => Some(inner.as_ref()),
+            _ => None,
+        }
+    }
+}
 
 impl Display for ActorErr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Panic(panic_msg) => {
-                write!(f, "Actor panicked '{panic_msg}'")
+                if f.alternate() {
+                    write!(f, "Actor panicked '{panic_msg:#}'")
+                } else {
+                    write!(f, "Actor panicked '{panic_msg}'")
+                }
             }
             Self::Cancelled => {
                 write!(f, "Actor operation cancelled")

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -281,13 +281,25 @@ impl<T> std::fmt::Display for RactorErr<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Actor(actor_err) => {
-                write!(f, "{actor_err}")
+                if f.alternate() {
+                    write!(f, "{actor_err:#}")
+                } else {
+                    write!(f, "{actor_err}")
+                }
             }
             Self::Messaging(messaging_err) => {
-                write!(f, "{messaging_err}")
+                if f.alternate() {
+                    write!(f, "{messaging_err:#}")
+                } else {
+                    write!(f, "{messaging_err}")
+                }
             }
             Self::Spawn(spawn_err) => {
-                write!(f, "{spawn_err}")
+                if f.alternate() {
+                    write!(f, "{spawn_err:#}")
+                } else {
+                    write!(f, "{spawn_err}")
+                }
             }
             Self::Timeout => {
                 write!(f, "timeout")

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
This captures the pretty-print (alternate) formatting flag from the parent caller, and propogates it (if necessary) and additionally captures the inner error on a startup panic (if possible).