### PR TITLE
[factory] Bug in worker lifecycle management

### DIFF
--- a/ractor/src/factory/mod.rs
+++ b/ractor/src/factory/mod.rs
@@ -165,6 +165,45 @@ where
     TMsg: Message,
     TWorker: Actor<Msg = WorkerMessage<TKey, TMsg>>,
 {
+    fn maybe_dequeue(
+        &self,
+        state: &mut FactoryState<TKey, TMsg, TWorker>,
+        who: WorkerId,
+    ) -> Result<(), ActorProcessingErr> {
+        match &self.routing_mode {
+            RoutingMode::Queuer | RoutingMode::StickyQueuer => {
+                // pop + discard expired jobs
+                let mut next_job = None;
+                while let Some(job) = state.messages.pop_front() {
+                    if !job.is_expired() {
+                        next_job = Some(job);
+                        break;
+                    } else {
+                        state.stats.job_ttl_expired();
+                    }
+                }
+                // de-queue another job
+                if let Some(job) = next_job {
+                    if let Some(worker) = state.pool.get_mut(&who).filter(|f| f.is_available()) {
+                        // Check if this worker is now free (should be the case except potentially in a sticky queuer which may automatically
+                        // move to a sticky message)
+                        worker.enqueue_job(job)?;
+                    } else if let Some(worker) =
+                        state.pool.values_mut().find(|worker| worker.is_available())
+                    {
+                        // If that worker is busy, try and scan the workers to find a free worker
+                        worker.enqueue_job(job)?;
+                    } else {
+                        // no free worker, put the message back into the queue where it was (at the front of the queue)
+                        state.messages.push_front(job);
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
     fn maybe_enqueue(&self, state: &mut FactoryState<TKey, TMsg, TWorker>, job: Job<TKey, TMsg>) {
         if let Some(limit) = self.discard_threshold {
             state.messages.push_back(job);
@@ -448,45 +487,17 @@ where
                 }
             }
             FactoryMessage::Finished(who, job_key) => {
-                if let Some(worker) = state.pool.get_mut(&who) {
+                let wid = if let Some(worker) = state.pool.get_mut(&who) {
                     if let Some(job_options) = worker.worker_complete(job_key)? {
                         // record the job data on the factory
                         state.stats.factory_job_done(&job_options);
                     }
-                }
-
-                match self.routing_mode {
-                    RoutingMode::Queuer | RoutingMode::StickyQueuer => {
-                        // pop + discard expired jobs
-                        let mut next_job = None;
-                        while let Some(job) = state.messages.pop_front() {
-                            if !job.is_expired() {
-                                next_job = Some(job);
-                                break;
-                            } else {
-                                state.stats.job_ttl_expired();
-                            }
-                        }
-                        // de-queue another job
-                        if let Some(job) = next_job {
-                            if let Some(worker) =
-                                state.pool.get_mut(&who).filter(|f| f.is_available())
-                            {
-                                // Check if this worker is now free (should be the case except potentially in a sticky queuer which may automatically
-                                // move to a sticky message)
-                                worker.enqueue_job(job)?;
-                            } else if let Some(worker) =
-                                state.pool.values_mut().find(|worker| worker.is_available())
-                            {
-                                // If that worker is busy, try and scan the workers to find a free worker
-                                worker.enqueue_job(job)?;
-                            } else {
-                                // no free worker, put the message back into the queue where it was (at the front of the queue)
-                                state.messages.push_front(job);
-                            }
-                        }
-                    }
-                    _ => {}
+                    Some(worker.wid)
+                } else {
+                    None
+                };
+                if let Some(wid) = wid {
+                    self.maybe_dequeue(state, wid)?;
                 }
             }
             FactoryMessage::WorkerPong(wid, time) => {
@@ -543,7 +554,7 @@ where
     ) -> Result<(), ActorProcessingErr> {
         match message {
             SupervisionEvent::ActorTerminated(who, _, reason) => {
-                if let Some(worker) = state
+                let wid = if let Some(worker) = state
                     .pool
                     .values_mut()
                     .find(|actor| actor.is_pid(who.get_id()))
@@ -563,10 +574,16 @@ where
                         Actor::spawn_linked(None, new_worker, spec, myself.get_cell()).await?;
 
                     worker.replace_worker(replacement, replacement_handle)?;
+                    Some(worker.wid)
+                } else {
+                    None
+                };
+                if let Some(wid) = wid {
+                    self.maybe_dequeue(state, wid)?;
                 }
             }
             SupervisionEvent::ActorPanicked(who, reason) => {
-                if let Some(worker) = state
+                let wid = if let Some(worker) = state
                     .pool
                     .values_mut()
                     .find(|actor| actor.is_pid(who.get_id()))
@@ -586,6 +603,12 @@ where
                         Actor::spawn_linked(None, new_worker, spec, myself.get_cell()).await?;
 
                     worker.replace_worker(replacement, replacement_handle)?;
+                    Some(worker.wid)
+                } else {
+                    None
+                };
+                if let Some(wid) = wid {
+                    self.maybe_dequeue(state, wid)?;
                 }
             }
             _ => {}

--- a/ractor/src/factory/mod.rs
+++ b/ractor/src/factory/mod.rs
@@ -302,7 +302,7 @@ where
 
     /// A reply to a factory ping supplying the worker id and the time
     /// of the ping start
-    WorkerPong(WorkerId, Instant),
+    WorkerPong(WorkerId, Duration),
 
     /// Trigger a scan for stuck worker detection
     IdentifyStuckWorkers,
@@ -506,7 +506,7 @@ where
                 }
             }
             FactoryMessage::DoPings(when) => {
-                if state.stats.ping_received(when) {
+                if state.stats.ping_received(when.elapsed()) {
                     state.log_stats(&myself);
                 }
 

--- a/ractor/src/factory/stats.rs
+++ b/ractor/src/factory/stats.rs
@@ -8,7 +8,7 @@
 use std::fmt::Display;
 use std::time::SystemTime;
 
-use crate::concurrency::Instant;
+use crate::concurrency::{Duration, Instant};
 use crate::factory::JobOptions;
 
 const MICROS_IN_SEC: u128 = 1000000;
@@ -123,10 +123,9 @@ impl MessageProcessingStats {
 
     /// Handle a factory ping, and every 10 minutes adjust the stats to the
     /// average + return a flag to state that we reset the ping counter (every RESET_PINGS_AFTER pings)
-    pub(crate) fn ping_received(&mut self, sent_when: Instant) -> bool {
+    pub(crate) fn ping_received(&mut self, duration: Duration) -> bool {
         self.last_ping = Instant::now();
         if self.enabled {
-            let duration = self.last_ping - sent_when;
             self.ping_count += 1;
             self.ping_timing_us += duration.as_micros();
             if self.ping_count > RESET_PINGS_AFTER {

--- a/ractor/src/factory/tests/mod.rs
+++ b/ractor/src/factory/tests/mod.rs
@@ -76,7 +76,7 @@ impl Actor for TestWorker {
             WorkerMessage::FactoryPing(time) => {
                 state
                     .factory
-                    .cast(FactoryMessage::WorkerPong(state.wid, time))?;
+                    .cast(FactoryMessage::WorkerPong(state.wid, time.elapsed()))?;
             }
             WorkerMessage::Dispatch(job) => {
                 log::debug!("Worker received {:?}", job.msg);
@@ -568,7 +568,7 @@ impl Actor for StuckWorker {
             WorkerMessage::FactoryPing(time) => {
                 state
                     .factory
-                    .cast(FactoryMessage::WorkerPong(state.wid, time))?;
+                    .cast(FactoryMessage::WorkerPong(state.wid, time.elapsed()))?;
             }
             WorkerMessage::Dispatch(job) => {
                 log::debug!("Worker received {:?}", job.msg);

--- a/ractor/src/factory/tests/mod.rs
+++ b/ractor/src/factory/tests/mod.rs
@@ -18,6 +18,8 @@ use super::{
     WorkerStartContext,
 };
 
+mod worker_lifecycle;
+
 const NUM_TEST_WORKERS: usize = 3;
 
 #[derive(Debug, Hash, Clone, Eq, PartialEq)]

--- a/ractor/src/factory/tests/worker_lifecycle.rs
+++ b/ractor/src/factory/tests/worker_lifecycle.rs
@@ -1,0 +1,152 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use std::sync::atomic::AtomicU16;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use crate::concurrency::sleep;
+use crate::concurrency::Duration;
+use crate::Actor;
+use crate::ActorProcessingErr;
+use crate::ActorRef;
+
+use crate::factory::*;
+
+struct MyWorker {
+    counter: Arc<AtomicU16>,
+}
+
+#[derive(Debug)]
+enum MyWorkerMessage {
+    Busy,
+    Increment,
+    Boom,
+}
+
+#[cfg(feature = "cluster")]
+impl Message for MyWorkerMessage {}
+
+#[async_trait::async_trait]
+impl Actor for MyWorker {
+    type State = Self::Arguments;
+    type Msg = WorkerMessage<(), MyWorkerMessage>;
+    type Arguments = WorkerStartContext<(), MyWorkerMessage>;
+
+    async fn pre_start(
+        &self,
+        _: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(args)
+    }
+
+    async fn handle(
+        &self,
+        _: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            WorkerMessage::FactoryPing(time) => {
+                state
+                    .factory
+                    .cast(FactoryMessage::WorkerPong(state.wid, time))?;
+            }
+            WorkerMessage::Dispatch(job) => {
+                log::warn!("Worker received {:?}", job.msg);
+
+                match job.msg {
+                    MyWorkerMessage::Boom => {
+                        panic!("Boom!");
+                    }
+                    MyWorkerMessage::Busy => {
+                        sleep(Duration::from_millis(50)).await;
+                    }
+                    MyWorkerMessage::Increment => {
+                        self.counter.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+
+                // job finished, on success or err we report back to the factory
+                state
+                    .factory
+                    .cast(FactoryMessage::Finished(state.wid, ()))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+struct MyWorkerBuilder {
+    counter: Arc<AtomicU16>,
+}
+
+impl WorkerBuilder<MyWorker> for MyWorkerBuilder {
+    fn build(&self, _wid: WorkerId) -> MyWorker {
+        MyWorker {
+            counter: self.counter.clone(),
+        }
+    }
+}
+
+#[crate::concurrency::test]
+async fn test_worker_death_restarts_and_gets_next_message() {
+    let counter = Arc::new(AtomicU16::new(0));
+    let worker_builder = MyWorkerBuilder {
+        counter: counter.clone(),
+    };
+    let factory_definition = Factory::<(), MyWorkerMessage, MyWorker> {
+        worker_count: 1,
+        routing_mode: RoutingMode::Queuer,
+        discard_threshold: Some(10),
+        ..Default::default()
+    };
+
+    let (factory, factory_handle) =
+        Actor::spawn(None, factory_definition, Box::new(worker_builder))
+            .await
+            .expect("Failed to spawn factory");
+
+    // Now we need to send a specific sequence of events
+    // first make the worker busy so we can be sure the "boom" job is enqueued
+    factory
+        .cast(FactoryMessage::Dispatch(Job {
+            key: (),
+            msg: MyWorkerMessage::Busy,
+            options: JobOptions::default(),
+        }))
+        .expect("Failed to send message to factory");
+    // After it's done being "busy" have it blow up, but we need to push some jobs into the queue asap so that
+    // there's a backlog of work
+    factory
+        .cast(FactoryMessage::Dispatch(Job {
+            key: (),
+            msg: MyWorkerMessage::Boom,
+            options: JobOptions::default(),
+        }))
+        .expect("Failed to send message to factory");
+
+    // After the worker "boom"'s, it should be restarted and SHOULD dequeue following work
+    // automatically without a new message needing to go to the factory
+    for _i in 0..5 {
+        factory
+            .cast(FactoryMessage::Dispatch(Job {
+                key: (),
+                msg: MyWorkerMessage::Increment,
+                options: JobOptions::default(),
+            }))
+            .expect("Failed to send message to factory");
+    }
+    // now wait for everything to propogate
+    sleep(Duration::from_millis(150)).await;
+
+    // check the counter state
+    assert_eq!(5, counter.load(Ordering::Relaxed));
+
+    // Cleanup
+    factory.stop(None);
+    factory_handle.await.unwrap();
+}

--- a/ractor/src/factory/tests/worker_lifecycle.rs
+++ b/ractor/src/factory/tests/worker_lifecycle.rs
@@ -53,7 +53,7 @@ impl Actor for MyWorker {
             WorkerMessage::FactoryPing(time) => {
                 state
                     .factory
-                    .cast(FactoryMessage::WorkerPong(state.wid, time))?;
+                    .cast(FactoryMessage::WorkerPong(state.wid, time.elapsed()))?;
             }
             WorkerMessage::Dispatch(job) => {
                 log::warn!("Worker received {:?}", job.msg);

--- a/ractor/src/factory/worker.rs
+++ b/ractor/src/factory/worker.rs
@@ -239,7 +239,7 @@ where
     }
 
     /// Comes back when a ping went out
-    pub(crate) fn ping_received(&mut self, time: Instant) {
+    pub(crate) fn ping_received(&mut self, time: Duration) {
         if self.stats.ping_received(time) {
             // TODO log metrics ? Should be configurable on the factory level
         }


### PR DESCRIPTION
This PR solves a small bug in worker lifecycle management.

**currently** If the factory has a queue of backlogged work, and a worker dies, when it's restarted, it won't immediately dequeue the next message from the factory's queue. It will only get a message on the next incoming factory message which additionally since there's a "free" worker, even with a backlog of work, that incoming message will jump the queue.

This is incorrect behavior, and queue'd message should be served first. This change makes it that when a worker is re-created, it will dequeue a message as the worker is now "free".

Tests added to cover this scenario going forward.