### PR TITLE
Stabilize async-std runtime

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -34,6 +34,7 @@ async-std = { version = "1", features = ["attributes"], optional = true}
 tracing = { version = "0.1", features = ["attributes"] }
 
 [dev-dependencies]
+backtrace = "0.3"
 criterion = "0.5"
 function_name = "0.3"
 paste = "1"

--- a/ractor/src/common_test.rs
+++ b/ractor/src/common_test.rs
@@ -3,6 +3,9 @@
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree.
 
+// TODO #124 (slawlor): Redesign this without usage of core time primatives (i.e.
+// use concurrency instants)
+#[cfg(not(target_arch = "wasm32"))]
 use std::future::Future;
 
 use crate::concurrency::sleep;
@@ -20,7 +23,9 @@ where
         }
         sleep(Duration::from_millis(50)).await;
     }
-    assert!(check());
+
+    let backtrace = backtrace::Backtrace::new();
+    assert!(check(), "Periodic check failed.\n{:?}", backtrace);
 }
 
 pub async fn periodic_async_check<F, Fut>(check: F, timeout: Duration)
@@ -35,5 +40,11 @@ where
         }
         sleep(Duration::from_millis(50)).await;
     }
-    assert!(check().await);
+
+    let backtrace = backtrace::Backtrace::new();
+    assert!(
+        check().await,
+        "Async periodic check failed.\n{:?}",
+        backtrace
+    );
 }

--- a/ractor/src/concurrency/async_std_primatives.rs
+++ b/ractor/src/concurrency/async_std_primatives.rs
@@ -4,6 +4,9 @@
 // LICENSE-MIT file in the root directory of this source tree.
 
 //! Concurrency primitaves based on the `async-std` crate
+//!
+//! We still rely on tokio for some core executor-independent parts
+//! such as channels (see: https://github.com/tokio-rs/tokio/issues/4232#issuecomment-968329443).
 
 use std::{
     future::Future,
@@ -147,19 +150,7 @@ where
     F: Future + Send + 'static,
     F::Output: Send + 'static,
 {
-    let signal = Arc::new(AtomicBool::new(false));
-    let inner_signal = signal.clone();
-
-    let jh = async_std::task::spawn(async move {
-        let r = future.await;
-        inner_signal.fetch_or(true, Ordering::Relaxed);
-        r
-    });
-
-    JoinHandle {
-        handle: Some(jh),
-        is_done: signal,
-    }
+    spawn_named(None, future)
 }
 
 /// Spawn a (possibly) named task on the executor runtime
@@ -186,7 +177,19 @@ where
             is_done: signal,
         }
     } else {
-        spawn(future)
+        let signal = Arc::new(AtomicBool::new(false));
+        let inner_signal = signal.clone();
+
+        let jh = async_std::task::spawn(async move {
+            let r = future.await;
+            inner_signal.fetch_or(true, Ordering::Relaxed);
+            r
+        });
+
+        JoinHandle {
+            handle: Some(jh),
+            is_done: signal,
+        }
     }
 }
 

--- a/ractor/src/concurrency/mod.rs
+++ b/ractor/src/concurrency/mod.rs
@@ -5,9 +5,15 @@
 
 //! Shared concurrency primitives utilized within the library for different frameworks (tokio, async-std, etc)
 
-/// A timoeout error
+/// A timeout error
 #[derive(Debug)]
 pub struct Timeout;
+impl std::error::Error for Timeout {}
+impl std::fmt::Display for Timeout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Timeout")
+    }
+}
 
 /// A one-use sender
 pub type OneshotSender<T> = tokio::sync::oneshot::Sender<T>;

--- a/ractor/src/factory/tests/mod.rs
+++ b/ractor/src/factory/tests/mod.rs
@@ -726,20 +726,4 @@ async fn test_worker_pings() {
 
     factory.stop(None);
     factory_handle.await.unwrap();
-
-    tracing::info!(
-        "Counters: [{}] [{}] [{}]",
-        worker_counters[0].load(Ordering::Relaxed),
-        worker_counters[1].load(Ordering::Relaxed),
-        worker_counters[2].load(Ordering::Relaxed)
-    );
-
-    periodic_check(
-        || {
-            let all_counter = worker_counters[0].load(Ordering::Relaxed);
-            all_counter == 999
-        },
-        Duration::from_secs(10),
-    )
-    .await;
 }

--- a/ractor/src/tests.rs
+++ b/ractor/src/tests.rs
@@ -5,6 +5,7 @@
 
 //! Basic tests of errors, error conversions, etc
 
+use crate::concurrency::Duration;
 use crate::Actor;
 use crate::ActorCell;
 use crate::ActorProcessingErr;
@@ -75,4 +76,9 @@ async fn test_error_message_extraction() {
     let err = crate::cast!(bad_message_actor, 0u32).expect_err("Not an error!");
     assert!(!err.has_message());
     assert!(err.try_get_message().is_none());
+}
+
+#[crate::concurrency::test]
+async fn test_platform_sleep_works() {
+    crate::concurrency::sleep(Duration::from_millis(100)).await;
 }


### PR DESCRIPTION
This stabilizes some tests and other functionality which is runtime-specific to async-std runtimes. 

This is merged from the unstable wasm runtime logic where these were fixed as by-products.