### PR TITLE
Get Actor references from SupervisionEvent

### DIFF
--- a/ractor/src/actor/messages.rs
+++ b/ractor/src/actor/messages.rs
@@ -122,8 +122,8 @@ impl SupervisionEvent {
         }
     }
 
-    /// If this supervision event refers to an [Actor], return the [ActorCell]
-    /// for that [actor][Actor].
+    /// If this supervision event refers to an [Actor] lifecycle event, return
+    /// the [ActorCell] for that [actor][Actor].
     ///
     ///
     /// [ActorCell]: crate::ActorCell
@@ -137,10 +137,10 @@ impl SupervisionEvent {
         }
     }
 
-    /// If this supervision event refers to an [Actor], return the [ActorId]
-    /// for that [actor][Actor].
+    /// If this supervision event refers to an [Actor] lifecycle event, return
+    /// the [ActorId] for that [actor][Actor].
     ///
-    /// [ActorCell]: crate::ActorId
+    /// [ActorId]: crate::ActorId
     /// [Actor]: crate::Actor
     pub fn actor_id(&self) -> Option<super::actor_id::ActorId> {
         self.actor_cell().map(|cell| cell.get_id())

--- a/ractor/src/actor/messages.rs
+++ b/ractor/src/actor/messages.rs
@@ -121,6 +121,30 @@ impl SupervisionEvent {
             Self::PidLifecycleEvent(evt) => Self::PidLifecycleEvent(evt.clone()),
         }
     }
+
+    /// If this supervision event refers to an [Actor], return the [ActorCell]
+    /// for that [actor][Actor].
+    ///
+    ///
+    /// [ActorCell]: crate::ActorCell
+    /// [Actor]: crate::Actor
+    pub fn actor_cell(&self) -> Option<&super::actor_cell::ActorCell> {
+        match self {
+            Self::ActorStarted(who)
+            | Self::ActorPanicked(who, _)
+            | Self::ActorTerminated(who, _, _) => Some(who),
+            _ => None,
+        }
+    }
+
+    /// If this supervision event refers to an [Actor], return the [ActorId]
+    /// for that [actor][Actor].
+    ///
+    /// [ActorCell]: crate::ActorId
+    /// [Actor]: crate::Actor
+    pub fn actor_id(&self) -> Option<super::actor_id::ActorId> {
+        self.actor_cell().map(|cell| cell.get_id())
+    }
 }
 
 impl Debug for SupervisionEvent {


### PR DESCRIPTION
Add convenience methods on SupervisionEvent to quickly get the actor the event refers to.

I find myself frequently writing pattern matchers for the `SupervisionEvent` type, such as for tracing or other general supervision event handling. Here is one example from the code base I'm working with:

```rust
impl MyActor {
    #[tracing::instrument(skip_all, fields(actor.id = tracing::field::Empty, actor.name_pretty = tracing::field::Empty))]
    async fn handle_my_specialized_supervisor_evt(
        &self,
        myself: ActorRef<MyMessage>,
        message: SupervisionEvent,
        state: &mut MyState,
    ) -> Result<(), ActorProcessingErr> {
        use SupervisionEvent::*;
        if let (ActorPanicked(who, _) | ActorTerminated(who, _, _) | ActorStarted(who)) = &message {
            tracing::Span::current()
                .record("actor.name_pretty", tracing::field::debug(who))
                .record("actor.id", tracing::field::display(who.get_id()));
        }

        todo!() /* actual message handling */
    }
}
```

Here's another non-instrumentation-related message (using `if let` would be "cleaner", I think this is a copy-paste from the default `handle_supervision_evt` implementation):
```rust
impl MyActor {
    fn is_buildctl_runner_evt(
        &self,
        state: &mut BuildctlBuilderState,
        message: &SupervisionEvent,
    ) -> bool {
        use SupervisionEvent::*;
        match message {
            ActorPanicked(who, _) | ActorTerminated(who, _, _) | ActorStarted(who) => {
                state.managed_buildctl_builders.get_by_id(who.get_id()).is_some()
            }
            _ => false,
        }
    }
}
```
These could be rewritten, respectively, like the following (ignoring the mess that is field formatting with the `tracing` package...)
```rust
impl MyActor {
    #[tracing::instrument(skip_all, fields(
        actor.id = message.actor_id().map(tracing::field::display), 
        actor.name_pretty = message.actor_cell().map(tracing::field::debug)
    ))]
    async fn handle_my_specialized_supervisor_evt(
        &self,
        myself: ActorRef<MyMessage>,
        message: SupervisionEvent,
        state: &mut MyState,
    ) -> Result<(), ActorProcessingErr> {
        todo!() /* actual message handling */
    }
}
```

and (now with less pattern matching, at least?)
```rust
impl MyActor {
    fn is_buildctl_runner_evt(
        &self,
        state: &mut BuildctlBuilderState,
        message: &SupervisionEvent,
    ) -> bool {
        message
            .actor_id()
            .and_then(|id| state.managed_buildctl_builders.get_by_id(id))
            .is_some()
    }
}
```