### PR TITLE
Factory improvements

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.9.8"
+version = "0.10.0"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/src/factory/lifecycle.rs
+++ b/ractor/src/factory/lifecycle.rs
@@ -1,0 +1,67 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! Lifecycle hooks support interjecting external logic into the factory's
+//! lifecycle (startup/shutdown/etc) such that users can intercept and
+//! adjust factory functionality at key interjection points.
+
+use super::FactoryMessage;
+use super::JobKey;
+use crate::ActorProcessingErr;
+use crate::ActorRef;
+use crate::Message;
+use crate::State;
+
+/// Hooks for [super::Factory] lifecycle events based on the
+/// underlying actor's lifecycle.
+#[crate::async_trait]
+pub trait FactoryLifecycleHooks<TKey, TMsg>: State + Sync
+where
+    TKey: JobKey,
+    TMsg: Message,
+{
+    /// Called when the factory has completed it's startup routine but
+    /// PRIOR to processing any messages. Just before this point, the factory
+    /// is ready to accept and process requests and all workers are started.
+    ///
+    /// This hook is there to provide custom startup logic you want to make sure has run
+    /// prior to processing messages on workers
+    ///
+    /// WARNING: An error or panic returned here WILL shutdown the factory and notify supervisors
+    #[allow(unused_variables)]
+    async fn on_factory_started(
+        &self,
+        factory_ref: ActorRef<FactoryMessage<TKey, TMsg>>,
+    ) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+
+    /// Called when the factory has completed it's shutdown routine but
+    /// PRIOR to fully exiting and notifying any relevant supervisors. Just prior
+    /// to this call the factory has processed its last message and will process
+    /// no more messages.
+    ///
+    /// This hook is there to provide custom shutdown logic you want to make sure has run
+    /// prior to the factory fully exiting
+    async fn on_factory_stopped(&self) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+
+    /// Called when the factory has received a signal to drain requests and exit after
+    /// draining has completed.
+    ///
+    /// This hook is to provide the ability to notify external services that the factory
+    /// is in the process of shutting down. If the factory is never "drained" formally,
+    /// this hook won't be called.
+    ///
+    /// WARNING: An error or panic returned here WILL shutdown the factory and notify supervisors
+    #[allow(unused_variables)]
+    async fn on_factory_draining(
+        &self,
+        factory_ref: ActorRef<FactoryMessage<TKey, TMsg>>,
+    ) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+}

--- a/ractor/src/factory/tests/draining_requests.rs
+++ b/ractor/src/factory/tests/draining_requests.rs
@@ -1,0 +1,141 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use std::sync::atomic::AtomicU16;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use crate::concurrency::sleep;
+use crate::concurrency::Duration;
+use crate::Actor;
+use crate::ActorProcessingErr;
+use crate::ActorRef;
+
+use super::super::*;
+
+#[derive(Debug, Hash, Clone, Eq, PartialEq)]
+struct TestKey {
+    id: u64,
+}
+
+#[cfg(feature = "cluster")]
+impl crate::BytesConvertable for TestKey {
+    fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self {
+            id: u64::from_bytes(bytes),
+        }
+    }
+    fn into_bytes(self) -> Vec<u8> {
+        self.id.into_bytes()
+    }
+}
+
+struct TestMessage;
+#[cfg(feature = "cluster")]
+impl crate::Message for TestMessage {}
+
+struct TestWorker {
+    counter: Arc<AtomicU16>,
+}
+
+#[cfg_attr(feature = "async-trait", crate::async_trait)]
+impl Actor for TestWorker {
+    type Msg = WorkerMessage<TestKey, TestMessage>;
+    type State = Self::Arguments;
+    type Arguments = WorkerStartContext<TestKey, TestMessage, ()>;
+
+    async fn pre_start(
+        &self,
+        _: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(args)
+    }
+
+    async fn handle(
+        &self,
+        _: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            WorkerMessage::FactoryPing(time) => {
+                state
+                    .factory
+                    .cast(FactoryMessage::WorkerPong(state.wid, time.elapsed()))?;
+            }
+            WorkerMessage::Dispatch(job) => {
+                self.counter.fetch_add(1, Ordering::Relaxed);
+
+                sleep(Duration::from_millis(5)).await;
+
+                // job finished, on success or err we report back to the factory
+                state
+                    .factory
+                    .cast(FactoryMessage::Finished(state.wid, job.key))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+struct SlowWorkerBuilder {
+    counter: Arc<AtomicU16>,
+}
+
+impl WorkerBuilder<TestWorker, ()> for SlowWorkerBuilder {
+    fn build(&self, _wid: usize) -> (TestWorker, ()) {
+        (
+            TestWorker {
+                counter: self.counter.clone(),
+            },
+            (),
+        )
+    }
+}
+
+#[crate::concurrency::test]
+#[tracing_test::traced_test]
+async fn test_request_draining() {
+    let counter = Arc::new(AtomicU16::new(0));
+
+    let worker_builder = SlowWorkerBuilder {
+        counter: counter.clone(),
+    };
+    let factory_definition = Factory::<TestKey, TestMessage, (), TestWorker> {
+        worker_count: 2,
+        routing_mode: RoutingMode::Queuer,
+        ..Default::default()
+    };
+    let (factory, factory_handle) =
+        Actor::spawn(None, factory_definition, Box::new(worker_builder))
+            .await
+            .expect("Failed to spawn factory");
+
+    for id in 0..999 {
+        factory
+            .cast(FactoryMessage::Dispatch(Job {
+                key: TestKey { id },
+                msg: TestMessage,
+                options: JobOptions::default(),
+            }))
+            .expect("Failed to send to factory");
+    }
+
+    // start draining requests
+    factory
+        .cast(FactoryMessage::DrainRequests)
+        .expect("Failed to contact factory");
+
+    // TODO: do this check by discarding
+
+    // try and push a new message, but it should be rejected since we're now draining
+
+    // wait for factory to exit (it should once drained)
+    factory_handle.await.unwrap();
+
+    // check the counter
+    assert_eq!(999, counter.load(Ordering::Relaxed));
+}

--- a/ractor/src/factory/tests/factory_lifecycle.rs
+++ b/ractor/src/factory/tests/factory_lifecycle.rs
@@ -1,0 +1,156 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use crate::concurrency::sleep;
+use crate::concurrency::Duration;
+use crate::Actor;
+use crate::ActorProcessingErr;
+use crate::ActorRef;
+
+use crate::common_test::periodic_check;
+use crate::factory::Factory;
+use crate::factory::FactoryLifecycleHooks;
+use crate::factory::FactoryMessage;
+use crate::factory::RoutingMode;
+use crate::factory::WorkerBuilder;
+use crate::factory::WorkerMessage;
+use crate::factory::WorkerStartContext;
+
+#[derive(Clone)]
+struct AtomicHooks {
+    state: Arc<AtomicU8>,
+}
+
+#[crate::async_trait]
+impl FactoryLifecycleHooks<(), ()> for AtomicHooks {
+    async fn on_factory_started(
+        &self,
+        _factory_ref: ActorRef<FactoryMessage<(), ()>>,
+    ) -> Result<(), ActorProcessingErr> {
+        self.state.store(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn on_factory_stopped(&self) -> Result<(), ActorProcessingErr> {
+        self.state.store(3, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn on_factory_draining(
+        &self,
+        _factory_ref: ActorRef<FactoryMessage<(), ()>>,
+    ) -> Result<(), ActorProcessingErr> {
+        self.state.store(2, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+struct TestWorker;
+
+#[async_trait::async_trait]
+impl Actor for TestWorker {
+    type State = Self::Arguments;
+    type Msg = WorkerMessage<(), ()>;
+    type Arguments = WorkerStartContext<(), (), ()>;
+
+    async fn pre_start(
+        &self,
+        _: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        // slow down factory startup waiting for workers to spawn
+        sleep(Duration::from_millis(100)).await;
+        Ok(args)
+    }
+
+    async fn post_stop(
+        &self,
+        _: ActorRef<Self::Msg>,
+        _: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        // slow down factory shutdown waiting for workers to die
+        sleep(Duration::from_millis(100)).await;
+        Ok(())
+    }
+
+    async fn handle(
+        &self,
+        _: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            WorkerMessage::FactoryPing(time) => {
+                state
+                    .factory
+                    .cast(FactoryMessage::WorkerPong(state.wid, time.elapsed()))?;
+            }
+            WorkerMessage::Dispatch(job) => {
+                tracing::warn!("Worker received message");
+                // job finished, on success or err we report back to the factory
+                state.factory.cast({
+                    job.key;
+                    FactoryMessage::Finished(state.wid, ())
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+struct TestWorkerBuilder;
+
+impl WorkerBuilder<TestWorker, ()> for TestWorkerBuilder {
+    fn build(&self, _wid: crate::factory::WorkerId) -> (TestWorker, ()) {
+        (TestWorker, ())
+    }
+}
+
+#[crate::concurrency::test]
+async fn test_lifecycle_hooks() {
+    let hooks = AtomicHooks {
+        state: Arc::new(AtomicU8::new(0)),
+    };
+
+    let worker_builder = TestWorkerBuilder;
+    let factory_definition = Factory::<(), (), (), TestWorker> {
+        worker_count: 1,
+        routing_mode: RoutingMode::Queuer,
+        lifecycle_hooks: Some(Box::new(hooks.clone())),
+        ..Default::default()
+    };
+
+    let (factory, factory_handle) =
+        Actor::spawn(None, factory_definition, Box::new(worker_builder))
+            .await
+            .expect("Failed to spawn factory");
+
+    // startup has some delay creating workers, so we shouldn't see on_started called immediately
+    assert_eq!(0, hooks.state.load(Ordering::SeqCst));
+    periodic_check(
+        || hooks.state.load(Ordering::SeqCst) == 1,
+        Duration::from_millis(500),
+    )
+    .await;
+
+    assert_eq!(1, hooks.state.load(Ordering::SeqCst));
+    factory
+        .cast(FactoryMessage::DrainRequests)
+        .expect("Failed to message factory");
+
+    // give a little time to see if the factory moved to the draining state
+    periodic_check(
+        || hooks.state.load(Ordering::SeqCst) == 2,
+        Duration::from_millis(500),
+    )
+    .await;
+    // once the factory is stopped, the shutdown handler should have been called
+    factory_handle.await.unwrap();
+    assert_eq!(3, hooks.state.load(Ordering::SeqCst));
+}

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.9.8"
+version = "0.10.0"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"
@@ -23,8 +23,8 @@ prost-build = { version = "0.12" }
 bytes = { version = "1" }
 prost = { version = "0.12" }
 prost-types = { version = "0.12" }
-ractor = { version = "0.9.0", features = ["cluster"], path = "../ractor" }
-ractor_cluster_derive = { version = "0.9.0", path = "../ractor_cluster_derive" }
+ractor = { version = "0.10.0", features = ["cluster"], path = "../ractor" }
+ractor_cluster_derive = { version = "0.10.0", path = "../ractor_cluster_derive" }
 rand = "0.8"
 sha2 = "0.10"
 tokio = { version = "1", features = ["rt", "time", "sync", "macros", "net", "io-util", "tracing"]}

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.9.8"
+version = "0.10.0"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
1. Draining of requests
2. Lifecycle hooks
3. Worker startup custom arguments which can be thread through the factory's worker builder
4. Discarding reasoning

Potentially to come in the future, dynamic worker pool management and queueing management.

## This is an API break, and therefore requires a major revision change to 0.10.0

The signature of the basic actor primatives, etc hasn't changed, but given we're adding new arguments and functionality to factories that isn't default-extendible this must be considered as an api break as users can't upgrade-in-place here.