### PR TITLE
`pg`: Add `ScopeName` -> `Vec<GroupName>` mapping

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -38,6 +38,7 @@ backtrace = "0.3"
 criterion = "0.5"
 function_name = "0.3"
 paste = "1"
+serial_test = "2.0.0"
 rand = "0.8"
 tokio = { version = "1", features = ["rt", "time", "sync", "macros", "rt-multi-thread", "tracing"] }
 tracing-glog = "0.3"

--- a/ractor/src/actor/messages.rs
+++ b/ractor/src/actor/messages.rs
@@ -121,6 +121,30 @@ impl SupervisionEvent {
             Self::PidLifecycleEvent(evt) => Self::PidLifecycleEvent(evt.clone()),
         }
     }
+
+    /// If this supervision event refers to an [Actor] lifecycle event, return
+    /// the [ActorCell] for that [actor][Actor].
+    ///
+    ///
+    /// [ActorCell]: crate::ActorCell
+    /// [Actor]: crate::Actor
+    pub fn actor_cell(&self) -> Option<&super::actor_cell::ActorCell> {
+        match self {
+            Self::ActorStarted(who)
+            | Self::ActorPanicked(who, _)
+            | Self::ActorTerminated(who, _, _) => Some(who),
+            _ => None,
+        }
+    }
+
+    /// If this supervision event refers to an [Actor] lifecycle event, return
+    /// the [ActorId] for that [actor][Actor].
+    ///
+    /// [ActorId]: crate::ActorId
+    /// [Actor]: crate::Actor
+    pub fn actor_id(&self) -> Option<super::actor_id::ActorId> {
+        self.actor_cell().map(|cell| cell.get_id())
+    }
 }
 
 impl Debug for SupervisionEvent {

--- a/ractor/src/pg/mod.rs
+++ b/ractor/src/pg/mod.rs
@@ -186,7 +186,7 @@ pub fn leave_scoped(scope: ScopeName, group: GroupName, actors: Vec<ActorCell>) 
                 mut_ref.remove(&actor.get_id());
             }
 
-            // the scope and group tuple is empty, remove it
+            // if the scope and group tuple is empty, remove it
             if mut_ref.is_empty() {
                 occupied.remove();
             }
@@ -376,7 +376,7 @@ pub fn which_scoped_groups(scope: &ScopeName) -> Vec<GroupName> {
 
 /// Returns a list of all known scope-group combinations.
 ///
-/// Returns a [`Vec<(ScopGroupKey)>`] representing all the registered
+/// Returns a [`Vec<ScopeGroupKey>`] representing all the registered
 /// combinations that form an identifying tuple
 pub fn which_scopes_and_groups() -> Vec<ScopeGroupKey> {
     let monitor = get_monitor();

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use crate::common_test::periodic_check;
 use crate::concurrency::Duration;
 use ::function_name::named;
+use serial_test::serial;
 
 use crate::{Actor, ActorProcessingErr, GroupName, ScopeName, SupervisionEvent};
 
@@ -74,43 +75,44 @@ async fn test_basic_group_in_named_scope() {
     handle.await.expect("Actor cleanup failed");
 }
 
-// #[named]
-// #[crate::concurrency::test]
-// #[tracing_test::traced_test]
-// async fn test_which_scopes_and_groups() {
-//     let (actor, handle) = Actor::spawn(None, TestActor, ())
-//         .await
-//         .expect("Failed to spawn test actor");
+#[named]
+#[serial]
+#[crate::concurrency::test]
+#[tracing_test::traced_test]
+async fn test_which_scopes_and_groups() {
+    let (actor, handle) = Actor::spawn(None, TestActor, ())
+        .await
+        .expect("Failed to spawn test actor");
 
-//     let scope_a = concat!(function_name!(), "_a").to_string();
-//     let scope_b = concat!(function_name!(), "_b").to_string();
-//     let group_a = concat!(function_name!(), "_a").to_string();
-//     let group_b = concat!(function_name!(), "_b").to_string();
+    let scope_a = concat!(function_name!(), "_a").to_string();
+    let scope_b = concat!(function_name!(), "_b").to_string();
+    let group_a = concat!(function_name!(), "_a").to_string();
+    let group_b = concat!(function_name!(), "_b").to_string();
 
-//     // join all scopes twice with each group
-//     let scope_group = [
-//         (scope_a.clone(), group_a.clone()),
-//         (scope_a.clone(), group_b.clone()),
-//         (scope_b.clone(), group_a.clone()),
-//         (scope_b.clone(), group_b.clone()),
-//     ];
+    // join all scopes twice with each group
+    let scope_group = [
+        (scope_a.clone(), group_a.clone()),
+        (scope_a.clone(), group_b.clone()),
+        (scope_b.clone(), group_a.clone()),
+        (scope_b.clone(), group_b.clone()),
+    ];
 
-//     for (scope, group) in scope_group.iter() {
-//         pg::join_scoped(scope.clone(), group.clone(), vec![actor.clone().into()]);
-//         pg::join_scoped(scope.clone(), group.clone(), vec![actor.clone().into()]);
-//     }
+    for (scope, group) in scope_group.iter() {
+        pg::join_scoped(scope.clone(), group.clone(), vec![actor.clone().into()]);
+        pg::join_scoped(scope.clone(), group.clone(), vec![actor.clone().into()]);
+    }
 
-//     let scopes_and_groups = which_scopes_and_groups();
-//     println!("Scopes and groups are: {:#?}", scopes_and_groups);
-//     assert_eq!(4, scopes_and_groups.len());
+    let scopes_and_groups = pg::which_scopes_and_groups();
+    // println!("Scopes and groups are: {:#?}", scopes_and_groups);
+    assert_eq!(4, scopes_and_groups.len());
 
-//     // Cleanup
-//     actor.stop(None);
-//     handle.await.expect("Actor cleanup failed");
+    // Cleanup
+    actor.stop(None);
+    handle.await.expect("Actor cleanup failed");
 
-//     let scopes_and_groups = which_scopes_and_groups();
-//     assert!(scopes_and_groups.is_empty());
-// }
+    let scopes_and_groups = pg::which_scopes_and_groups();
+    assert!(scopes_and_groups.is_empty());
+}
 
 #[named]
 #[crate::concurrency::test]
@@ -471,6 +473,7 @@ async fn test_actor_leaves_scope_manually() {
 }
 
 #[named]
+#[serial]
 #[crate::concurrency::test]
 #[tracing_test::traced_test]
 async fn test_pg_monitoring() {
@@ -576,6 +579,7 @@ async fn test_pg_monitoring() {
 }
 
 #[named]
+#[serial]
 #[crate::concurrency::test]
 #[tracing_test::traced_test]
 async fn test_scope_monitoring() {

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -218,7 +218,7 @@ async fn test_which_scoped_groups() {
     );
 
     let groups_in_scope = pg::which_scoped_groups(&scope);
-    assert_eq!(vec![scope.clone()], groups_in_scope);
+    assert_eq!(vec![group.clone()], groups_in_scope);
 
     // Cleanup
     for actor in actors {

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -418,6 +418,10 @@ async fn test_actor_leaves_pg_group_manually() {
     let groups = pg::which_groups();
     assert!(!groups.contains(&group));
 
+    // pif-paf-poof the group is gone from the monitor's index!
+    let scoped_groups = pg::which_scoped_groups(&group);
+    assert!(!scoped_groups.contains(&group));
+
     // members comes back empty
     let members = pg::get_members(&group);
     assert_eq!(0, members.len());
@@ -462,6 +466,10 @@ async fn test_actor_leaves_scope_manually() {
     // pif-paf-poof the group is gone!
     let groups = pg::which_groups();
     assert!(!groups.contains(&group));
+
+    // pif-paf-poof the group is gone from the monitor's index!
+    let scoped_groups = pg::which_scoped_groups(&group);
+    assert!(!scoped_groups.contains(&group));
 
     // members comes back empty
     let members = pg::get_scoped_members(&scope, &group);


### PR DESCRIPTION
Introduces an `index` field to the `PgState` struct to map `ScopeName` to `Vec<GroupName>`.

If this isn't what was in mind, I'd need another pointer :)
Would also be open to refactoring the index's value and the modules `Vec<...>`-method returns to `HashSet`s if that makes more sense.

--
Relating to https://github.com/slawlor/ractor/pull/177#discussion_r1363016547
> This is where having another index might be helpful, i.e. Scope -> Group name in a separate mapping. But that's an optimization that can be added in the future.

and https://github.com/slawlor/ractor/issues/184#issuecomment-1846273238

> I meant another global index linking the scopes to groups. So you could efficiently lookup the groups from a given scope. This would remove some scan operations but it is a minimal operation.




