### PR TITLE
Add node event subscription

### DIFF
--- a/ractor_cluster/src/lib.rs
+++ b/ractor_cluster/src/lib.rs
@@ -67,7 +67,8 @@ pub use net::{IncomingEncryptionMode, NetworkStream};
 pub use node::client::connect as client_connect;
 pub use node::client::connect_enc as client_connect_enc;
 pub use node::{
-    client::ClientConnectErr, NodeServer, NodeServerMessage, NodeSession, NodeSessionMessage,
+    client::ClientConnectErr, NodeEventSubscription, NodeServer, NodeServerMessage, NodeSession,
+    NodeSessionMessage,
 };
 
 // Re-export the procedural macros so people don't need to reference them directly

--- a/ractor_cluster/src/node/node_session/mod.rs
+++ b/ractor_cluster/src/node/node_session/mod.rs
@@ -910,6 +910,9 @@ impl Actor for NodeSession {
                             self.handle_auth(state, auth_message, myself.clone()).await;
                             // If we were not originally authenticated, but now we are, startup the node sync'ing logic
                             if !p_state && state.auth.is_ok() {
+                                self.node_server.cast(
+                                    NodeServerMessage::ConnectionAuthenticated(myself.get_id()),
+                                )?;
                                 self.after_authenticated(myself, state);
                             }
                         }


### PR DESCRIPTION
When setting up a node, presently there's no way to capture events on nodes without polling the `NodeServer`.

This change adds a `NodeEventSubscription` trait so that subscribers can implement the trait to get node events.

Additionally integration tests updated to prove subscription events are wired up right

```text
node-a  | [2023-05-19T15:51:28.807Z WARN  ractor_cluster_integration_tests::tests::auth_handshake] [SubscriptionEventLogger] Node 0 (172.19.0.3:38756) opened
node-b  | [2023-05-19T15:51:28.807Z WARN  ractor_cluster_integration_tests::tests::auth_handshake] [SubscriptionEventLogger] Node 0 (172.19.0.2:8199) opened
...
node-b  | [2023-05-19T15:51:28.808Z WARN  ractor_cluster_integration_tests::tests::auth_handshake] [SubscriptionEventLogger] Node 0 (172.19.0.2:8199) authenticated
node-a  | [2023-05-19T15:51:28.808Z WARN  ractor_cluster_integration_tests::tests::auth_handshake] [SubscriptionEventLogger] Node 0 (172.19.0.3:38756) authenticated
```