### PR TITLE
Fix actor module documentation formatting

### DIFF
--- a/ractor/src/actor/mod.rs
+++ b/ractor/src/actor/mod.rs
@@ -21,6 +21,7 @@
 //!
 //! An example supervision tree may look like:
 //!
+//! ```text
 //! Root/
 //! ├─ Actor A/
 //! │  ├─ Actor A_1/
@@ -30,6 +31,7 @@
 //! │  ├─ Actor C_1/
 //! │  │  ├─ Actor C_1_1/
 //! │  │  │  ├─ Actor C_1_1_1/
+//! ```
 //!
 //! To link actors together in the supervision tree, there are 2 choices.
 //!


### PR DESCRIPTION
Adds text section annotation to actor module docs to fix formatting in docs.rs

before
<img width="973" alt="image" src="https://github.com/slawlor/ractor/assets/2771466/2dbb1e5a-094b-4099-86fd-5a7e00c446d3">

after
<img width="979" alt="image" src="https://github.com/slawlor/ractor/assets/2771466/1ca325e6-0e67-4ed1-b6ab-c594e3798d18">
