### PR TITLE
Adding handling if the actor fails during pre_start that it doesn't poison the named and pid registries.

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/src/factory/job.rs
+++ b/ractor/src/factory/job.rs
@@ -231,7 +231,8 @@ where
     TKey: JobKey,
     TMsg: Message,
 {
-    pub(crate) fn is_expired(&self) -> bool {
+    /// Determine if this job is expired
+    pub fn is_expired(&self) -> bool {
         if let Some(ttl) = self.options.ttl {
             self.options.submit_time.elapsed().unwrap() > ttl
         } else {

--- a/ractor/src/factory/worker.rs
+++ b/ractor/src/factory/worker.rs
@@ -195,7 +195,10 @@ where
         self.actor.get_id() == pid
     }
 
-    pub(crate) fn is_processing_key(&self, key: &TKey) -> bool {
+    /// Identifies if a worker is processing a specific job key
+    ///
+    /// Returns true if the worker is currently processing the given key
+    pub fn is_processing_key(&self, key: &TKey) -> bool {
         self.curr_jobs.contains_key(key)
     }
 
@@ -219,16 +222,17 @@ where
         Ok(())
     }
 
-    pub(crate) fn is_available(&self) -> bool {
+    /// Identify if the worker is available for enqueueing work
+    pub fn is_available(&self) -> bool {
         self.curr_jobs.is_empty()
     }
 
-    pub(crate) fn is_working(&self) -> bool {
+    /// Identify if the worker is currently processing any requests
+    pub fn is_working(&self) -> bool {
         !self.curr_jobs.is_empty()
     }
 
     /// Denotes if the worker is stuck (i.e. unable to complete it's current job)
-
     pub(crate) fn is_stuck(&self, duration: Duration) -> bool {
         if Instant::now() - self.stats.last_ping > duration {
             let key_strings = self
@@ -244,8 +248,9 @@ where
     }
 
     /// Enqueue a new job to this worker. If the discard threshold has been exceeded
-    /// it will discard the oldest elements from the message queue
-    pub(crate) fn enqueue_job(
+    /// it will discard the oldest or newest elements from the message queue (based
+    /// on discard semantics)
+    pub fn enqueue_job(
         &mut self,
         mut job: Job<TKey, TMsg>,
     ) -> Result<(), MessagingErr<WorkerMessage<TKey, TMsg>>> {

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
Handling actor startup errors in `pre_start` results in a `SpawnErr` however it wasn't being handled putting the actor into a `Stopped` state (which it should have), since that's where the actor registries are cleaned up such as the named and `pg` registries. This would result in dangling references in those registries.

This PR specifically captures spawn failures and sets the actor to stopped to call the necessary de-registration hooks.

Resolves #240