### PR TITLE
Fix monte_carlo example

### DIFF
--- a/ractor/examples/monte_carlo.rs
+++ b/ractor/examples/monte_carlo.rs
@@ -101,8 +101,7 @@ impl Actor for Game {
                     id: myself.get_id(),
                     results: state.results_vec.clone(),
                 }
-            )
-            .expect("Failed to send message");
+            )?;
             // Because the `GameManager` is monitoring this actor we can stop this actor
             myself.stop(None);
         }


### PR DESCRIPTION
This causes the cast to the parent to not panic, avoiding error messages, and simply error out the child if it can't talk to the parent.

Resolves #162 