### PR TITLE
Add Erlang-inspired process group (`pg`) scopes

### DIFF
--- a/ractor/src/actor/messages.rs
+++ b/ractor/src/actor/messages.rs
@@ -146,7 +146,12 @@ impl std::fmt::Display for SupervisionEvent {
                 write!(f, "Actor panicked {actor:?} - {panic_msg}")
             }
             SupervisionEvent::ProcessGroupChanged(change) => {
-                write!(f, "Process group {} changed", change.get_group())
+                write!(
+                    f,
+                    "Process group {} in scope {} changed",
+                    change.get_group(),
+                    change.get_scope()
+                )
             }
             #[cfg(feature = "cluster")]
             SupervisionEvent::PidLifecycleEvent(change) => {

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -198,6 +198,9 @@ pub type ActorName = String;
 /// A process group's name, equivalent to an [Erlang `atom()`](https://www.erlang.org/doc/reference_manual/data_types.html#atom)
 pub type GroupName = String;
 
+/// A scope's name, equivalent to an [Erlang `atom()`](https://www.erlang.org/doc/reference_manual/data_types.html#atom)
+pub type ScopeName = String;
+
 /// Represents the state of an actor. Must be safe
 /// to send between threads (same bounds as a [Message])
 pub trait State: std::any::Any + Send + 'static {}

--- a/ractor/src/pg/mod.rs
+++ b/ractor/src/pg/mod.rs
@@ -220,7 +220,7 @@ pub(crate) fn leave_all(actor: ActorId) {
 
 /// Returns all the actors running on the local node in the group `group`.
 ///
-/// * `group_name` - Either a statically named group or scope
+/// * `group_name` - Either a statically named group
 ///
 /// Returns a [`Vec<ActorCell>`] representing the members of this paging group
 pub fn get_local_members(group_name: &GroupName) -> Vec<ActorCell> {
@@ -265,7 +265,7 @@ pub fn which_groups() -> Vec<GroupName> {
 
 /// Subscribes the provided [crate::Actor] to the scope or group for updates
 ///
-/// * `group_name` - The scope or group to monitor
+/// * `group_name` - The group to monitor
 /// * `actor` - The [ActorCell] representing who will receive updates
 pub fn monitor(group_name: GroupName, actor: ActorCell) {
     let monitor = get_monitor();
@@ -292,7 +292,7 @@ pub fn demonitor(group_name: GroupName, actor: ActorId) {
     }
 }
 
-/// Remove the specified [ActorId] from monitoring all groups it might be.
+/// Remove the specified [ActorId] from monitoring all groups it might be in.
 /// Used only during actor shutdown
 pub(crate) fn demonitor_all(actor: ActorId) {
     let monitor = get_monitor();

--- a/ractor/src/pg/mod.rs
+++ b/ractor/src/pg/mod.rs
@@ -344,8 +344,7 @@ pub fn which_groups() -> Vec<GroupName> {
     let mut groups = monitor
         .map
         .iter()
-        .map(|kvp| kvp.key().clone())
-        .map(|kvp| kvp.group.clone())
+        .map(|kvp| kvp.key().group.to_owned())
         .collect::<Vec<_>>();
     groups.sort_unstable();
     groups.dedup();
@@ -363,9 +362,14 @@ pub fn which_scoped_groups(scope: &ScopeName) -> Vec<GroupName> {
     monitor
         .map
         .iter()
-        .map(|kvp| kvp.key().clone())
-        .filter(|kvp| kvp.scope == *scope)
-        .map(|kvp| kvp.group.clone())
+        .filter_map(|kvp| {
+            let key = kvp.key();
+            if key.scope == *scope {
+                Some(key.group.to_owned())
+            } else {
+                None
+            }
+        })
         .collect::<Vec<_>>()
 }
 
@@ -390,8 +394,10 @@ pub fn which_scopes() -> Vec<ScopeName> {
     monitor
         .map
         .iter()
-        .map(|kvp| kvp.key().clone())
-        .map(|kvp| kvp.scope.clone())
+        .map(|kvp| {
+            let key = kvp.key();
+            key.scope.to_owned()
+        })
         .collect::<Vec<_>>()
 }
 
@@ -519,8 +525,14 @@ fn get_world_monitor_keys() -> Vec<ScopeGroupKey> {
     let mut world_monitor_keys = monitor
         .listeners
         .iter()
-        .map(|kvp| kvp.key().clone())
-        .filter(|kvp| kvp.scope == ALL_SCOPES_NOTIFICATION || kvp.group == ALL_GROUPS_NOTIFICATION)
+        .filter_map(|kvp| {
+            let key = kvp.key().clone();
+            if key.scope == ALL_SCOPES_NOTIFICATION || key.group == ALL_GROUPS_NOTIFICATION {
+                Some(key)
+            } else {
+                None
+            }
+        })
         .collect::<Vec<ScopeGroupKey>>();
     world_monitor_keys.sort_unstable();
     world_monitor_keys.dedup();

--- a/ractor/src/pg/mod.rs
+++ b/ractor/src/pg/mod.rs
@@ -104,7 +104,7 @@ fn get_monitor<'a>() -> &'a PgState {
 
 /// Join actors to the group `group` in the default scope
 ///
-/// * `group` - The statically named group. Will be created if first actors to join
+/// * `group` - The named group. Will be created if first actors to join
 /// * `actors` - The list of [crate::Actor]s to add to the group
 pub fn join(group: GroupName, actors: Vec<ActorCell>) {
     join_scoped(DEFAULT_SCOPE.to_owned(), group, actors);
@@ -112,8 +112,8 @@ pub fn join(group: GroupName, actors: Vec<ActorCell>) {
 
 /// Join actors to the group `group` within the scope `scope`
 ///
-/// * `scope` - the statically named scope. Will be created if first actors join
-/// * `group` - The statically named group. Will be created if first actors to join
+/// * `scope` - the named scope. Will be created if first actors to join
+/// * `group` - The named group. Will be created if first actors to join
 /// * `actors` - The list of [crate::Actor]s to add to the group
 pub fn join_scoped(scope: ScopeName, group: GroupName, actors: Vec<ActorCell>) {
     let key = ScopeGroupKey {
@@ -161,7 +161,7 @@ pub fn join_scoped(scope: ScopeName, group: GroupName, actors: Vec<ActorCell>) {
 
 /// Leaves the specified [crate::Actor]s from the PG group in the default scope
 ///
-/// * `group` - The statically named group
+/// * `group` - A named group
 /// * `actors` - The list of actors to remove from the group
 pub fn leave(group: GroupName, actors: Vec<ActorCell>) {
     leave_scoped(DEFAULT_SCOPE.to_owned(), group, actors);
@@ -169,8 +169,8 @@ pub fn leave(group: GroupName, actors: Vec<ActorCell>) {
 
 /// Leaves the specified [crate::Actor]s from the PG group within the scope `scope`
 ///
-/// * `scope` - The statically named scope
-/// * `group` - The statically named group
+/// * `scope` - A named scope
+/// * `group` - A named group
 /// * `actors` - The list of actors to remove from the group
 pub fn leave_scoped(scope: ScopeName, group: GroupName, actors: Vec<ActorCell>) {
     let key = ScopeGroupKey {
@@ -275,7 +275,7 @@ pub(crate) fn leave_all(actor: ActorId) {
 /// Returns all actors running on the local node in the group `group`
 /// in the default scope.
 ///
-/// * `group_name` - Either a statically named group
+/// * `group` - A named group
 ///
 /// Returns a [`Vec<ActorCell>`] representing the members of this paging group
 pub fn get_local_members(group: &GroupName) -> Vec<ActorCell> {
@@ -285,8 +285,8 @@ pub fn get_local_members(group: &GroupName) -> Vec<ActorCell> {
 /// Returns all actors running on the local node in the group `group`
 /// in scope `scope`
 ///
-/// * `scope_name` - A statically named scope
-/// * `group_name` - Either a statically named group
+/// * `scope_name` - A named scope
+/// * `group_name` - A named group
 ///
 /// Returns a [`Vec<ActorCell>`] representing the members of this paging group
 pub fn get_scoped_local_members(scope: &ScopeName, group: &GroupName) -> Vec<ActorCell> {
@@ -310,7 +310,7 @@ pub fn get_scoped_local_members(scope: &ScopeName, group: &GroupName) -> Vec<Act
 /// Returns all the actors running on any node in the group `group`
 /// in the default scope.
 ///
-/// * `group_name` - Either a statically named group or scope
+/// * `group_name` - A named group
 ///
 /// Returns a [`Vec<ActorCell>`] with the member actors
 pub fn get_members(group_name: &GroupName) -> Vec<ActorCell> {
@@ -320,7 +320,8 @@ pub fn get_members(group_name: &GroupName) -> Vec<ActorCell> {
 /// Returns all the actors running on any node in the group `group`
 /// in the scope `scope`.
 ///
-/// * `group_name` - Either a statically named group or scope
+/// * `scope` - A named scope
+/// * `group` - A named group
 ///
 /// Returns a [`Vec<ActorCell>`] with the member actors
 pub fn get_scoped_members(scope: &ScopeName, group: &GroupName) -> Vec<ActorCell> {
@@ -375,7 +376,7 @@ pub fn which_scoped_groups(scope: &ScopeName) -> Vec<GroupName> {
 
 /// Returns a list of all known scope-group combinations.
 ///
-/// Returns a [`Vec<(ScopeName,GroupName)>`] representing all the registered
+/// Returns a [`Vec<(ScopGroupKey)>`] representing all the registered
 /// combinations that form an identifying tuple
 pub fn which_scopes_and_groups() -> Vec<ScopeGroupKey> {
     let monitor = get_monitor();
@@ -518,7 +519,7 @@ pub(crate) fn demonitor_all(actor: ActorId) {
 
 /// Gets the keys for the world monitors.
 ///
-/// Returns a `Vec<ScopeName, GroupName>` represending all registered tuples
+/// Returns a `Vec<ScopeGroupKey>` represending all registered tuples
 /// for which ane of the values is equivalent to one of the world_monitor_keys
 fn get_world_monitor_keys() -> Vec<ScopeGroupKey> {
     let monitor = get_monitor();

--- a/ractor/src/pg/mod.rs
+++ b/ractor/src/pg/mod.rs
@@ -28,11 +28,15 @@ use once_cell::sync::OnceCell;
 
 use crate::{ActorCell, ActorId, GroupName, ScopeName, SupervisionEvent};
 
+// TODO: Check if this is still needed at the end
 /// Key to monitor all of the groups
 pub const ALL_GROUPS_NOTIFICATION: &str = "__world__";
 
 #[cfg(test)]
 mod tests;
+
+// TODO: Research if there is a need to explicitly start a `Scope` analogous
+// to [Erlang's `pg` module](https://www.erlang.org/doc/man/pg.html).
 
 /// Scopes are sets of process groups. Each group is in exactly one scope.
 /// A process may join any number of groups in any number of scopes.
@@ -84,6 +88,7 @@ impl GroupChangeMessage {
     }
 }
 
+// TODO: Add scopes to `PgState`
 struct PgState {
     map: Arc<DashMap<GroupName, HashMap<ActorId, ActorCell>>>,
     listeners: Arc<DashMap<GroupName, Vec<ActorCell>>>,
@@ -91,6 +96,7 @@ struct PgState {
 
 static PG_MONITOR: OnceCell<PgState> = OnceCell::new();
 
+// TODO: Add scopes to `get_monitor`
 fn get_monitor<'a>() -> &'a PgState {
     PG_MONITOR.get_or_init(|| PgState {
         map: Arc::new(DashMap::new()),
@@ -98,7 +104,7 @@ fn get_monitor<'a>() -> &'a PgState {
     })
 }
 
-/// Join actors to the group `group`
+/// Join actors to the group `group` in the default scope
 ///
 /// * `group` - The statically named group. Will be created if first actors to join
 /// * `actors` - The list of [crate::Actor]s to add to the group
@@ -138,7 +144,17 @@ pub fn join(group: GroupName, actors: Vec<ActorCell>) {
     }
 }
 
-/// Leaves the specified [crate::Actor]s from the PG group
+/// Join actors to the group `group` within the scope `scope`
+///
+/// * `scope` - the statically named scope. Will be created if first actors join
+/// * `group` - The statically named group. Will be created if first actors to join
+/// * `actors` - The list of [crate::Actor]s to add to the group
+#[allow(unused_variables)]
+pub fn join_named_scope(scope: &Scope, group: GroupName, actors: Vec<ActorCell>) {
+    todo!();
+}
+
+/// Leaves the specified [crate::Actor]s from the PG group in the default scope
 ///
 /// * `group` - The statically named group
 /// * `actors` - The list of actors to remove from the group
@@ -174,6 +190,17 @@ pub fn leave(group: GroupName, actors: Vec<ActorCell>) {
     }
 }
 
+/// Leaves the specified [crate::Actor]s from the PG group within the scope `scope`
+///
+/// * `scope` - The statically named scope
+/// * `group` - The statically named group
+/// * `actors` - The list of actors to remove from the group
+#[allow(unused_variables)]
+pub fn leave_named_scope(scope: &Scope, group: GroupName, actors: Vec<ActorCell>) {
+    todo!();
+}
+
+// TODO: Leave all groups in all scopes
 /// Leave all groups for a specific [ActorId].
 /// Used only during actor shutdown
 pub(crate) fn leave_all(actor: ActorId) {
@@ -218,7 +245,8 @@ pub(crate) fn leave_all(actor: ActorId) {
     }
 }
 
-/// Returns all the actors running on the local node in the group `group`.
+/// Returns all actors running on the local node in the group `group`
+/// in the default scope.
 ///
 /// * `group_name` - Either a statically named group
 ///
@@ -237,7 +265,20 @@ pub fn get_local_members(group_name: &GroupName) -> Vec<ActorCell> {
     }
 }
 
-/// Returns all the actors running on any node in the group `group`.
+/// Returns all actors running on the local node in the group `group`
+/// in scope `scope`
+///
+/// * `scope_name` - A statically named scope
+/// * `group_name` - Either a statically named group
+///
+/// Returns a [`Vec<ActorCell>`] representing the members of this paging group
+#[allow(unused_variables)]
+pub fn get_local_members_in_scope(scope: &Scope, group_name: &GroupName) -> Vec<ActorCell> {
+    todo!();
+}
+
+/// Returns all the actors running on any node in the group `group`
+/// in the default scope.
 ///
 /// * `group_name` - Either a statically named group or scope
 ///
@@ -249,6 +290,17 @@ pub fn get_members(group_name: &GroupName) -> Vec<ActorCell> {
     } else {
         vec![]
     }
+}
+
+/// Returns all the actors running on any node in the group `group`
+/// in the scope `scope`.
+///
+/// * `group_name` - Either a statically named group or scope
+///
+/// Returns a [`Vec<ActorCell>`] with the member actors
+#[allow(unused_variables)]
+pub fn get_members_in_scope(scope: &Scope, group_name: &GroupName) -> Vec<ActorCell> {
+    todo!();
 }
 
 /// Return a list of all known groups
@@ -263,7 +315,26 @@ pub fn which_groups() -> Vec<GroupName> {
         .collect::<Vec<_>>()
 }
 
-/// Subscribes the provided [crate::Actor] to the scope or group for updates
+/// Returns a list of all known groups in scope `scope`
+///
+/// * `scope` - The scope to retrieve the groups from
+///
+/// Returns a [`Vec<GroupName>`] representing all the registered group names
+/// in `scope`
+#[allow(unused_variables)]
+pub fn which_groups_in_scope(scope: &Scope) -> Vec<GroupName> {
+    todo!();
+}
+
+/// Returns a list of all known scopes
+///
+/// Returns a [`Vec<Scope>`] representing all the registered scopes
+#[allow(unused_variables)]
+pub fn which_scopes() -> Vec<Scope> {
+    todo!();
+}
+
+/// Subscribes the provided [crate::Actor] to the group for updates
 ///
 /// * `group_name` - The group to monitor
 /// * `actor` - The [ActorCell] representing who will receive updates
@@ -277,10 +348,19 @@ pub fn monitor(group_name: GroupName, actor: ActorCell) {
     }
 }
 
-/// Unsubscribes the provided [crate::Actor] from the scope or group for updates
+/// Subscribes the provided [crate::Actor] to the scope for updates
 ///
-/// * `group_name` - The scope or group to monitor
+/// * `scope` - the scope to monitor
 /// * `actor` - The [ActorCell] representing who will receive updates
+#[allow(unused_variables)]
+pub fn monitor_scope(scope: &Scope, actor: ActorCell) {
+    todo!();
+}
+
+/// Unsubscribes the provided [crate::Actor] from the group for updates
+///
+/// * `group_name` - The group to demonitor
+/// * `actor` - The [ActorCell] representing who will no longer receive updates
 pub fn demonitor(group_name: GroupName, actor: ActorId) {
     let monitor = get_monitor();
     if let Occupied(mut entry) = monitor.listeners.entry(group_name) {
@@ -290,6 +370,15 @@ pub fn demonitor(group_name: GroupName, actor: ActorId) {
             entry.remove();
         }
     }
+}
+
+/// Unsubscribes the provided [crate::Actor] from the scope for updates
+///
+/// * `scope` - The scope to demonitor
+/// * `actor` - The [ActorCell] representing who will no longer receive updates
+#[allow(unused_variables)]
+pub fn demonitor_scope(scope: &Scope, actor: ActorId) {
+    todo!();
 }
 
 /// Remove the specified [ActorId] from monitoring all groups it might be in.

--- a/ractor/src/pg/mod.rs
+++ b/ractor/src/pg/mod.rs
@@ -301,12 +301,15 @@ pub fn get_scoped_members(scope: &ScopeName, group_name: &GroupName) -> Vec<Acto
 /// Returns a [`Vec<GroupName>`] representing all the registered group names
 pub fn which_groups() -> Vec<GroupName> {
     let monitor = get_monitor();
-    monitor
+    let mut groups = monitor
         .map
         .iter()
         .map(|kvp| kvp.key().clone())
         .map(|(_scope, group)| group.clone())
-        .collect::<Vec<_>>()
+        .collect::<Vec<_>>();
+    groups.sort_unstable();
+    groups.dedup();
+    groups
 }
 
 /// Returns a list of all known groups in scope `scope`

--- a/ractor/src/pg/mod.rs
+++ b/ractor/src/pg/mod.rs
@@ -358,7 +358,10 @@ pub fn get_local_members(group_name: &GroupName) -> Vec<ActorCell> {
 /// * `group_name` - Either a statically named group
 ///
 /// Returns a [`Vec<ActorCell>`] representing the members of this paging group
-pub fn get_local_members_with_scope(scope: &ScopeName, group_name: &GroupName) -> Vec<ActorCell> {
+pub fn get_local_members_with_named_scope(
+    scope: &ScopeName,
+    group_name: &GroupName,
+) -> Vec<ActorCell> {
     let monitor = get_monitor();
     if let Some(actors) = monitor.map.get(&(scope.to_owned(), group_name.to_owned())) {
         actors
@@ -396,7 +399,7 @@ pub fn get_members(group_name: &GroupName) -> Vec<ActorCell> {
 /// * `group_name` - Either a statically named group or scope
 ///
 /// Returns a [`Vec<ActorCell>`] with the member actors
-pub fn get_members_with_scope(scope: &ScopeName, group_name: &GroupName) -> Vec<ActorCell> {
+pub fn get_members_with_named_scope(scope: &ScopeName, group_name: &GroupName) -> Vec<ActorCell> {
     let monitor = get_monitor();
     if let Some(actors) = monitor.map.get(&(scope.to_owned(), group_name.to_owned())) {
         actors.value().values().cloned().collect::<Vec<_>>()

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -251,10 +251,10 @@ async fn test_pg_monitoring() {
         ) -> Result<(), ActorProcessingErr> {
             if let SupervisionEvent::ProcessGroupChanged(change) = message {
                 match change {
-                    pg::GroupChangeMessage::Join(_which, who) => {
+                    pg::GroupChangeMessage::Join(_scope, _which, who) => {
                         self.counter.fetch_add(who.len() as u8, Ordering::Relaxed);
                     }
-                    pg::GroupChangeMessage::Leave(_which, who) => {
+                    pg::GroupChangeMessage::Leave(_scope, _which, who) => {
                         self.counter.fetch_sub(who.len() as u8, Ordering::Relaxed);
                     }
                 }

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -52,6 +52,13 @@ async fn test_basic_group() {
     handle.await.expect("Actor cleanup failed");
 }
 
+#[crate::concurrency::test]
+#[tracing_test::traced_test]
+#[allow(unused_variables)]
+async fn test_default_scope() {
+    todo!();
+}
+
 #[named]
 #[crate::concurrency::test]
 #[tracing_test::traced_test]
@@ -87,6 +94,13 @@ async fn test_multiple_members_in_group() {
     for handle in handles.into_iter() {
         handle.await.expect("Actor cleanup failed");
     }
+}
+
+#[crate::concurrency::test]
+#[tracing_test::traced_test]
+#[allow(unused_variables)]
+async fn test_multiple_members_in_scope() {
+    todo!();
 }
 
 #[named]
@@ -134,6 +148,13 @@ async fn test_multiple_groups() {
     }
 }
 
+#[crate::concurrency::test]
+#[tracing_test::traced_test]
+#[allow(unused_variables)]
+async fn test_multiple_scopes() {
+    todo!();
+}
+
 #[named]
 #[crate::concurrency::test]
 #[tracing_test::traced_test]
@@ -157,6 +178,13 @@ async fn test_actor_leaves_pg_group_on_shutdown() {
 
     let members = pg::get_members(&group);
     assert_eq!(0, members.len());
+}
+
+#[crate::concurrency::test]
+#[tracing_test::traced_test]
+#[allow(unused_variables)]
+async fn test_actor_leaves_scope_on_shupdown() {
+    todo!();
 }
 
 #[named]
@@ -193,6 +221,13 @@ async fn test_actor_leaves_pg_group_manually() {
     // Cleanup
     actor.stop(None);
     handle.await.expect("Actor cleanup failed");
+}
+
+#[crate::concurrency::test]
+#[tracing_test::traced_test]
+#[allow(unused_variables)]
+async fn test_actor_leaves_scope_manually() {
+    todo!();
 }
 
 #[named]
@@ -300,6 +335,7 @@ async fn test_pg_monitoring() {
     monitor_handle.await.expect("Actor cleanup failed");
 }
 
+//TODO: Add scopes
 #[named]
 #[cfg(feature = "cluster")]
 #[crate::concurrency::test]

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -34,7 +34,7 @@ impl Actor for TestActor {
 #[named]
 #[crate::concurrency::test]
 #[tracing_test::traced_test]
-async fn test_basic_group() {
+async fn test_basic_group_in_default_scope() {
     let (actor, handle) = Actor::spawn(None, TestActor, ())
         .await
         .expect("Failed to spawn test actor");
@@ -335,7 +335,13 @@ async fn test_pg_monitoring() {
     monitor_handle.await.expect("Actor cleanup failed");
 }
 
-//TODO: Add scopes
+#[crate::concurrency::test]
+#[tracing_test::traced_test]
+#[allow(unused_variables)]
+async fn test_scope_monitoring() {
+    todo!()
+}
+
 #[named]
 #[cfg(feature = "cluster")]
 #[crate::concurrency::test]
@@ -404,4 +410,12 @@ async fn local_vs_remote_pg_members() {
     for handle in handles.into_iter() {
         handle.await.expect("Actor cleanup failed");
     }
+}
+
+#[cfg(feature = "cluster")]
+#[crate::concurrency::test]
+#[tracing_test::traced_test]
+#[allow(unused_variables)]
+async fn local_vs_remote_pg_members_in_named_scopes() {
+    todo!();
 }

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -64,15 +64,53 @@ async fn test_basic_group_in_named_scope() {
     let group = function_name!().to_string();
 
     // join the group
-    pg::join_with_named_scope(scope.clone(), group.clone(), vec![actor.clone().into()]);
+    pg::join_scoped(scope.clone(), group.clone(), vec![actor.clone().into()]);
 
-    let members = pg::get_members_with_named_scope(&scope, &group);
+    let members = pg::get_scoped_members(&scope, &group);
     assert_eq!(1, members.len());
 
     // Cleanup
     actor.stop(None);
     handle.await.expect("Actor cleanup failed");
 }
+
+// #[named]
+// #[crate::concurrency::test]
+// #[tracing_test::traced_test]
+// async fn test_which_scopes_and_groups() {
+//     let (actor, handle) = Actor::spawn(None, TestActor, ())
+//         .await
+//         .expect("Failed to spawn test actor");
+
+//     let scope_a = concat!(function_name!(), "_a").to_string();
+//     let scope_b = concat!(function_name!(), "_b").to_string();
+//     let group_a = concat!(function_name!(), "_a").to_string();
+//     let group_b = concat!(function_name!(), "_b").to_string();
+
+//     // join all scopes twice with each group
+//     let scope_group = [
+//         (scope_a.clone(), group_a.clone()),
+//         (scope_a.clone(), group_b.clone()),
+//         (scope_b.clone(), group_a.clone()),
+//         (scope_b.clone(), group_b.clone()),
+//     ];
+
+//     for (scope, group) in scope_group.iter() {
+//         pg::join_scoped(scope.clone(), group.clone(), vec![actor.clone().into()]);
+//         pg::join_scoped(scope.clone(), group.clone(), vec![actor.clone().into()]);
+//     }
+
+//     let scopes_and_groups = which_scopes_and_groups();
+//     println!("Scopes and groups are: {:#?}", scopes_and_groups);
+//     assert_eq!(4, scopes_and_groups.len());
+
+//     // Cleanup
+//     actor.stop(None);
+//     handle.await.expect("Actor cleanup failed");
+
+//     let scopes_and_groups = which_scopes_and_groups();
+//     assert!(scopes_and_groups.is_empty());
+// }
 
 #[named]
 #[crate::concurrency::test]
@@ -114,7 +152,7 @@ async fn test_multiple_members_in_group() {
 #[named]
 #[crate::concurrency::test]
 #[tracing_test::traced_test]
-async fn test_multiple_members_in_group_in_named_scope() {
+async fn test_multiple_members_in_scoped_group() {
     let scope = function_name!().to_string();
     let group = function_name!().to_string();
 
@@ -129,7 +167,7 @@ async fn test_multiple_members_in_group_in_named_scope() {
     }
 
     // join the group
-    pg::join_with_named_scope(
+    pg::join_scoped(
         scope.clone(),
         group.clone(),
         actors
@@ -138,7 +176,7 @@ async fn test_multiple_members_in_group_in_named_scope() {
             .collect::<Vec<_>>(),
     );
 
-    let members = pg::get_members_with_named_scope(&scope, &group);
+    let members = pg::get_scoped_members(&scope, &group);
     assert_eq!(10, members.len());
 
     // Cleanup
@@ -153,7 +191,7 @@ async fn test_multiple_members_in_group_in_named_scope() {
 #[named]
 #[crate::concurrency::test]
 #[tracing_test::traced_test]
-async fn test_which_groups_in_named_scope() {
+async fn test_which_scoped_groups() {
     let scope = function_name!().to_string();
     let group = function_name!().to_string();
 
@@ -168,7 +206,7 @@ async fn test_which_groups_in_named_scope() {
     }
 
     // join the group
-    pg::join_with_named_scope(
+    pg::join_scoped(
         scope.clone(),
         group.clone(),
         actors
@@ -177,7 +215,7 @@ async fn test_which_groups_in_named_scope() {
             .collect::<Vec<_>>(),
     );
 
-    let groups_in_scope = pg::which_groups_in_named_scope(&scope);
+    let groups_in_scope = pg::which_scoped_groups(&scope);
     assert_eq!(vec![scope.clone()], groups_in_scope);
 
     // Cleanup
@@ -259,36 +297,36 @@ async fn test_multiple_groups_in_multiple_scopes() {
         .iter()
         .map(|a| a.clone().get_cell())
         .collect::<Vec<_>>();
-    pg::join_with_named_scope(scope_a.clone(), group_a.clone(), these_actors);
+    pg::join_scoped(scope_a.clone(), group_a.clone(), these_actors);
 
     let these_actors = actors[5..10]
         .iter()
         .map(|a| a.clone().get_cell())
         .collect::<Vec<_>>();
-    pg::join_with_named_scope(scope_a.clone(), group_b.clone(), these_actors);
+    pg::join_scoped(scope_a.clone(), group_b.clone(), these_actors);
 
     let these_actors = actors[0..5]
         .iter()
         .map(|a| a.clone().get_cell())
         .collect::<Vec<_>>();
-    pg::join_with_named_scope(scope_b.clone(), group_a.clone(), these_actors);
+    pg::join_scoped(scope_b.clone(), group_a.clone(), these_actors);
 
     let these_actors = actors[5..10]
         .iter()
         .map(|a| a.clone().get_cell())
         .collect::<Vec<_>>();
-    pg::join_with_named_scope(scope_b.clone(), group_b.clone(), these_actors);
+    pg::join_scoped(scope_b.clone(), group_b.clone(), these_actors);
 
-    let members = pg::get_members_with_named_scope(&scope_a, &group_a);
+    let members = pg::get_scoped_members(&scope_a, &group_a);
     assert_eq!(5, members.len());
 
-    let members = pg::get_members_with_named_scope(&scope_a, &group_b);
+    let members = pg::get_scoped_members(&scope_a, &group_b);
     assert_eq!(5, members.len());
 
-    let members = pg::get_members_with_named_scope(&scope_b, &group_a);
+    let members = pg::get_scoped_members(&scope_b, &group_a);
     assert_eq!(5, members.len());
 
-    let members = pg::get_members_with_named_scope(&scope_b, &group_b);
+    let members = pg::get_scoped_members(&scope_b, &group_b);
     assert_eq!(5, members.len());
 
     // Cleanup
@@ -337,9 +375,9 @@ async fn test_actor_leaves_scope_on_shupdown() {
     let group = function_name!().to_string();
 
     // join the scope and group
-    pg::join_with_named_scope(scope.clone(), group.clone(), vec![actor.clone().into()]);
+    pg::join_scoped(scope.clone(), group.clone(), vec![actor.clone().into()]);
 
-    let members = pg::get_members_with_named_scope(&scope, &group);
+    let members = pg::get_scoped_members(&scope, &group);
     assert_eq!(1, members.len());
 
     // Cleanup
@@ -347,7 +385,7 @@ async fn test_actor_leaves_scope_on_shupdown() {
     handle.await.expect("Actor cleanup failed");
     drop(actor);
 
-    let members = pg::get_members_with_named_scope(&scope, &group);
+    let members = pg::get_scoped_members(&scope, &group);
     assert_eq!(0, members.len());
 }
 
@@ -399,7 +437,7 @@ async fn test_actor_leaves_scope_manually() {
         .expect("Failed to spawn test actor");
 
     // join the group in scope (create on first use)
-    pg::join_with_named_scope(scope.clone(), group.clone(), vec![actor.clone().into()]);
+    pg::join_scoped(scope.clone(), group.clone(), vec![actor.clone().into()]);
 
     // the scope was created and is present
     let scopes = pg::which_scopes();
@@ -409,11 +447,11 @@ async fn test_actor_leaves_scope_manually() {
     let groups = pg::which_groups();
     assert!(groups.contains(&group));
 
-    let members = pg::get_members_with_named_scope(&scope, &group);
+    let members = pg::get_scoped_members(&scope, &group);
     assert_eq!(1, members.len());
 
     // leave the group
-    pg::leave_with_named_scope(scope.clone(), group.clone(), vec![actor.clone().into()]);
+    pg::leave_scoped(scope.clone(), group.clone(), vec![actor.clone().into()]);
 
     // pif-paf-poof the scope is gone!
     let scopes = pg::which_scopes();
@@ -424,7 +462,7 @@ async fn test_actor_leaves_scope_manually() {
     assert!(!groups.contains(&group));
 
     // members comes back empty
-    let members = pg::get_members_with_named_scope(&scope, &group);
+    let members = pg::get_scoped_members(&scope, &group);
     assert_eq!(0, members.len());
 
     // Cleanup
@@ -562,7 +600,7 @@ async fn test_scope_monitoring() {
             myself: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
-            pg::join_with_named_scope(
+            pg::join_scoped(
                 self.scope.clone(),
                 self.pg_group.clone(),
                 vec![myself.into()],
@@ -800,13 +838,13 @@ async fn local_vs_remote_pg_members_in_named_scopes() {
     handles.push(handle);
 
     // join the group in scope
-    pg::join_with_named_scope(scope.clone(), group.clone(), actors.to_vec());
+    pg::join_scoped(scope.clone(), group.clone(), actors.to_vec());
 
     // assert
-    let members = pg::get_local_members_with_named_scope(&scope, &group);
+    let members = pg::get_scoped_local_members(&scope, &group);
     assert_eq!(10, members.len());
 
-    let members = pg::get_members_with_named_scope(&scope, &group);
+    let members = pg::get_scoped_members(&scope, &group);
     assert_eq!(11, members.len());
 
     // Cleanup

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -66,7 +66,7 @@ async fn test_basic_group_in_named_scope() {
     // join the group
     pg::join_with_named_scope(scope.clone(), group.clone(), vec![actor.clone().into()]);
 
-    let members = pg::get_members_with_scope(&scope, &group);
+    let members = pg::get_members_with_named_scope(&scope, &group);
     assert_eq!(1, members.len());
 
     // Cleanup
@@ -138,7 +138,7 @@ async fn test_multiple_members_in_group_in_named_scope() {
             .collect::<Vec<_>>(),
     );
 
-    let members = pg::get_members_with_scope(&scope, &group);
+    let members = pg::get_members_with_named_scope(&scope, &group);
     assert_eq!(10, members.len());
 
     // Cleanup
@@ -279,16 +279,16 @@ async fn test_multiple_groups_in_multiple_scopes() {
         .collect::<Vec<_>>();
     pg::join_with_named_scope(scope_b.clone(), group_b.clone(), these_actors);
 
-    let members = pg::get_members_with_scope(&scope_a, &group_a);
+    let members = pg::get_members_with_named_scope(&scope_a, &group_a);
     assert_eq!(5, members.len());
 
-    let members = pg::get_members_with_scope(&scope_a, &group_b);
+    let members = pg::get_members_with_named_scope(&scope_a, &group_b);
     assert_eq!(5, members.len());
 
-    let members = pg::get_members_with_scope(&scope_b, &group_a);
+    let members = pg::get_members_with_named_scope(&scope_b, &group_a);
     assert_eq!(5, members.len());
 
-    let members = pg::get_members_with_scope(&scope_b, &group_b);
+    let members = pg::get_members_with_named_scope(&scope_b, &group_b);
     assert_eq!(5, members.len());
 
     // Cleanup
@@ -339,7 +339,7 @@ async fn test_actor_leaves_scope_on_shupdown() {
     // join the scope and group
     pg::join_with_named_scope(scope.clone(), group.clone(), vec![actor.clone().into()]);
 
-    let members = pg::get_members_with_scope(&scope, &group);
+    let members = pg::get_members_with_named_scope(&scope, &group);
     assert_eq!(1, members.len());
 
     // Cleanup
@@ -347,7 +347,7 @@ async fn test_actor_leaves_scope_on_shupdown() {
     handle.await.expect("Actor cleanup failed");
     drop(actor);
 
-    let members = pg::get_members_with_scope(&scope, &group);
+    let members = pg::get_members_with_named_scope(&scope, &group);
     assert_eq!(0, members.len());
 }
 
@@ -409,7 +409,7 @@ async fn test_actor_leaves_scope_manually() {
     let groups = pg::which_groups();
     assert!(groups.contains(&group));
 
-    let members = pg::get_members_with_scope(&scope, &group);
+    let members = pg::get_members_with_named_scope(&scope, &group);
     assert_eq!(1, members.len());
 
     // leave the group
@@ -424,7 +424,7 @@ async fn test_actor_leaves_scope_manually() {
     assert!(!groups.contains(&group));
 
     // members comes back empty
-    let members = pg::get_members_with_scope(&scope, &group);
+    let members = pg::get_members_with_named_scope(&scope, &group);
     assert_eq!(0, members.len());
 
     // Cleanup
@@ -803,10 +803,10 @@ async fn local_vs_remote_pg_members_in_named_scopes() {
     pg::join_with_named_scope(scope.clone(), group.clone(), actors.to_vec());
 
     // assert
-    let members = pg::get_local_members_with_scope(&scope, &group);
+    let members = pg::get_local_members_with_named_scope(&scope, &group);
     assert_eq!(10, members.len());
 
-    let members = pg::get_members_with_scope(&scope, &group);
+    let members = pg::get_members_with_named_scope(&scope, &group);
     assert_eq!(11, members.len());
 
     // Cleanup

--- a/ractor_cluster/src/node/node_session/mod.rs
+++ b/ractor_cluster/src/node/node_session/mod.rs
@@ -682,6 +682,11 @@ impl NodeSession {
             state.tcp_send_control(msg);
         }
 
+        // setup scope monitoring
+        ractor::pg::monitor_scope(
+            ractor::pg::ALL_SCOPES_NOTIFICATION.to_string(),
+            myself.get_cell(),
+        );
         // setup PG monitoring
         ractor::pg::monitor(
             ractor::pg::ALL_GROUPS_NOTIFICATION.to_string(),
@@ -874,6 +879,10 @@ impl Actor for NodeSession {
         _state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
         // unhook monitoring sessions
+        ractor::pg::demonitor_scope(
+            ractor::pg::ALL_SCOPES_NOTIFICATION.to_string(),
+            myself.get_id(),
+        );
         ractor::pg::demonitor(
             ractor::pg::ALL_GROUPS_NOTIFICATION.to_string(),
             myself.get_id(),

--- a/ractor_cluster/src/node/node_session/mod.rs
+++ b/ractor_cluster/src/node/node_session/mod.rs
@@ -12,7 +12,7 @@ use std::convert::TryInto;
 use std::net::SocketAddr;
 
 use ractor::message::SerializedMessage;
-use ractor::pg::{GroupChangeMessage, DEFAULT_SCOPE};
+use ractor::pg::{which_scopes_and_groups, GroupChangeMessage};
 use ractor::registry::PidLifecycleEvent;
 use ractor::rpc::CallResult;
 use ractor::{Actor, ActorId, ActorProcessingErr, ActorRef, SpawnErr, SupervisionEvent};
@@ -688,12 +688,10 @@ impl NodeSession {
             myself.get_cell(),
         );
 
-        // Scan all PG groups + synchronize them
-        let groups = ractor::pg::which_groups();
-        // TODO: Add this for all scopes!
-        let scope = DEFAULT_SCOPE;
-        for group in groups {
-            let local_members = ractor::pg::get_local_members(&group)
+        // Scan all scopes with their PG groups + synchronize them
+        let scopes_and_groups = which_scopes_and_groups();
+        for (scope, group) in scopes_and_groups {
+            let local_members = ractor::pg::get_local_members_with_scope(&scope, &group)
                 .into_iter()
                 .filter(|v| v.supports_remoting())
                 .map(|act| control_protocol::Actor {

--- a/ractor_cluster/src/node/node_session/mod.rs
+++ b/ractor_cluster/src/node/node_session/mod.rs
@@ -12,7 +12,7 @@ use std::convert::TryInto;
 use std::net::SocketAddr;
 
 use ractor::message::SerializedMessage;
-use ractor::pg::{GroupChangeMessage, Scope};
+use ractor::pg::{GroupChangeMessage, DEFAULT_SCOPE};
 use ractor::registry::PidLifecycleEvent;
 use ractor::rpc::CallResult;
 use ractor::{Actor, ActorId, ActorProcessingErr, ActorRef, SpawnErr, SupervisionEvent};
@@ -691,7 +691,7 @@ impl NodeSession {
         // Scan all PG groups + synchronize them
         let groups = ractor::pg::which_groups();
         // TODO: Add this for all scopes!
-        let scope = Scope::Default;
+        let scope = DEFAULT_SCOPE;
         for group in groups {
             let local_members = ractor::pg::get_local_members(&group)
                 .into_iter()
@@ -705,7 +705,7 @@ impl NodeSession {
                 let control_message = control_protocol::ControlMessage {
                     msg: Some(control_protocol::control_message::Msg::PgJoin(
                         control_protocol::PgJoin {
-                            scope: scope.as_str(),
+                            scope: scope.to_owned(),
                             group,
                             actors: local_members,
                         },
@@ -1014,7 +1014,7 @@ impl Actor for NodeSession {
                         let msg = control_protocol::ControlMessage {
                             msg: Some(control_protocol::control_message::Msg::PgJoin(
                                 control_protocol::PgJoin {
-                                    scope: scope.as_str(),
+                                    scope,
                                     group,
                                     actors: filtered,
                                 },
@@ -1036,7 +1036,7 @@ impl Actor for NodeSession {
                         let msg = control_protocol::ControlMessage {
                             msg: Some(control_protocol::control_message::Msg::PgLeave(
                                 control_protocol::PgLeave {
-                                    scope: scope.as_str(),
+                                    scope,
                                     group,
                                     actors: filtered,
                                 },

--- a/ractor_cluster/src/node/node_session/mod.rs
+++ b/ractor_cluster/src/node/node_session/mod.rs
@@ -696,7 +696,7 @@ impl NodeSession {
         // Scan all scopes with their PG groups + synchronize them
         let scopes_and_groups = which_scopes_and_groups();
         for (scope, group) in scopes_and_groups {
-            let local_members = ractor::pg::get_local_members_with_scope(&scope, &group)
+            let local_members = ractor::pg::get_local_members_with_named_scope(&scope, &group)
                 .into_iter()
                 .filter(|v| v.supports_remoting())
                 .map(|act| control_protocol::Actor {

--- a/ractor_cluster/src/node/node_session/mod.rs
+++ b/ractor_cluster/src/node/node_session/mod.rs
@@ -12,7 +12,7 @@ use std::convert::TryInto;
 use std::net::SocketAddr;
 
 use ractor::message::SerializedMessage;
-use ractor::pg::{which_scopes_and_groups, GroupChangeMessage};
+use ractor::pg::{get_scoped_local_members, which_scopes_and_groups, GroupChangeMessage};
 use ractor::registry::PidLifecycleEvent;
 use ractor::rpc::CallResult;
 use ractor::{Actor, ActorId, ActorProcessingErr, ActorRef, SpawnErr, SupervisionEvent};
@@ -696,7 +696,7 @@ impl NodeSession {
         // Scan all scopes with their PG groups + synchronize them
         let scopes_and_groups = which_scopes_and_groups();
         for (scope, group) in scopes_and_groups {
-            let local_members = ractor::pg::get_local_members_with_named_scope(&scope, &group)
+            let local_members = get_scoped_local_members(&scope, &group)
                 .into_iter()
                 .filter(|v| v.supports_remoting())
                 .map(|act| control_protocol::Actor {

--- a/ractor_cluster/src/node/node_session/mod.rs
+++ b/ractor_cluster/src/node/node_session/mod.rs
@@ -690,6 +690,7 @@ impl NodeSession {
 
         // Scan all PG groups + synchronize them
         let groups = ractor::pg::which_groups();
+        // TODO: Add this for all scopes!
         let scope = Scope::Default;
         for group in groups {
             let local_members = ractor::pg::get_local_members(&group)

--- a/ractor_cluster/src/node/node_session/mod.rs
+++ b/ractor_cluster/src/node/node_session/mod.rs
@@ -695,8 +695,8 @@ impl NodeSession {
 
         // Scan all scopes with their PG groups + synchronize them
         let scopes_and_groups = which_scopes_and_groups();
-        for (scope, group) in scopes_and_groups {
-            let local_members = get_scoped_local_members(&scope, &group)
+        for key in scopes_and_groups {
+            let local_members = get_scoped_local_members(&key.get_scope(), &key.get_group())
                 .into_iter()
                 .filter(|v| v.supports_remoting())
                 .map(|act| control_protocol::Actor {
@@ -708,8 +708,8 @@ impl NodeSession {
                 let control_message = control_protocol::ControlMessage {
                     msg: Some(control_protocol::control_message::Msg::PgJoin(
                         control_protocol::PgJoin {
-                            scope: scope.to_owned(),
-                            group,
+                            scope: key.get_scope(),
+                            group: key.get_group(),
                             actors: local_members,
                         },
                     )),

--- a/ractor_cluster/src/node/node_session/tests.rs
+++ b/ractor_cluster/src/node/node_session/tests.rs
@@ -11,7 +11,6 @@ use std::sync::{
 };
 
 use ractor::concurrency::sleep;
-use ractor::pg::Scope;
 
 use crate::node::NodeConnectionMode;
 use crate::NodeSessionMessage;
@@ -761,7 +760,7 @@ async fn node_session_handle_control() {
         .expect("Failed to process control message");
     assert_eq!(0, state.remote_actors.len());
 
-    let scope_name = Scope::Named(String::from("node_session_test_scope"));
+    let scope_name = "node_session_test_scope";
     let group_name = "node_session_handle_control";
 
     // check pg join spawns + joins to a pg group
@@ -771,7 +770,7 @@ async fn node_session_handle_control() {
             control_protocol::ControlMessage {
                 msg: Some(control_protocol::control_message::Msg::PgJoin(
                     control_protocol::PgJoin {
-                        scope: scope_name.as_str(),
+                        scope: scope_name.to_string(),
                         group: group_name.to_string(),
                         actors: vec![control_protocol::Actor {
                             name: None,
@@ -801,7 +800,7 @@ async fn node_session_handle_control() {
             control_protocol::ControlMessage {
                 msg: Some(control_protocol::control_message::Msg::PgLeave(
                     control_protocol::PgLeave {
-                        scope: scope_name.as_str(),
+                        scope: scope_name.to_string(),
                         group: group_name.to_string(),
                         actors: vec![control_protocol::Actor {
                             name: None,

--- a/ractor_cluster/src/node/node_session/tests.rs
+++ b/ractor_cluster/src/node/node_session/tests.rs
@@ -11,6 +11,7 @@ use std::sync::{
 };
 
 use ractor::concurrency::sleep;
+use ractor::pg::Scope;
 
 use crate::node::NodeConnectionMode;
 use crate::NodeSessionMessage;
@@ -760,6 +761,7 @@ async fn node_session_handle_control() {
         .expect("Failed to process control message");
     assert_eq!(0, state.remote_actors.len());
 
+    let scope_name = Scope::Named(String::from("node_session_test_scope"));
     let group_name = "node_session_handle_control";
 
     // check pg join spawns + joins to a pg group
@@ -769,6 +771,7 @@ async fn node_session_handle_control() {
             control_protocol::ControlMessage {
                 msg: Some(control_protocol::control_message::Msg::PgJoin(
                     control_protocol::PgJoin {
+                        scope: scope_name.as_str(),
                         group: group_name.to_string(),
                         actors: vec![control_protocol::Actor {
                             name: None,
@@ -798,6 +801,7 @@ async fn node_session_handle_control() {
             control_protocol::ControlMessage {
                 msg: Some(control_protocol::control_message::Msg::PgLeave(
                     control_protocol::PgLeave {
+                        scope: scope_name.as_str(),
                         group: group_name.to_string(),
                         actors: vec![control_protocol::Actor {
                             name: None,

--- a/ractor_cluster/src/protocol/control.proto
+++ b/ractor_cluster/src/protocol/control.proto
@@ -52,22 +52,22 @@ message Terminate {
 
 // Process group join occurred
 message PgJoin {
-    // the scope
-    string scope = 1;
     // The group
-    string group = 2;
+    string group = 1;
     // The actors
-    repeated Actor actors = 3;
+    repeated Actor actors = 2;
+    // the scope
+    string scope = 3;
 }
 
 // Process group leave occurred
 message PgLeave {
-    // the scope
-    string scope = 1;
     // The group
-    string group = 2;
+    string group = 1;
     // The actors
-    repeated Actor actors = 3;
+    repeated Actor actors = 2;
+    // The scope
+    string scope = 3;
 }
 
 // A collection of NodeSession endpoints

--- a/ractor_cluster/src/protocol/control.proto
+++ b/ractor_cluster/src/protocol/control.proto
@@ -52,18 +52,22 @@ message Terminate {
 
 // Process group join occurred
 message PgJoin {
+    // the scope
+    string scope = 1;
     // The group
-    string group = 1;
+    string group = 2;
     // The actors
-    repeated Actor actors = 2;
+    repeated Actor actors = 3;
 }
 
 // Process group leave occurred
 message PgLeave {
+    // the scope
+    string scope = 1;
     // The group
-    string group = 1;
+    string group = 2;
     // The actors
-    repeated Actor actors = 2;
+    repeated Actor actors = 3;
 }
 
 // A collection of NodeSession endpoints


### PR DESCRIPTION
Might resolve #31.

I went the proposed route with split functions and `(scope, group)` as an identifying tuple.
Couldn't find the mentioned protobuf OTW cluster protocol changes.

As this is my first-ever PR with 'real' code I suggest a more thorough look. My main concerns besides the API design are:
* correct handling of monitors, and adjacently,
* whether I should handle idempotency of received messages if an `ActorCell` is part of multiple scopes and groups. Couldn't find any mechanisms for the existing process group implementation, so I assume this is not necessary.

Thanks!

--
Edit: Regarding the code coverage: this seems to mostly stem from duplicated yet also previously untested logic due to the split function approach. The exception is the new `which_scopes_and_groups()` for which I can provide a test if desired - just a bit trickier when running tests concurrently. :)