### PR TITLE
`pg`: Add `ScopeName` -> `Vec<GroupName>` mapping

### DIFF
--- a/ractor/src/pg/mod.rs
+++ b/ractor/src/pg/mod.rs
@@ -246,7 +246,6 @@ pub fn leave_scoped(scope: ScopeName, group: GroupName, actors: Vec<ActorCell>) 
 pub(crate) fn leave_all(actor: ActorId) {
     let pg_monitor = get_monitor();
     let map = pg_monitor.map.clone();
-    // let index = pg_monitor.index.clone();
 
     let mut empty_scope_group_keys = vec![];
     let mut removal_events = HashMap::new();

--- a/ractor/src/pg/mod.rs
+++ b/ractor/src/pg/mod.rs
@@ -186,7 +186,7 @@ pub fn leave_scoped(scope: ScopeName, group: GroupName, actors: Vec<ActorCell>) 
                 mut_ref.remove(&actor.get_id());
             }
 
-            // the scope and group tuple is empty, remove it
+            // if the scope and group tuple is empty, remove it
             if mut_ref.is_empty() {
                 occupied.remove();
             }
@@ -376,7 +376,7 @@ pub fn which_scoped_groups(scope: &ScopeName) -> Vec<GroupName> {
 
 /// Returns a list of all known scope-group combinations.
 ///
-/// Returns a [`Vec<(ScopGroupKey)>`] representing all the registered
+/// Returns a [`Vec<ScopeGroupKey>`] representing all the registered
 /// combinations that form an identifying tuple
 pub fn which_scopes_and_groups() -> Vec<ScopeGroupKey> {
     let monitor = get_monitor();

--- a/ractor/src/pg/mod.rs
+++ b/ractor/src/pg/mod.rs
@@ -223,15 +223,15 @@ pub fn leave_scoped(scope: ScopeName, group: GroupName, actors: Vec<ActorCell>) 
             // if the scope and group tuple is empty, remove it
             if mut_ref.is_empty() {
                 occupied_map.remove();
+            }
 
-                // remove the group and possibly the scope from the monitor's index
-                if let Some(mut groups_in_scope) = monitor_idx {
-                    groups_in_scope.retain(|group_name| group_name != &group);
-                    if groups_in_scope.is_empty() {
-                        // drop the `RefMut` to prevent a `DashMap` deadlock
-                        drop(groups_in_scope);
-                        monitor.index.remove(&scope);
-                    }
+            // remove the group and possibly the scope from the monitor's index
+            if let Some(mut groups_in_scope) = monitor_idx {
+                groups_in_scope.retain(|group_name| group_name != &group);
+                if groups_in_scope.is_empty() {
+                    // drop the `RefMut` to prevent a `DashMap` deadlock
+                    drop(groups_in_scope);
+                    monitor.index.remove(&scope);
                 }
             }
 

--- a/ractor/src/pg/mod.rs
+++ b/ractor/src/pg/mod.rs
@@ -208,6 +208,7 @@ pub fn leave_scoped(scope: ScopeName, group: GroupName, actors: Vec<ActorCell>) 
                 if let Some(mut groups_in_scope) = monitor.index.get_mut(&scope) {
                     groups_in_scope.retain(|group_name| group_name != &group);
                     if groups_in_scope.is_empty() {
+                        // drop the `RefMut` to prevent a `DashMap` deadlock
                         drop(groups_in_scope);
                         monitor.index.remove(&scope);
                     }

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -218,7 +218,7 @@ async fn test_which_scoped_groups() {
     );
 
     let groups_in_scope = pg::which_scoped_groups(&scope);
-    assert_eq!(vec![scope.clone()], groups_in_scope);
+    assert_eq!(vec![group.clone()], groups_in_scope);
 
     // Cleanup
     for actor in actors {

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -418,6 +418,10 @@ async fn test_actor_leaves_pg_group_manually() {
     let groups = pg::which_groups();
     assert!(!groups.contains(&group));
 
+    // pif-paf-poof the group is gone from the monitor's index!
+    let scoped_groups = pg::which_scoped_groups(&group);
+    assert!(!scoped_groups.contains(&group));
+
     // members comes back empty
     let members = pg::get_members(&group);
     assert_eq!(0, members.len());
@@ -462,6 +466,10 @@ async fn test_actor_leaves_scope_manually() {
     // pif-paf-poof the group is gone!
     let groups = pg::which_groups();
     assert!(!groups.contains(&group));
+
+    // pif-paf-poof the group is gone from the monitor's index!
+    let scoped_groups = pg::which_scoped_groups(&group);
+    assert!(!scoped_groups.contains(&group));
 
     // members comes back empty
     let members = pg::get_scoped_members(&scope, &group);


### PR DESCRIPTION
Supersedes #189 and introduces an `index` field to the `PgState` struct to map `ScopeName` to `Vec<GroupName>`.

If this isn't what was in mind, I'd need another pointer :)
Would also be open to refactoring the index's value and the modules `Vec<...>`-method returns to `HashSet`s if that makes more sense.

And sorry for the PR noise :)

--
Relating to https://github.com/slawlor/ractor/pull/177#discussion_r1363016547

> This is where having another index might be helpful, i.e. Scope -> Group name in a separate mapping. But that's an optimization that can be added in the future.

and https://github.com/slawlor/ractor/issues/184#issuecomment-1846273238

> I meant another global index linking the scopes to groups. So you could efficiently lookup the groups from a given scope. This would remove some scan operations but it is a minimal operation.