### PR TITLE
Minor updates and fixes to the project's website

### DIFF
--- a/_pages/best_practices.md
+++ b/_pages/best_practices.md
@@ -6,9 +6,9 @@ layout: single
 author_profile: false
 ---
 
-## Should actors be long lived or short lived?
+## Should actors be long-lived or short-lived?
 
-General guidance is that actors should be long lived. There's a historical reason here (Erlang patterns are typically long-lived `gen_server`s).
+General guidance is that actors should be long-lived. There's a historical reason here (Erlang patterns are typically long-lived `gen_server`s).
 The other reason, internally to ractor, is there's non-trivial overhead spawning and creating the actor. Not only from the real actor spawn, creating
 necessary dependent resources and actor ref's, but also from any overhead incurred in the actor's `pre_start` routine.
 

--- a/_pages/quickstart.md
+++ b/_pages/quickstart.md
@@ -1,6 +1,6 @@
 ---
 permalink: /quickstart/
-title: "Quick start"
+title: "Quickstart"
 toc: true
 layout: single
 author_profile: false
@@ -22,7 +22,7 @@ Install `ractor` by adding the following to your Cargo.toml dependencies
 
 ```toml
 [dependencies]
-ractor = "0.8"
+ractor = "0.9"
 ```
 
 ## Your first actor
@@ -116,7 +116,7 @@ async fn main() {
     // have completed)
     let (actor, actor_handle) = Actor::spawn(None, MyFirstActor, ()).await.expect("Actor failed to start");
     
-    for i in 1..10 {
+    for _i in 0..10 {
         // Sends a message, with no reply
         actor.cast(MyFirstActorMessage::PrintHelloWorld).expect("Failed to send message to actor");
     }
@@ -201,7 +201,7 @@ async fn main() {
             .await
             .expect("Actor failed to start");
     
-    for i in 1..10 {
+    for _i in 0..10 {
         // Sends a message, with no reply
         actor.cast(MyFirstActorMessage::PrintHelloWorld)
             .expect("Failed to send message to actor");


### PR DESCRIPTION
**Quickstart page**
* Changed title from 'Quick start' to 'Quickstart'
* Updated `ractor` version from `0.8` to `0.9`
* Prefixed unused `i` to `_i`
* Fix the `for` loop's exclusive range `1..10` to `0..10`; correctly processing 10 messages.

**FAQ page**
* Minor spelling fixes

I'm a bit unsure about the 'FAQ' title vs. the `best_practice.md` file but that's again a very minor nit. Left as is.