### PR TITLE
Move to oneshot's instead of bounded channels of size 1

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,4 +42,9 @@ jobs:
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
         with:
+          fail_ci_if_error: true # optional (default = false)
           files: coverage/*.lcov
+          token: ${{ secrets.CODECOV_TOKEN }} # required
+          verbose: true # optional (default = false)
+          name: ractor # optional
+

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
Before
```
        9.82 real         4.19 user         3.78 sys
          1353138176  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               90426  page reclaims
                   3  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                1870  voluntary context switches
              524687  involuntary context switches
         40331547246  instructions retired
         23204316450  cycles elapsed
          1351667776  peak memory footprint
  ```
  After:
  ```
          6.29 real         2.73 user         2.32 sys
          1121075200  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               76399  page reclaims
                   3  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
               10887  voluntary context switches
              413558  involuntary context switches
         29945793283  instructions retired
         14556521293  cycles elapsed
          1119671040  peak memory footprint
  ```

Which is an additional ~18% memory savings. Additionally benchmarks show general improvements across the board for actor spawning and message processing

```
     Running benches/actor.rs (target/release/deps/actor-b536336e1fcc1c92)
Gnuplot not found, using plotters backend
Creation of 100 actors  time:   [232.86 µs 243.49 µs 253.01 µs]
                        change: [-8.8130% -5.1155% -1.0848%] (p = 0.01 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Creation of 10000 actors
                        time:   [17.479 ms 17.885 ms 18.333 ms]
                        change: [-29.372% -27.067% -24.870%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  8 (8.00%) high mild
  1 (1.00%) high severe

Benchmarking Waiting on 100 actors to process first message: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.8s, enable flat sampling, or reduce sample count to 60.
Waiting on 100 actors to process first message
                        time:   [916.23 µs 929.97 µs 945.06 µs]
                        change: [-8.9031% -4.3915% -0.2873%] (p = 0.05 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe

Waiting on 1000 actors to process first message
                        time:   [9.9507 ms 10.223 ms 10.513 ms]
                        change: [-0.7415% +2.4407% +5.4566%] (p = 0.14 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  8 (8.00%) high mild
  2 (2.00%) high severe

Waiting on 100000 messages to be processed
                        time:   [14.888 ms 14.938 ms 14.997 ms]
                        change: [-12.560% -12.238% -11.906%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  9 (9.00%) high mild
  5 (5.00%) high severe
```