### PR TITLE
Add re-export of async_trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ never be executed in parallel. Following the actor model leads to microservices 
 An example `ping-pong` actor might be the following
 
 ```rust
-use ractor::{cast, Actor, ActorProcessingErr, ActorRef};
+use ractor::{async_trait, cast, Actor, ActorProcessingErr, ActorRef};
 
 /// [PingPong] is a basic actor that will print
 /// ping..pong.. repeatedly until some exit
@@ -114,7 +114,7 @@ impl Message {
 }
 
 // the implementation of our actor's "logic"
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for PingPong {
     // An actor has a message type
     type Msg = Message;

--- a/ractor/examples/counter.rs
+++ b/ractor/examples/counter.rs
@@ -14,7 +14,7 @@
 
 extern crate ractor;
 
-use ractor::{call_t, Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+use ractor::{async_trait, call_t, Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
 
 struct Counter;
 
@@ -31,7 +31,7 @@ enum CounterMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for CounterMessage {}
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for Counter {
     type Msg = CounterMessage;
 

--- a/ractor/examples/monte_carlo.rs
+++ b/ractor/examples/monte_carlo.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 
-use ractor::{cast, Actor, ActorId, ActorProcessingErr, ActorRef};
+use ractor::{async_trait, cast, Actor, ActorId, ActorProcessingErr, ActorRef};
 use rand::{thread_rng, Rng};
 
 // ================== Player Actor ================== //
@@ -62,7 +62,7 @@ struct GameMessage(ActorRef<GameManagerMessage>);
 #[cfg(feature = "cluster")]
 impl ractor::Message for GameMessage {}
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for Game {
     type Msg = GameMessage;
 
@@ -140,7 +140,7 @@ impl GameManagerState {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for GameManager {
     type Msg = GameManagerMessage;
 

--- a/ractor/examples/output_port.rs
+++ b/ractor/examples/output_port.rs
@@ -15,7 +15,7 @@ extern crate ractor;
 
 use std::sync::Arc;
 
-use ractor::{Actor, ActorProcessingErr, ActorRef, OutputPort};
+use ractor::{async_trait, Actor, ActorProcessingErr, ActorRef, OutputPort};
 use tokio::time::{timeout, Duration};
 
 enum PublisherMessage {
@@ -31,7 +31,7 @@ impl ractor::Message for Output {}
 
 struct Publisher;
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for Publisher {
     type Msg = PublisherMessage;
 
@@ -70,7 +70,7 @@ enum SubscriberMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for SubscriberMessage {}
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for Subscriber {
     type Msg = SubscriberMessage;
 

--- a/ractor/examples/philosophers.rs
+++ b/ractor/examples/philosophers.rs
@@ -20,7 +20,7 @@
 
 use std::collections::{HashMap, VecDeque};
 
-use ractor::{cast, Actor, ActorId, ActorName, ActorProcessingErr, ActorRef, RpcReplyPort};
+use ractor::{async_trait, cast, Actor, ActorId, ActorName, ActorProcessingErr, ActorRef, RpcReplyPort};
 use tokio::time::{Duration, Instant};
 
 // ============================ Fork Actor ============================ //
@@ -109,7 +109,7 @@ impl Fork {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for Fork {
     type Msg = ForkMessage;
     type State = ForkState;
@@ -322,7 +322,7 @@ impl Philosopher {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for Philosopher {
     type Msg = PhilosopherMessage;
     type State = PhilosopherState;

--- a/ractor/examples/philosophers.rs
+++ b/ractor/examples/philosophers.rs
@@ -20,7 +20,9 @@
 
 use std::collections::{HashMap, VecDeque};
 
-use ractor::{async_trait, cast, Actor, ActorId, ActorName, ActorProcessingErr, ActorRef, RpcReplyPort};
+use ractor::{
+    async_trait, cast, Actor, ActorId, ActorName, ActorProcessingErr, ActorRef, RpcReplyPort,
+};
 use tokio::time::{Duration, Instant};
 
 // ============================ Fork Actor ============================ //

--- a/ractor/examples/ping_pong.rs
+++ b/ractor/examples/ping_pong.rs
@@ -14,7 +14,7 @@
 
 extern crate ractor;
 
-use ractor::{cast, Actor, ActorProcessingErr, ActorRef};
+use ractor::{async_trait, cast, Actor, ActorProcessingErr, ActorRef};
 
 pub struct PingPong;
 
@@ -42,7 +42,7 @@ impl Message {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for PingPong {
     type Msg = Message;
 

--- a/ractor/examples/supervisor.rs
+++ b/ractor/examples/supervisor.rs
@@ -11,7 +11,7 @@
 //! cargo run --example supervisor
 //! ```
 
-use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort, SupervisionEvent};
+use ractor::{async_trait, Actor, ActorProcessingErr, ActorRef, RpcReplyPort, SupervisionEvent};
 
 use tokio::time::Duration;
 
@@ -68,7 +68,7 @@ enum LeafActorMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for LeafActorMessage {}
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for LeafActor {
     type Msg = LeafActorMessage;
     type State = LeafActorState;
@@ -131,7 +131,7 @@ enum MidLevelActorMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for MidLevelActorMessage {}
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for MidLevelActor {
     type Msg = MidLevelActorMessage;
     type State = MidLevelActorState;
@@ -211,7 +211,7 @@ enum RootActorMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for RootActorMessage {}
 
-#[async_trait::async_trait]
+#[async_trait]
 impl Actor for RootActor {
     type Msg = RootActorMessage;
     type State = RootActorState;

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -179,6 +179,7 @@ pub use actor::errors::{ActorErr, ActorProcessingErr, MessagingErr, SpawnErr};
 pub use actor::messages::{Signal, SupervisionEvent};
 pub use actor::{Actor, ActorRuntime};
 pub use actor_id::ActorId;
+pub use async_trait::async_trait;
 pub use message::Message;
 pub use port::{OutputMessage, OutputPort, RpcReplyPort};
 #[cfg(feature = "cluster")]


### PR DESCRIPTION
While importing `ractor` into one of my projects, I was trying to re-create the example under `ractor/ractor/examples/supervisor.rs`. However, I was getting an issue around the use of ` #[async_trait::async_trait]` to mark the `impl Actor` for the existing structs. I imagine this didn't come up in development, since the `async_trait` lib is one of the examples. I know for certain libraries, such as `serde`, it's sometimes common to include the `Serialize, Deserialize` traits as re-exported from the base library (sometimes hidden behind a feature flag, if `serde` is optional), which prevents developers from having to manually re-add a second dependency in order to take advantage of it. I've done the same here, which seems to have solved the problem. If you have any questions or would like to discuss more, just let me know! 