### PR TITLE
Serde blanket implementation feature 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,9 @@ jobs:
           - name: Test ractor with the `cluster` feature
             package: ractor
             flags: -F cluster
+          - name: Test ractor with the `blanket_serde` feature
+            package: ractor
+            flags: -F blanket_serde
           - name: Test ractor_cluster
             package: ractor_cluster
             # flags: 

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         toolchain: [stable]
         os: [ubuntu]
-        features: [serde_blanket, cluster]
+        features: [blanket_serde, cluster]
 
     steps:
       - uses: actions/checkout@main
@@ -27,25 +27,25 @@ jobs:
       - name: Build the docker image
         working-directory: .
         run: |
-          docker compose build
+          FEATURES=${{matrix.features}} docker compose build
 
       - name: Authentication Handshake
         working-directory: .
         run: |
-          FEATURES=${{matrix.features}} docker compose --env-file ./ractor_cluster_integration_tests/envs/auth-handshake.env up --exit-code-from node-b
+          docker compose --env-file ./ractor_cluster_integration_tests/envs/auth-handshake.env up --exit-code-from node-b
 
       - name: Process Groups
         working-directory: .
         run: |
-          FEATURES=${{matrix.features}} docker compose --env-file ./ractor_cluster_integration_tests/envs/pg-groups.env up --exit-code-from node-b
+          docker compose --env-file ./ractor_cluster_integration_tests/envs/pg-groups.env up --exit-code-from node-b
 
       - name: Encrypted communications
         working-directory: .
         run: |
-          FEATURES=${{matrix.features}} docker compose --env-file ./ractor_cluster_integration_tests/envs/encryption.env up --exit-code-from node-b
+          docker compose --env-file ./ractor_cluster_integration_tests/envs/encryption.env up --exit-code-from node-b
           
       - name: Transitive connections
         working-directory: .
         run: |
-          FEATURES=${{matrix.features}} docker compose --env-file ./ractor_cluster_integration_tests/envs/dist-connect.env up --exit-code-from node-c
+          docker compose --env-file ./ractor_cluster_integration_tests/envs/dist-connect.env up --exit-code-from node-c
       

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         toolchain: [stable]
         os: [ubuntu]
+        features: [serde_blanket, cluster]
 
     steps:
       - uses: actions/checkout@main
@@ -31,20 +32,20 @@ jobs:
       - name: Authentication Handshake
         working-directory: .
         run: |
-          docker compose --env-file ./ractor_cluster_integration_tests/envs/auth-handshake.env up --exit-code-from node-b
+          FEATURES=${{matrix.features}} docker compose --env-file ./ractor_cluster_integration_tests/envs/auth-handshake.env up --exit-code-from node-b
 
       - name: Process Groups
         working-directory: .
         run: |
-          docker compose --env-file ./ractor_cluster_integration_tests/envs/pg-groups.env up --exit-code-from node-b
+          FEATURES=${{matrix.features}} docker compose --env-file ./ractor_cluster_integration_tests/envs/pg-groups.env up --exit-code-from node-b
 
       - name: Encrypted communications
         working-directory: .
         run: |
-          docker compose --env-file ./ractor_cluster_integration_tests/envs/encryption.env up --exit-code-from node-b
+          FEATURES=${{matrix.features}} docker compose --env-file ./ractor_cluster_integration_tests/envs/encryption.env up --exit-code-from node-b
           
       - name: Transitive connections
         working-directory: .
         run: |
-          docker compose --env-file ./ractor_cluster_integration_tests/envs/dist-connect.env up --exit-code-from node-c
+          FEATURES=${{matrix.features}} docker compose --env-file ./ractor_cluster_integration_tests/envs/dist-connect.env up --exit-code-from node-c
       

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: ractor_cluster_integration_tests/Dockerfile
+      args:
+        - FEATURES=${FEATURES}
     image: ractor_cluster_tests:latest
     networks:
       - test-net
@@ -19,6 +21,8 @@ services:
     build:
       context: .
       dockerfile: ractor_cluster_integration_tests/Dockerfile
+      args:
+        - FEATURES=${FEATURES}
     image: ractor_cluster_tests:latest
     networks:
       - test-net
@@ -34,6 +38,8 @@ services:
     build:
       context: .
       dockerfile: ractor_cluster_integration_tests/Dockerfile
+      args:
+        - FEATURES=${FEATURES}
     image: ractor_cluster_tests:latest
     networks:
       - test-net

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.64"
 ### Other features
 cluster = []
 tokio_runtime = ["tokio/time", "tokio/rt", "tokio/macros", "tokio/tracing"]
+blanket_serde = ["serde", "pot"]
 
 # default = ["async-std"]
 default = ["tokio_runtime", "async-trait"]
@@ -34,6 +35,10 @@ async-std = { version = "1", features = ["attributes"], optional = true }
 async-trait = { version = "0.1", optional = true }
 tokio = { version = "1", features = ["sync"] }
 tracing = { version = "0.1", features = ["attributes"] }
+
+## Blanket Serde
+serde = { version = "1", optional = true }
+pot =  { version = "3.0", optional = true }
 
 [dev-dependencies]
 backtrace = "0.3"

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.64"
 ### Other features
 cluster = []
 tokio_runtime = ["tokio/time", "tokio/rt", "tokio/macros", "tokio/tracing"]
-blanket_serde = ["serde", "pot"]
+blanket_serde = ["serde", "pot", "cluster"]
 
 # default = ["async-std"]
 default = ["tokio_runtime", "async-trait"]

--- a/ractor/src/serialization.rs
+++ b/ractor/src/serialization.rs
@@ -253,7 +253,7 @@ mod tests {
     #[allow(non_snake_case)]
     fn test_bytes_conversion_String() {
         let test_data: String = random_string();
-        let bytes = test_data.clone().into_bytes();
+        let bytes = <String as BytesConvertable>::into_bytes(test_data.clone());
         let back = <String as BytesConvertable>::from_bytes(bytes);
         assert_eq!(test_data, back);
     }

--- a/ractor/src/serialization.rs
+++ b/ractor/src/serialization.rs
@@ -33,7 +33,7 @@ mod impls {
             pot::from_slice(&bytes).unwrap()
         }
         fn into_bytes(self) -> Vec<u8> {
-            pot::to_vec(&self).unwrap()
+            vec![]
         }
     }
 }

--- a/ractor/src/serialization.rs
+++ b/ractor/src/serialization.rs
@@ -24,7 +24,8 @@ pub trait BytesConvertable {
 }
 
 #[cfg(feature = "blanket_serde")]
-mod impls{
+/// Contains a blanket implementation for all types that implement serde::Serialize and serde::Deserialize
+pub mod impls{
     use crate::BytesConvertable;
 
     impl<T: serde::Serialize + serde::de::DeserializeOwned> BytesConvertable for T {
@@ -38,7 +39,8 @@ mod impls{
 }
 
 #[cfg(not(feature = "blanket_serde"))]
-mod impls{
+/// Contains the default implementations for the `BytesConvertable` trait
+pub mod impls{
     use crate::BytesConvertable;
     
     // ==================== Primitive implementations ==================== //

--- a/ractor/src/serialization.rs
+++ b/ractor/src/serialization.rs
@@ -33,7 +33,7 @@ mod impls {
             pot::from_slice(&bytes).unwrap()
         }
         fn into_bytes(self) -> Vec<u8> {
-            vec![]
+            pot::to_vec(&self).unwrap()
         }
     }
 }

--- a/ractor_cluster_integration_tests/Cargo.toml
+++ b/ractor_cluster_integration_tests/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/slawlor/ractor"
 readme = "../README.md"
 publish = false
 
+[features]
+blanket_serde = ["ractor/blanket_serde"]
+cluster = []
+
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"

--- a/ractor_cluster_integration_tests/Dockerfile
+++ b/ractor_cluster_integration_tests/Dockerfile
@@ -7,7 +7,8 @@ FROM rust:latest
 WORKDIR /usr/src/app
 RUN apt-get update && apt-get install -y cmake build-essential
 COPY . .
-RUN cargo install --path ractor_cluster_integration_tests/
+ARG FEATURES
+RUN cargo install --path ractor_cluster_integration_tests/ -F $FEATURES
 RUN mv /usr/local/cargo/bin/ractor_cluster_integration_tests /usr/local/bin/ractor_cluster_integration_tests
 RUN mv /usr/src/app/ractor_cluster_integration_tests/test-ca/ /usr/local/bin/test-ca
 WORKDIR /usr/local/bin

--- a/ractor_cluster_integration_tests/src/ractor_forward_port_tests.rs
+++ b/ractor_cluster_integration_tests/src/ractor_forward_port_tests.rs
@@ -34,7 +34,9 @@ async fn no_timeout_rpc() {
     match no_timeout_serialized {
         SerializedMessage::Call { args, reply, .. } => {
             let str = get_len_encoded_string(args);
-            let _ = reply.send(str.into_bytes());
+            let _ = reply.send(<String as ractor_cluster::BytesConvertable>::into_bytes(
+                str,
+            ));
         }
         _ => panic!("Invalid"),
     }
@@ -53,7 +55,9 @@ async fn with_timeout_rpc() {
     match with_timeout_serialized {
         SerializedMessage::Call { args, reply, .. } => {
             let str = get_len_encoded_string(args);
-            let _ = reply.send(str.into());
+            let _ = reply.send(<String as ractor_cluster::BytesConvertable>::into_bytes(
+                str,
+            ));
         }
         _ => panic!("Invalid"),
     }

--- a/ractor_cluster_integration_tests/src/tests/pg_groups.rs
+++ b/ractor_cluster_integration_tests/src/tests/pg_groups.rs
@@ -182,7 +182,7 @@ pub(crate) async fn test(config: PgGroupsConfig) -> i32 {
         let tic = Instant::now();
 
         let mut rpc_result = ractor::call_t!(test_actor, HelloActorMessage::IsDone, 500);
-        while rpc_result.is_ok() {
+        loop {
             let duration: Duration = Instant::now() - tic;
             if duration.as_millis() > PING_PONG_ALLOTED_MS {
                 tracing::error!("Ping pong actor didn't complete in allotted time");

--- a/ractor_cluster_integration_tests/src/tests/pg_groups.rs
+++ b/ractor_cluster_integration_tests/src/tests/pg_groups.rs
@@ -175,10 +175,7 @@ pub(crate) async fn test(config: PgGroupsConfig) -> i32 {
 
     if err_code == 0 {
         // we're authenticated. Startup our PG group testing
-        let _ = ractor::cast!(
-            test_actor,
-            HelloActorMessage::Hey("Hello there".to_string())
-        );
+        let _ = ractor::cast!(test_actor, HelloActorMessage::Hey("Hey there".to_string()));
         let tic = Instant::now();
 
         let mut rpc_result = ractor::call_t!(test_actor, HelloActorMessage::IsDone, 500);


### PR DESCRIPTION
When working with types in outside crates it quickly becomes a nuisance to implement various wrapper types just to be able to implement BytesConvertable. This becomes especially annoying once one has to interface with an existing codebase that has the original types deeply ingrained.

This PR adds an optional feature called "blanket_serde" which replaces the current default implementations of BytesConvertable with a blanket implementation utilizing serde and pot.

In the process a handful of bugs were found, where tests and BytesConvertable implementations were inconsistent in their Deserialization / Serialization.
For example there were cases of Strings into_bytes() function being used for serialization in combination with <String as BytesConvertable>::from_bytes being used for deserialization, this didn't cause any errors since the default implementation similarly just called .into_bytes().