### PR TITLE
Add monitoring of actors from peers, without full linking support.

### DIFF
--- a/ractor/src/actor/actor_ref.rs
+++ b/ractor/src/actor/actor_ref.rs
@@ -76,11 +76,14 @@ impl<TMessage> ActorRef<TMessage> {
         self.inner.clone()
     }
 
-    /// Notify the supervisors that a supervision event occurred
+    /// Notify the supervisor and all monitors that a supervision event occurred.
+    /// Monitors receive a reduced copy of the supervision event which won't contain
+    /// the [crate::actor::BoxedState] and collapses the [crate::ActorProcessingErr]
+    /// exception to a [String]
     ///
     /// * `evt` - The event to send to this [crate::Actor]'s supervisors
-    pub fn notify_supervisor(&self, evt: SupervisionEvent) {
-        self.inner.notify_supervisor(evt)
+    pub fn notify_supervisor_and_monitors(&self, evt: SupervisionEvent) {
+        self.inner.notify_supervisor_and_monitors(evt)
     }
 }
 

--- a/ractor/src/actor/mod.rs
+++ b/ractor/src/actor/mod.rs
@@ -536,7 +536,10 @@ where
             myself.terminate();
 
             // notify supervisors of the actor's death
-            myself.notify_supervisor(evt);
+            myself.notify_supervisor_and_monitors(evt);
+
+            // clear any monitor actors
+            myself.clear_monitors();
 
             // unlink superisors
             if let Some(sup) = supervisor {
@@ -565,7 +568,7 @@ where
             .map_err(ActorErr::Panic)?;
 
         myself.set_status(ActorStatus::Running);
-        myself.notify_supervisor(SupervisionEvent::ActorStarted(myself.get_cell()));
+        myself.notify_supervisor_and_monitors(SupervisionEvent::ActorStarted(myself.get_cell()));
 
         let myself_clone = myself.clone();
 

--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -1146,3 +1146,109 @@ async fn test_supervisor_double_link() {
     ah.await.unwrap();
     bh.await.unwrap();
 }
+
+#[crate::concurrency::test]
+#[tracing_test::traced_test]
+async fn test_simple_monitor() {
+    struct Peer;
+    struct Monitor {
+        counter: Arc<AtomicU8>,
+    }
+
+    #[crate::async_trait]
+    impl Actor for Peer {
+        type Msg = ();
+        type State = ();
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _: ActorRef<Self::Msg>,
+            _: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+
+        async fn handle(
+            &self,
+            myself: ActorRef<Self::Msg>,
+            _: Self::Msg,
+            _: &mut Self::State,
+        ) -> Result<(), ActorProcessingErr> {
+            myself.stop(Some("oh no!".to_string()));
+            Ok(())
+        }
+    }
+
+    #[crate::async_trait]
+    impl Actor for Monitor {
+        type Msg = ();
+        type State = ();
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _: ActorRef<Self::Msg>,
+            _: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+
+        async fn handle_supervisor_evt(
+            &self,
+            _: ActorRef<Self::Msg>,
+            evt: SupervisionEvent,
+            _: &mut Self::State,
+        ) -> Result<(), ActorProcessingErr> {
+            if let SupervisionEvent::ActorTerminated(_who, _state, Some(msg)) = evt {
+                if msg.as_str() == "oh no!" {
+                    self.counter.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            Ok(())
+        }
+    }
+
+    let count = Arc::new(AtomicU8::new(0));
+
+    let (p, ph) = Actor::spawn(None, Peer, ())
+        .await
+        .expect("Failed to start peer");
+    let (m, mh) = Actor::spawn(
+        None,
+        Monitor {
+            counter: count.clone(),
+        },
+        (),
+    )
+    .await
+    .expect("Faield to start monitor");
+
+    m.monitor(p.get_cell());
+
+    // stopping the peer should notify the monitor, who can capture the state
+    p.cast(()).expect("Failed to contact peer");
+    periodic_check(
+        || count.load(Ordering::Relaxed) == 1,
+        Duration::from_secs(1),
+    )
+    .await;
+    ph.await.unwrap();
+
+    let (p, ph) = Actor::spawn(None, Peer, ())
+        .await
+        .expect("Failed to start peer");
+    m.monitor(p.get_cell());
+    m.unmonitor(p.get_cell());
+
+    p.cast(()).expect("Failed to contact peer");
+    ph.await.unwrap();
+
+    // The count doesn't increment when the peer exits (we give some time
+    // to schedule the supervision evt)
+    crate::concurrency::sleep(Duration::from_millis(100)).await;
+    assert_eq!(1, count.load(Ordering::Relaxed));
+
+    m.stop(None);
+    mh.await.unwrap();
+}

--- a/ractor/src/pg/mod.rs
+++ b/ractor/src/pg/mod.rs
@@ -34,7 +34,7 @@ pub const ALL_GROUPS_NOTIFICATION: &str = "__world__";
 #[cfg(test)]
 mod tests;
 
-/// Represents a change in group or scope membership
+/// Represents a change in a process group's membership
 #[derive(Clone)]
 pub enum GroupChangeMessage {
     /// Some actors joined a group

--- a/ractor/src/registry/pid_registry.rs
+++ b/ractor/src/registry/pid_registry.rs
@@ -15,7 +15,10 @@ use once_cell::sync::OnceCell;
 
 use crate::{ActorCell, ActorId, SupervisionEvent};
 
-/// Represents a change in group or scope membership
+/// Represents a change ocurring to some actor in the global process registry. Only relevant in
+/// cluster enabled functionality.
+///
+/// It represents actors spawning and exiting, irrespective of procress groups.
 #[derive(Clone)]
 pub enum PidLifecycleEvent {
     /// Some actors joined a group


### PR DESCRIPTION
# Motivation

`link`ing an actor to another actor, in `ractor`, invokes the parent-child relationship and makes the parent the supervisor of the child. This means if the parent dies, before the child can process a supervision event (in say a doubly-linked scenario), the child will be terminated as part of the parent's exit flow (and not just terminated, but killed halting any async work in any flow). 

This is non-ideal for looser ownership scenarios.

This PR introduces the notion of `monitor`ing (along with `unmonitor` and `clear_monitors`) which allows a non-parent relationship to supervision. This means an actor can monitor another actor without being in the direct lifecycle path yet still receive supervision events.

NOTE: In order to not require the state to implement `Clone`, we instead add a "slimmed out" supervision event for monitors, such that they (a) won't receive the actor's state upon a termination event, if available at all, and (b) won't receive the actual exception with potential extra information, rather a serialized string version. This helps require that the underlying `Actor::State` be as limited in trait implementations as possible (just `Send + 'static`)

Tests added on new functionality