### PR TITLE
Minimize tokio dependence in async_std runtime and cleanup doc ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ A pure-Rust actor framework. Inspired from [Erlang's `gen_server`](https://www.e
 ## About
 
 `ractor` tries to solve the problem of building and maintaining an Erlang-like actor framework in Rust. It gives
-a set of generic primitives and helps automate the supervision tree and management of our actors along with the traditional actor message processing logic. It's built *heavily* on `tokio` which is a
-hard requirement for `ractor` (today).
+a set of generic primitives and helps automate the supervision tree and management of our actors along with the traditional actor message processing logic. It was originally designed to use the `tokio` runtime, however does now support the `async-std` runtime.
 
 `ractor` is a modern actor framework written in 100% Rust.
 
@@ -72,7 +71,7 @@ The minimum supported Rust version (MSRV) of `ractor` is `1.64`
 `ractor` exposes the following features:
 
 1. `cluster`, which exposes various functionality required for `ractor_cluster` to set up and manage a cluster of actors over a network link. This is work-in-progress and is being tracked in [#16](https://github.com/slawlor/ractor/issues/16).
-2. `async-std`, which enables usage of `async-std`'s asynchronous runtime instead of the `tokio` runtime. **However** `tokio` remains a dependency because we utilize the messaging synchronization primatives from `tokio` regardless of runtime as they are not specific to the `tokio` runtime. This work is tracked in [#173](https://github.com/slawlor/ractor/pull/173).
+2. `async-std`, which enables usage of `async-std`'s asynchronous runtime instead of the `tokio` runtime. **However** `tokio` with the `sync` feature remains a dependency because we utilize the messaging synchronization primatives from `tokio` regardless of runtime as they are not specific to the `tokio` runtime. This work is tracked in [#173](https://github.com/slawlor/ractor/pull/173). You can remove default features to "minimize" the tokio dependencies to just the synchronization primatives.
 
 ## Working with Actors
 

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -16,9 +16,10 @@ rust-version = "1.64"
 [features]
 ### Other features
 cluster = []
+tokio_runtime = ["tokio/time", "tokio/rt", "tokio/macros", "tokio/tracing"]
 
 # default = ["async-std"]
-default = []
+default = ["tokio_runtime"]
 
 [dependencies]
 ## Required dependencies
@@ -29,8 +30,8 @@ once_cell = "1"
 rand = "0.8"
 
 # Tracing feature requires --cfg=tokio_unstable
-tokio = { version = "1", features = ["sync", "time", "rt", "macros", "tracing"] }
-async-std = { version = "1", features = ["attributes"], optional = true}
+tokio = { version = "1", features = ["sync"] }
+async-std = { version = "1", features = ["attributes"], optional = true }
 tracing = { version = "0.1", features = ["attributes"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Closes #197 