### PR TITLE
Remove the need for the `async_trait` crate by leveraging the native `async fn`s support now in Rust as of v1.75

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ractor
 
 <p align="center">
-    <img src="https://raw.githubusercontent.com/slawlor/ractor/main/docs/ractor_logo.svg" width="50%" /> 
+    <img src="https://raw.githubusercontent.com/slawlor/ractor/main/docs/ractor_logo.svg" width="50%" />
 </p>
 
 *Pronounced ract-er*
@@ -64,7 +64,7 @@ Install `ractor` by adding the following to your Cargo.toml dependencies.
 ractor = "0.9"
 ```
 
-The minimum supported Rust version (MSRV) of `ractor` is `1.64`
+The minimum supported Rust version (MSRV) of `ractor` is `1.64`. However to utilize the native `async fn` support in traits and not rely on the `async-trait` crate's desugaring functionliaty, you need to be on Rust version `>= 1.75`. The stabilization of `async fn` in traits [was recently added](https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html).
 
 ## Features
 
@@ -81,7 +81,7 @@ never be executed in parallel. Following the actor model leads to microservices 
 An example `ping-pong` actor might be the following
 
 ```rust
-use ractor::{async_trait, cast, Actor, ActorProcessingErr, ActorRef};
+use ractor::{cast, Actor, ActorProcessingErr, ActorRef};
 
 /// [PingPong] is a basic actor that will print
 /// ping..pong.. repeatedly until some exit
@@ -114,7 +114,6 @@ impl Message {
 }
 
 // the implementation of our actor's "logic"
-#[async_trait]
 impl Actor for PingPong {
     // An actor has a message type
     type Msg = Message;

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -19,19 +19,20 @@ cluster = []
 tokio_runtime = ["tokio/time", "tokio/rt", "tokio/macros", "tokio/tracing"]
 
 # default = ["async-std"]
-default = ["tokio_runtime"]
+default = ["tokio_runtime", "async-trait"]
 
 [dependencies]
 ## Required dependencies
-async-trait = "0.1"
 dashmap = "5"
 futures = "0.3"
 once_cell = "1"
 rand = "0.8"
 
+## Configurable dependencies
 # Tracing feature requires --cfg=tokio_unstable
-tokio = { version = "1", features = ["sync"] }
 async-std = { version = "1", features = ["attributes"], optional = true }
+async-trait = { version = "0.1", optional = true }
+tokio = { version = "1", features = ["sync"] }
 tracing = { version = "0.1", features = ["attributes"] }
 
 [dev-dependencies]

--- a/ractor/benches/actor.rs
+++ b/ractor/benches/actor.rs
@@ -17,7 +17,7 @@ struct BenchActorMessage;
 #[cfg(feature = "cluster")]
 impl Message for BenchActorMessage {}
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
 impl Actor for BenchActor {
     type Msg = BenchActorMessage;
 
@@ -247,7 +247,7 @@ fn process_messages(c: &mut Criterion) {
         num_msgs: u64,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", ractor::async_trait)]
     impl Actor for MessagingActor {
         type Msg = BenchActorMessage;
 

--- a/ractor/examples/counter.rs
+++ b/ractor/examples/counter.rs
@@ -14,7 +14,7 @@
 
 extern crate ractor;
 
-use ractor::{async_trait, call_t, Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+use ractor::{call_t, Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
 
 struct Counter;
 
@@ -31,7 +31,7 @@ enum CounterMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for CounterMessage {}
 
-#[async_trait]
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
 impl Actor for Counter {
     type Msg = CounterMessage;
 

--- a/ractor/examples/monte_carlo.rs
+++ b/ractor/examples/monte_carlo.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 
-use ractor::{async_trait, cast, Actor, ActorId, ActorProcessingErr, ActorRef};
+use ractor::{cast, Actor, ActorId, ActorProcessingErr, ActorRef};
 use rand::{thread_rng, Rng};
 
 // ================== Player Actor ================== //
@@ -62,7 +62,7 @@ struct GameMessage(ActorRef<GameManagerMessage>);
 #[cfg(feature = "cluster")]
 impl ractor::Message for GameMessage {}
 
-#[async_trait]
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
 impl Actor for Game {
     type Msg = GameMessage;
 
@@ -139,7 +139,7 @@ impl GameManagerState {
     }
 }
 
-#[async_trait]
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
 impl Actor for GameManager {
     type Msg = GameManagerMessage;
 

--- a/ractor/examples/output_port.rs
+++ b/ractor/examples/output_port.rs
@@ -15,7 +15,7 @@ extern crate ractor;
 
 use std::sync::Arc;
 
-use ractor::{async_trait, Actor, ActorProcessingErr, ActorRef, OutputPort};
+use ractor::{Actor, ActorProcessingErr, ActorRef, OutputPort};
 use tokio::time::{timeout, Duration};
 
 enum PublisherMessage {
@@ -31,7 +31,7 @@ impl ractor::Message for Output {}
 
 struct Publisher;
 
-#[async_trait]
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
 impl Actor for Publisher {
     type Msg = PublisherMessage;
 
@@ -70,7 +70,7 @@ enum SubscriberMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for SubscriberMessage {}
 
-#[async_trait]
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
 impl Actor for Subscriber {
     type Msg = SubscriberMessage;
 

--- a/ractor/examples/philosophers.rs
+++ b/ractor/examples/philosophers.rs
@@ -20,9 +20,7 @@
 
 use std::collections::{HashMap, VecDeque};
 
-use ractor::{
-    async_trait, cast, Actor, ActorId, ActorName, ActorProcessingErr, ActorRef, RpcReplyPort,
-};
+use ractor::{cast, Actor, ActorId, ActorName, ActorProcessingErr, ActorRef, RpcReplyPort};
 use tokio::time::{Duration, Instant};
 
 // ============================ Fork Actor ============================ //
@@ -113,7 +111,7 @@ impl Fork {
     }
 }
 
-#[async_trait]
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
 impl Actor for Fork {
     type Msg = ForkMessage;
     type State = ForkState;
@@ -326,7 +324,7 @@ impl Philosopher {
     }
 }
 
-#[async_trait]
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
 impl Actor for Philosopher {
     type Msg = PhilosopherMessage;
     type State = PhilosopherState;

--- a/ractor/examples/ping_pong.rs
+++ b/ractor/examples/ping_pong.rs
@@ -14,7 +14,7 @@
 
 extern crate ractor;
 
-use ractor::{async_trait, cast, Actor, ActorProcessingErr, ActorRef};
+use ractor::{cast, Actor, ActorProcessingErr, ActorRef};
 
 pub struct PingPong;
 
@@ -42,7 +42,7 @@ impl Message {
     }
 }
 
-#[async_trait]
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
 impl Actor for PingPong {
     type Msg = Message;
 

--- a/ractor/examples/supervisor.rs
+++ b/ractor/examples/supervisor.rs
@@ -11,7 +11,7 @@
 //! cargo run --example supervisor
 //! ```
 
-use ractor::{async_trait, Actor, ActorProcessingErr, ActorRef, RpcReplyPort, SupervisionEvent};
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort, SupervisionEvent};
 
 use tokio::time::Duration;
 
@@ -97,7 +97,7 @@ enum LeafActorMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for LeafActorMessage {}
 
-#[async_trait]
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
 impl Actor for LeafActor {
     type Msg = LeafActorMessage;
     type State = LeafActorState;
@@ -160,7 +160,7 @@ enum MidLevelActorMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for MidLevelActorMessage {}
 
-#[async_trait]
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
 impl Actor for MidLevelActor {
     type Msg = MidLevelActorMessage;
     type State = MidLevelActorState;
@@ -240,7 +240,7 @@ enum RootActorMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for RootActorMessage {}
 
-#[async_trait]
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
 impl Actor for RootActor {
     type Msg = RootActorMessage;
     type State = RootActorState;

--- a/ractor/src/actor/tests/mod.rs
+++ b/ractor/src/actor/tests/mod.rs
@@ -27,7 +27,7 @@ impl crate::Message for EmptyMessage {}
 async fn test_panic_on_start_captured() {
     struct TestActor;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -51,7 +51,7 @@ async fn test_panic_on_start_captured() {
 async fn test_error_on_start_captured() {
     struct TestActor;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -79,7 +79,7 @@ async fn test_stop_higher_priority_over_messages() {
         counter: Arc<AtomicU8>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -154,7 +154,7 @@ async fn test_stop_higher_priority_over_messages() {
 async fn test_kill_terminates_work() {
     struct TestActor;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -200,7 +200,7 @@ async fn test_kill_terminates_work() {
 async fn test_stop_does_not_terminate_async_work() {
     struct TestActor;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -255,7 +255,7 @@ async fn test_stop_does_not_terminate_async_work() {
 async fn test_kill_terminates_supervision_work() {
     struct TestActor;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -305,7 +305,7 @@ async fn test_sending_message_to_invalid_actor_type() {
     struct TestMessage1;
     #[cfg(feature = "cluster")]
     impl crate::Message for TestMessage1 {}
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor1 {
         type Msg = TestMessage1;
         type State = ();
@@ -322,7 +322,7 @@ async fn test_sending_message_to_invalid_actor_type() {
     struct TestMessage2;
     #[cfg(feature = "cluster")]
     impl crate::Message for TestMessage2 {}
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor2 {
         type Msg = TestMessage2;
         type State = ();
@@ -361,7 +361,7 @@ async fn test_sending_message_to_invalid_actor_type() {
 async fn test_sending_message_to_dead_actor() {
     struct TestActor;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -419,7 +419,7 @@ async fn test_serialized_cast() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = TestMessage;
         type State = ();
@@ -549,7 +549,7 @@ async fn test_serialized_rpc() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = TestMessage;
         type State = ();
@@ -624,7 +624,7 @@ async fn test_remote_actor() {
     let counter = Arc::new(AtomicU8::new(0));
 
     struct DummySupervisor;
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for DummySupervisor {
         type Msg = ();
         type State = ();
@@ -659,7 +659,7 @@ async fn test_remote_actor() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestRemoteActor {
         type Msg = TestRemoteMessage;
         type State = ();
@@ -732,7 +732,7 @@ async fn spawning_local_actor_as_remote_fails() {
     struct RemoteActor;
     struct RemoteActorMessage;
     impl crate::Message for RemoteActorMessage {}
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for RemoteActor {
         type Msg = RemoteActorMessage;
         type State = ();
@@ -747,7 +747,7 @@ async fn spawning_local_actor_as_remote_fails() {
     }
 
     struct EmptyActor;
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for EmptyActor {
         type Msg = ();
         type State = ();
@@ -787,7 +787,7 @@ async fn instant_spawns() {
     let counter = Arc::new(AtomicU8::new(0));
 
     struct EmptyActor;
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for EmptyActor {
         type Msg = String;
         type State = Arc<AtomicU8>;
@@ -846,7 +846,7 @@ async fn instant_spawns() {
 #[tracing_test::traced_test]
 async fn stop_and_wait() {
     struct SlowActor;
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for SlowActor {
         type Msg = ();
         type State = ();
@@ -875,7 +875,7 @@ async fn stop_and_wait() {
 #[tracing_test::traced_test]
 async fn kill_and_wait() {
     struct SlowActor;
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for SlowActor {
         type Msg = ();
         type State = ();
@@ -916,7 +916,7 @@ fn returns_actor_references() {
 
     struct TestActor;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();

--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -25,7 +25,7 @@ async fn test_supervision_panic_in_post_startup() {
         flag: Arc<AtomicU64>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -46,7 +46,7 @@ async fn test_supervision_panic_in_post_startup() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -113,7 +113,7 @@ async fn test_supervision_error_in_post_startup() {
         flag: Arc<AtomicU64>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -134,7 +134,7 @@ async fn test_supervision_error_in_post_startup() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -201,7 +201,7 @@ async fn test_supervision_panic_in_handle() {
         flag: Arc<AtomicU64>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -223,7 +223,7 @@ async fn test_supervision_panic_in_handle() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -298,7 +298,7 @@ async fn test_supervision_error_in_handle() {
         flag: Arc<AtomicU64>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -320,7 +320,7 @@ async fn test_supervision_error_in_handle() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -395,7 +395,7 @@ async fn test_supervision_panic_in_post_stop() {
         flag: Arc<AtomicU64>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -418,7 +418,7 @@ async fn test_supervision_panic_in_post_stop() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -476,7 +476,7 @@ async fn test_supervision_error_in_post_stop() {
         flag: Arc<AtomicU64>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -499,7 +499,7 @@ async fn test_supervision_error_in_post_stop() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -560,7 +560,7 @@ async fn test_supervision_panic_in_supervisor_handle() {
         flag: Arc<AtomicU64>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -582,7 +582,7 @@ async fn test_supervision_panic_in_supervisor_handle() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Midpoint {
         type Msg = ();
         type State = ();
@@ -607,7 +607,7 @@ async fn test_supervision_panic_in_supervisor_handle() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -702,7 +702,7 @@ async fn test_supervision_error_in_supervisor_handle() {
         flag: Arc<AtomicU64>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Child {
         type Msg = ();
         type Arguments = ();
@@ -724,7 +724,7 @@ async fn test_supervision_error_in_supervisor_handle() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Midpoint {
         type Msg = ();
         type State = ();
@@ -749,7 +749,7 @@ async fn test_supervision_error_in_supervisor_handle() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -839,7 +839,7 @@ async fn test_killing_a_supervisor_terminates_children() {
     struct Child;
     struct Supervisor;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -853,7 +853,7 @@ async fn test_killing_a_supervisor_terminates_children() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -912,7 +912,7 @@ async fn instant_supervised_spawns() {
     let counter = Arc::new(AtomicU8::new(0));
 
     struct EmptySupervisor;
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for EmptySupervisor {
         type Msg = ();
         type State = ();
@@ -934,7 +934,7 @@ async fn instant_supervised_spawns() {
     }
 
     struct EmptyActor;
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for EmptyActor {
         type Msg = String;
         type State = Arc<AtomicU8>;
@@ -1008,7 +1008,7 @@ async fn test_supervisor_captures_dead_childs_state() {
         flag: Arc<AtomicU64>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Child {
         type Msg = ();
         type State = u64;
@@ -1030,7 +1030,7 @@ async fn test_supervisor_captures_dead_childs_state() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -1110,7 +1110,7 @@ async fn test_supervisor_captures_dead_childs_state() {
 async fn test_supervisor_double_link() {
     struct Who;
 
-    #[crate::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Who {
         type Msg = ();
         type State = ();
@@ -1155,7 +1155,7 @@ async fn test_simple_monitor() {
         counter: Arc<AtomicU8>,
     }
 
-    #[crate::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Peer {
         type Msg = ();
         type State = ();
@@ -1180,7 +1180,7 @@ async fn test_simple_monitor() {
         }
     }
 
-    #[crate::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Monitor {
         type Msg = ();
         type State = ();

--- a/ractor/src/factory/mod.rs
+++ b/ractor/src/factory/mod.rs
@@ -326,7 +326,7 @@ where
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "async-trait", crate::async_trait)]
 impl<TKey, TMsg, TWorker> Actor for Factory<TKey, TMsg, TWorker>
 where
     TKey: JobKey,

--- a/ractor/src/factory/tests/mod.rs
+++ b/ractor/src/factory/tests/mod.rs
@@ -57,7 +57,7 @@ struct TestWorker {
     slow: Option<u64>,
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "async-trait", crate::async_trait)]
 impl Actor for TestWorker {
     type Msg = super::WorkerMessage<TestKey, TestMessage>;
     type State = Self::Arguments;
@@ -563,7 +563,7 @@ struct StuckWorker {
     slow: Option<u64>,
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "async-trait", crate::async_trait)]
 impl Actor for StuckWorker {
     type Msg = super::WorkerMessage<TestKey, TestMessage>;
     type State = Self::Arguments;

--- a/ractor/src/factory/tests/worker_lifecycle.rs
+++ b/ractor/src/factory/tests/worker_lifecycle.rs
@@ -30,7 +30,7 @@ enum MyWorkerMessage {
 #[cfg(feature = "cluster")]
 impl Message for MyWorkerMessage {}
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "async-trait", crate::async_trait)]
 impl Actor for MyWorker {
     type State = Self::Arguments;
     type Msg = WorkerMessage<(), MyWorkerMessage>;

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -15,7 +15,8 @@
 //! ractor = "0.9"
 //! ```
 //!
-//! The minimum supported Rust version (MSRV) of `ractor` is `1.64`
+//! The minimum supported Rust version (MSRV) is 1.64. However if you disable the `async-trait` feature, then you need Rust >= 1.75 due to the native
+//! use of `async fn` in traits. See the [Rust blob](https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html).
 //!
 //! ## Getting started
 //!
@@ -57,7 +58,7 @@
 //! }
 //!
 //! // the implementation of our actor's "logic"
-//! #[async_trait::async_trait]
+//! #[cfg_attr(feature = "async-trait", ractor::async_trait)]
 //! impl Actor for PingPong {
 //!     // An actor has a message type
 //!     type Msg = Message;
@@ -183,6 +184,7 @@ pub use actor::actor_id::ActorId;
 pub use actor::actor_ref::ActorRef;
 pub use actor::messages::{Signal, SupervisionEvent};
 pub use actor::{Actor, ActorRuntime};
+#[cfg(feature = "async-trait")]
 pub use async_trait::async_trait;
 pub use errors::{ActorErr, ActorProcessingErr, MessagingErr, RactorErr, SpawnErr};
 pub use message::Message;

--- a/ractor/src/macros.rs
+++ b/ractor/src/macros.rs
@@ -33,7 +33,7 @@ macro_rules! cast {
 /// #[cfg(feature = "cluster")]
 /// impl ractor::Message for MessageFormat {}
 ///
-/// #[async_trait::async_trait]
+/// #[cfg_attr(feature = "async-trait", ractor::async_trait)]
 /// impl Actor for TestActor {
 ///     type Msg = MessageFormat;
 ///     type Arguments = ();
@@ -114,7 +114,7 @@ macro_rules! call {
 /// #[cfg(feature = "cluster")]
 /// impl ractor::Message for MessageFormat {}
 ///
-/// #[async_trait::async_trait]
+/// #[cfg_attr(feature = "async-trait", ractor::async_trait)]
 /// impl Actor for TestActor {
 ///     type Msg = MessageFormat;
 ///     type Arguments = ();

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -17,7 +17,7 @@ use crate::pg::{self};
 
 struct TestActor;
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "async-trait", crate::async_trait)]
 impl Actor for TestActor {
     type Msg = ();
     type Arguments = ();
@@ -493,7 +493,7 @@ async fn test_pg_monitoring() {
         pg_group: GroupName,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for AutoJoinActor {
         type Msg = ();
         type Arguments = ();
@@ -514,7 +514,7 @@ async fn test_pg_monitoring() {
         counter: Arc<AtomicU8>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for NotificationMonitor {
         type Msg = ();
         type Arguments = ();
@@ -601,7 +601,7 @@ async fn test_scope_monitoring() {
         pg_group: GroupName,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for AutoJoinActor {
         type Msg = ();
         type Arguments = ();
@@ -626,7 +626,7 @@ async fn test_scope_monitoring() {
         counter: Arc<AtomicU8>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for NotificationMonitor {
         type Msg = ();
         type Arguments = ();
@@ -739,7 +739,7 @@ async fn local_vs_remote_pg_members() {
     struct TestRemoteActor;
     struct TestRemoteActorMessage;
     impl crate::Message for TestRemoteActorMessage {}
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestRemoteActor {
         type Msg = TestRemoteActorMessage;
         type State = ();
@@ -810,7 +810,7 @@ async fn local_vs_remote_pg_members_in_named_scopes() {
     struct TestRemoteActor;
     struct TestRemoteActorMessage;
     impl crate::Message for TestRemoteActorMessage {}
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestRemoteActor {
         type Msg = TestRemoteActorMessage;
         type State = ();

--- a/ractor/src/port/output/tests.rs
+++ b/ractor/src/port/output/tests.rs
@@ -23,7 +23,7 @@ async fn test_single_forward() {
     }
     #[cfg(feature = "cluster")]
     impl crate::Message for TestActorMessage {}
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = TestActorMessage;
         type Arguments = ();
@@ -87,7 +87,7 @@ async fn test_50_receivers() {
     }
     #[cfg(feature = "cluster")]
     impl crate::Message for TestActorMessage {}
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = TestActorMessage;
         type Arguments = ();

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -14,7 +14,7 @@ use crate::{Actor, ActorProcessingErr, SpawnErr};
 async fn test_basic_registation() {
     struct EmptyActor;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for EmptyActor {
         type Msg = ();
         type Arguments = ();
@@ -47,7 +47,7 @@ async fn test_basic_registation() {
 async fn test_duplicate_registration() {
     struct EmptyActor;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for EmptyActor {
         type Msg = ();
         type Arguments = ();
@@ -95,7 +95,7 @@ async fn test_duplicate_registration() {
 async fn test_actor_registry_unenrollment() {
     struct EmptyActor;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for EmptyActor {
         type Msg = ();
         type Arguments = ();
@@ -145,7 +145,7 @@ mod pid_registry_tests {
     struct RemoteActor;
     struct RemoteActorMessage;
     impl crate::Message for RemoteActorMessage {}
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for RemoteActor {
         type Msg = RemoteActorMessage;
         type State = ();
@@ -163,7 +163,7 @@ mod pid_registry_tests {
     #[tracing_test::traced_test]
     async fn try_enroll_remote_actor() {
         struct EmptyActor;
-        #[async_trait::async_trait]
+        #[cfg_attr(feature = "async-trait", crate::async_trait)]
         impl Actor for EmptyActor {
             type Msg = ();
             type State = ();
@@ -210,7 +210,7 @@ mod pid_registry_tests {
     async fn test_basic_registation() {
         struct EmptyActor;
 
-        #[async_trait::async_trait]
+        #[cfg_attr(feature = "async-trait", crate::async_trait)]
         impl Actor for EmptyActor {
             type Msg = ();
             type Arguments = ();
@@ -244,7 +244,7 @@ mod pid_registry_tests {
     async fn test_actor_registry_unenrollment() {
         struct EmptyActor;
 
-        #[async_trait::async_trait]
+        #[cfg_attr(feature = "async-trait", crate::async_trait)]
         impl Actor for EmptyActor {
             type Msg = ();
             type Arguments = ();
@@ -288,7 +288,7 @@ mod pid_registry_tests {
 
         struct AutoJoinActor;
 
-        #[async_trait::async_trait]
+        #[cfg_attr(feature = "async-trait", crate::async_trait)]
         impl Actor for AutoJoinActor {
             type Msg = ();
             type Arguments = ();
@@ -307,7 +307,7 @@ mod pid_registry_tests {
             counter: Arc<DashMap<ActorId, u8>>,
         }
 
-        #[async_trait::async_trait]
+        #[cfg_attr(feature = "async-trait", crate::async_trait)]
         impl Actor for NotificationMonitor {
             type Msg = ();
             type Arguments = ();

--- a/ractor/src/rpc/tests.rs
+++ b/ractor/src/rpc/tests.rs
@@ -24,7 +24,7 @@ async fn test_rpc_cast() {
         counter: Arc<AtomicU8>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = ();
         type Arguments = ();
@@ -85,7 +85,7 @@ async fn test_rpc_call() {
     }
     #[cfg(feature = "cluster")]
     impl crate::Message for MessageFormat {}
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = MessageFormat;
         type Arguments = ();
@@ -178,7 +178,7 @@ async fn test_rpc_call_forwarding() {
     }
     #[cfg(feature = "cluster")]
     impl crate::Message for WorkerMessage {}
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Worker {
         type Msg = WorkerMessage;
         type Arguments = ();
@@ -221,8 +221,7 @@ async fn test_rpc_call_forwarding() {
     }
     #[cfg(feature = "cluster")]
     impl crate::Message for ForwarderMessage {}
-
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Forwarder {
         type Msg = ForwarderMessage;
         type Arguments = ();
@@ -336,7 +335,7 @@ async fn test_multi_call() {
     }
     #[cfg(feature = "cluster")]
     impl crate::Message for MessageFormat {}
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = MessageFormat;
         type Arguments = ();

--- a/ractor/src/tests.rs
+++ b/ractor/src/tests.rs
@@ -44,7 +44,7 @@ fn test_error_conversions() {
 async fn test_error_message_extraction() {
     struct TestActor;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = ();
         type State = ();

--- a/ractor/src/time/tests.rs
+++ b/ractor/src/time/tests.rs
@@ -23,7 +23,7 @@ async fn test_intervals() {
         counter: Arc<AtomicU8>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = ();
         type State = Arc<AtomicU8>;
@@ -87,7 +87,7 @@ async fn test_send_after() {
         counter: Arc<AtomicU8>,
     }
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = ();
         type State = Arc<AtomicU8>;
@@ -147,7 +147,7 @@ async fn test_send_after() {
 async fn test_exit_after() {
     struct TestActor;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = ();
         type State = ();
@@ -179,7 +179,7 @@ async fn test_exit_after() {
 async fn test_kill_after() {
     struct TestActor;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for TestActor {
         type Msg = ();
         type State = ();

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -20,7 +20,6 @@ prost-build = { version = "0.12" }
 
 [dependencies]
 ## Required dependencies
-async-trait = "0.1"
 bytes = { version = "1" }
 prost = { version = "0.12" }
 prost-types = { version = "0.12" }

--- a/ractor_cluster/src/net/listener.rs
+++ b/ractor_cluster/src/net/listener.rs
@@ -46,7 +46,7 @@ pub struct ListenerState {
 #[derive(crate::RactorMessage)]
 pub struct ListenerMessage;
 
-#[async_trait::async_trait]
+#[ractor::async_trait]
 impl Actor for Listener {
     type Msg = ListenerMessage;
     type Arguments = ();

--- a/ractor_cluster/src/net/session.rs
+++ b/ractor_cluster/src/net/session.rs
@@ -107,7 +107,7 @@ pub struct SessionState {
     reader: ActorRef<SessionReaderMessage>,
 }
 
-#[async_trait::async_trait]
+#[ractor::async_trait]
 impl Actor for Session {
     type Msg = SessionMessage;
     type Arguments = super::NetworkStream;
@@ -296,7 +296,7 @@ enum SessionWriterMessage {
     WriteObject(crate::protocol::NetworkMessage),
 }
 
-#[async_trait::async_trait]
+#[ractor::async_trait]
 impl Actor for SessionWriter {
     type Msg = SessionWriterMessage;
     type Arguments = ActorWriteHalf;
@@ -385,7 +385,7 @@ struct SessionReaderState {
     reader: Option<ActorReadHalf>,
 }
 
-#[async_trait::async_trait]
+#[ractor::async_trait]
 impl Actor for SessionReader {
     type Msg = SessionReaderMessage;
     type Arguments = ActorReadHalf;

--- a/ractor_cluster/src/node/mod.rs
+++ b/ractor_cluster/src/node/mod.rs
@@ -317,7 +317,7 @@ impl NodeServerState {
     }
 }
 
-#[async_trait::async_trait]
+#[ractor::async_trait]
 impl Actor for NodeServer {
     type Msg = NodeServerMessage;
     type State = NodeServerState;

--- a/ractor_cluster/src/node/node_session/mod.rs
+++ b/ractor_cluster/src/node/node_session/mod.rs
@@ -825,7 +825,7 @@ impl NodeSessionState {
     }
 }
 
-#[async_trait::async_trait]
+#[ractor::async_trait]
 impl Actor for NodeSession {
     type Msg = super::NodeSessionMessage;
     type Arguments = crate::net::NetworkStream;

--- a/ractor_cluster/src/node/node_session/tests.rs
+++ b/ractor_cluster/src/node/node_session/tests.rs
@@ -18,7 +18,7 @@ use crate::NodeSessionMessage;
 use super::*;
 
 struct DummyNodeServer;
-#[async_trait::async_trait]
+#[ractor::async_trait]
 impl Actor for DummyNodeServer {
     type Msg = crate::node::NodeServerMessage;
     type State = ();
@@ -57,7 +57,7 @@ impl Actor for DummyNodeServer {
 }
 
 struct DummyNodeSession;
-#[async_trait::async_trait]
+#[ractor::async_trait]
 impl Actor for DummyNodeSession {
     type Msg = crate::node::NodeSessionMessage;
     type State = ();
@@ -540,7 +540,7 @@ async fn node_session_handle_node_msg() {
         call_replies: Arc<AtomicU8>,
     }
 
-    #[async_trait::async_trait]
+    #[ractor::async_trait]
     impl Actor for DummyRemoteActor {
         type Msg = crate::remote_actor::RemoteActorMessage;
         type State = ();

--- a/ractor_cluster/src/remote_actor/mod.rs
+++ b/ractor_cluster/src/remote_actor/mod.rs
@@ -78,7 +78,7 @@ impl RemoteActorState {
 #[derive(RactorMessage)]
 pub(crate) struct RemoteActorMessage;
 
-#[async_trait::async_trait]
+#[ractor::async_trait]
 impl Actor for RemoteActor {
     type Msg = RemoteActorMessage;
     type State = RemoteActorState;

--- a/ractor_cluster/src/remote_actor/tests.rs
+++ b/ractor_cluster/src/remote_actor/tests.rs
@@ -17,7 +17,7 @@ impl FakeNodeSession {
     }
 }
 
-#[async_trait::async_trait]
+#[ractor::async_trait]
 impl Actor for FakeNodeSession {
     type Msg = crate::node::NodeSessionMessage;
     type State = ();

--- a/ractor_cluster_integration_tests/src/tests/pg_groups.rs
+++ b/ractor_cluster_integration_tests/src/tests/pg_groups.rs
@@ -37,7 +37,7 @@ struct PingPongActorState {
     done: bool,
 }
 
-#[async_trait::async_trait]
+#[ractor::async_trait]
 impl Actor for PingPongActor {
     type Msg = PingPongActorMessage;
     type State = PingPongActorState;

--- a/ractor_playground/Cargo.toml
+++ b/ractor_playground/Cargo.toml
@@ -11,7 +11,6 @@ readme = "../README.md"
 publish = false
 
 [dependencies]
-async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 ractor = { path="../ractor", features = ["cluster"] }
 ractor_cluster = { path = "../ractor_cluster" }

--- a/ractor_playground/src/distributed.rs
+++ b/ractor_playground/src/distributed.rs
@@ -76,7 +76,7 @@ enum PingPongActorMessage {
     Rpc(String, RpcReplyPort<String>),
 }
 
-#[async_trait::async_trait]
+#[ractor::async_trait]
 impl Actor for PingPongActor {
     type Msg = PingPongActorMessage;
     type State = ();

--- a/ractor_playground/src/ping_pong.rs
+++ b/ractor_playground/src/ping_pong.rs
@@ -32,7 +32,7 @@ impl Message {
     }
 }
 
-#[async_trait::async_trait]
+#[ractor::async_trait]
 impl Actor for PingPong {
     type Msg = Message;
     type Arguments = ();


### PR DESCRIPTION
https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html

This PR also makes the newly supported functionality opt-in via `no-default-features` and not enabling the `async-trait` feature (and therefore dependency).

Benchmarks show that functionality isn't generally impacted on small-scale tests, however by using `async fn` natively in the trait we risk a performance impact because this won't `Box` the futures into a `BoxFuture` and won't move the future onto the heap.