### PR TITLE
Generic stats impl for factories

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.11.2"
+version = "0.12.0"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/src/factory/mod.rs
+++ b/ractor/src/factory/mod.rs
@@ -145,6 +145,7 @@
 //!                 key: (),
 //!                 msg: ExampleMessage::PrintValue(i),
 //!                 options: JobOptions::default(),
+//!                 accepted: None,
 //!             }))
 //!             .expect("Failed to send to factory");
 //!     }
@@ -155,6 +156,7 @@
 //!                     key: (),
 //!                     msg: ExampleMessage::EchoValue(123, prt),
 //!                     options: JobOptions::default(),
+//!                     accepted: None,
 //!                 })
 //!             },
 //!             None,
@@ -186,7 +188,7 @@ pub mod worker;
 #[cfg(test)]
 mod tests;
 
-use stats::MessageProcessingStats;
+use stats::FactoryStatsLayer;
 
 pub use discard::{
     DiscardHandler, DiscardMode, DiscardReason, DiscardSettings, DynamicDiscardController,

--- a/ractor/src/factory/stats.rs
+++ b/ractor/src/factory/stats.rs
@@ -5,229 +5,141 @@
 
 //! Statistics management + collection for factories
 
-use std::fmt::Display;
-use std::time::SystemTime;
+use std::sync::Arc;
 
 use crate::concurrency::{Duration, Instant};
 use crate::factory::JobOptions;
 
-const MICROS_IN_SEC: u128 = 1000000;
-const RESET_PINGS_AFTER: u64 = 600;
+/// A wrapper over whatever stats collection a user wishes to utilize
+/// in the [super::Factory].
+pub trait FactoryStatsLayer: Send + Sync + 'static {
+    /// Called when a factory ping has been received, marking the duration
+    /// between when it was sent and now.
+    ///
+    /// Measures ping latency on the factory
+    fn factory_ping_received(&self, factory: &str, sent: Instant);
 
-/// Messaging statistics collected on a factory and/or
-/// a worker
-#[derive(Clone)]
-pub struct MessageProcessingStats {
-    // ========== Pings ========== //
-    /// number of pings
-    pub ping_count: u64,
-    /// Running sum of ping time
-    pub ping_timing_us: u128,
-    /// The time of the last ping (workers only)
-    pub last_ping: Instant,
-    // ========== Incoming Job QPS ========== //
-    /// The time a last job came through
-    pub last_job_time: Instant,
-    /// Job count
-    pub job_count: u64,
-    /// Incoming job time
-    pub job_incoming_time_us: u128,
-    // ========== Finished jobs (factory-only) ========== //
-    /// Job processed count
-    pub processed_job_count: u64,
-    /// Total processed job count
-    pub total_processed_job_count: u128,
-    /// Factory's processing time for jobs (factory initial handling -> job done)
-    pub factory_processing_latency_usec: u128,
-    /// Worker's processing time for jobs (worker initial handling -> job done)
-    pub worker_processing_latency_usec: u128,
-    /// Overall job latency (submission time -> job done)
-    pub job_processing_latency_usec: u128,
-    // ========== Expired jobs ========== //
-    /// Number of expired jobs
-    pub total_num_expired_jobs: u128,
-    // ========== Discarded jobs ========== //
-    /// Number of discarded jobs
-    pub total_num_discarded_jobs: u128,
+    /// Called when a worker replies to a ping request from the factory,
+    /// measuring the duration between the time the ping was sent and the
+    /// factory processed the ping response.
+    ///
+    /// Measures worker "free" latency and this metric relates to identification
+    /// of "stuck" or slow workers.
+    fn worker_ping_received(&self, factory: &str, elapsed: Duration);
 
-    /// Stats enabled
-    pub enabled: bool,
-}
+    /// Called for each new incoming job
+    fn new_job(&self, factory: &str);
 
-impl Display for MessageProcessingStats {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Avg ping time: {}us
-Num processed jobs: {}
-Job qps: {}
-Avg job processing time: {}us
-Avg time in factory queue: {}us
-Num expired jobs: {}
-Num discarded jobs: {}
-            ",
-            if self.ping_count > 0 {
-                self.ping_timing_us / self.ping_count as u128
-            } else {
-                0
-            },
-            self.total_processed_job_count,
-            self.avg_job_qps(),
-            if self.processed_job_count > 0 {
-                self.job_processing_latency_usec / self.processed_job_count as u128
-            } else {
-                0
-            },
-            if self.processed_job_count > 0 {
-                self.factory_processing_latency_usec / self.processed_job_count as u128
-            } else {
-                0
-            },
-            self.total_num_expired_jobs,
-            self.total_num_discarded_jobs,
-        )
-    }
-}
-
-impl Default for MessageProcessingStats {
-    fn default() -> Self {
-        Self {
-            ping_count: 0,
-            job_incoming_time_us: 0,
-            last_ping: Instant::now(),
-            last_job_time: Instant::now(),
-            ping_timing_us: 0,
-            job_count: 0,
-            job_processing_latency_usec: 0,
-            processed_job_count: 0,
-            total_processed_job_count: 0,
-            factory_processing_latency_usec: 0,
-            total_num_expired_jobs: 0,
-            total_num_discarded_jobs: 0,
-            worker_processing_latency_usec: 0,
-            enabled: false,
-        }
-    }
-}
-
-impl MessageProcessingStats {
-    pub(crate) fn enable(&mut self) {
-        self.enabled = true;
-    }
-
-    pub(crate) fn reset_global_counters(&mut self) {
-        self.total_num_discarded_jobs = 0;
-        self.total_num_expired_jobs = 0;
-        self.total_processed_job_count = 0;
-    }
-
-    /// Handle a factory ping, and every 10 minutes adjust the stats to the
-    /// average + return a flag to state that we reset the ping counter (every RESET_PINGS_AFTER pings)
-    pub(crate) fn ping_received(&mut self, duration: Duration) -> bool {
-        self.last_ping = Instant::now();
-        if self.enabled {
-            self.ping_count += 1;
-            self.ping_timing_us += duration.as_micros();
-            if self.ping_count > RESET_PINGS_AFTER {
-                // When we hit 10min, convert the message timing to an average and reset the counters
-                // this lets us track degradation without being overwhelmed by old (stale) data
-                if self.ping_count > 0 {
-                    self.ping_timing_us /= self.ping_count as u128;
-                }
-
-                self.ping_count = 1;
-                return true;
-            }
-        }
-        false
-    }
-
-    pub(crate) fn job_submitted(&mut self) {
-        if !self.enabled {
-            return;
-        }
-
-        let time_since_last_job = Instant::now() - self.last_job_time;
-        // update the job counter
-        self.last_job_time = Instant::now();
-        self.job_incoming_time_us += time_since_last_job.as_micros();
-        self.job_count += 1;
-
-        if self.job_count > 10000 {
-            self.job_incoming_time_us /= self.job_count as u128;
-            self.job_count = 1;
-        }
-    }
-
-    pub(crate) fn job_ttl_expired(&mut self) {
-        if !self.enabled {
-            return;
-        }
-        self.total_num_expired_jobs += 1;
-    }
-
-    pub(crate) fn jobs_ttls_expired(&mut self, num_jobs: usize) {
-        if !self.enabled {
-            return;
-        }
-        self.total_num_expired_jobs += num_jobs as u128;
-    }
-
-    pub(crate) fn job_discarded(&mut self) {
-        if !self.enabled {
-            return;
-        }
-        self.total_num_discarded_jobs += 1;
-    }
-
-    pub(crate) fn avg_job_qps(&self) -> u128 {
-        if self.job_count > 0 {
-            let us_between_jobs = self.job_incoming_time_us / self.job_count as u128;
-
-            if us_between_jobs > 0 {
-                MICROS_IN_SEC / us_between_jobs
-            } else {
-                0
-            }
-        } else {
-            0
-        }
-    }
-
-    /// Called each time a job is completed to report factory processing time, worker processing time, total processing time
+    /// Called when a job is completed to report factory processing time,
+    /// worker processing time, total processing time, and job count
     ///
     /// From these metrics you can derive
     /// 1. Time in factory's queue = factory_job_processing_latency_usec - worker_job_processing_latency_usec
     /// 2. Time in worker's queue + being processed by worker = worker_job_processing_latency_usec
     /// 3. Total time since submission = job_processing_latency_usec
+    fn job_completed(&self, factory: &str, options: &JobOptions);
+
+    /// Called when a job is discarded
+    fn job_discarded(&self, factory: &str);
+
+    /// Called when jobs TTL timeout in the factory's queue
+    fn job_ttl_expired(&self, factory: &str, num_removed: usize);
+
+    /// Fixed-period recording of the factory's queue depth
+    fn record_queue_depth(&self, factory: &str, depth: usize);
+
+    /// Fixed-period recording of the factory's number of processed messages
+    fn record_processing_messages_count(&self, factory: &str, count: usize);
+
+    /// Fixed-period recording of the factory's number of workers
+    fn record_worker_count(&self, factory: &str, count: usize);
+
+    /// Fixed-period recording of the factory's maximum allowed queue size
+    fn record_queue_limit(&self, factory: &str, count: usize);
+}
+
+impl FactoryStatsLayer for Option<Arc<dyn FactoryStatsLayer>> {
+    /// Called when a factory ping has been received, marking the duration
+    /// between when it was sent and now.
     ///
-    /// NOTE: Depending on selected routing metric, these *could* be 0 in some instances (i.e. a key-persistent
-    /// routing factory will have near-0 time in the factory's queue since it doesn't exist)
-    pub(crate) fn factory_job_done(&mut self, options: &JobOptions) {
-        if !self.enabled {
-            return;
+    /// Measures ping latency on the factory
+    fn factory_ping_received(&self, factory: &str, sent: Instant) {
+        if let Some(s) = self {
+            s.factory_ping_received(factory, sent);
         }
+    }
 
-        self.processed_job_count += 1;
-        self.total_processed_job_count += 1;
+    /// Called when a worker replies to a ping request from the factory,
+    /// measuring the duration between the time the ping was sent and the
+    /// factory processed the ping response.
+    ///
+    /// Measures worker "free" latency and this metric relates to identification
+    /// of "stuck" or slow workers.
+    fn worker_ping_received(&self, factory: &str, elapsed: Duration) {
+        if let Some(s) = self {
+            s.worker_ping_received(factory, elapsed);
+        }
+    }
 
-        let now = SystemTime::now();
-        let duration = now
-            .duration_since(options.factory_time)
-            .unwrap()
-            .as_micros();
-        self.factory_processing_latency_usec += duration;
+    /// Called for each new incoming job
+    fn new_job(&self, factory: &str) {
+        if let Some(s) = self {
+            s.new_job(factory);
+        }
+    }
 
-        let duration = now.duration_since(options.worker_time).unwrap().as_micros();
-        self.worker_processing_latency_usec += duration;
+    /// Called when a job is completed to report factory processing time,
+    /// worker processing time, total processing time, and job count
+    ///
+    /// From these metrics you can derive
+    /// 1. Time in factory's queue = factory_job_processing_latency_usec - worker_job_processing_latency_usec
+    /// 2. Time in worker's queue + being processed by worker = worker_job_processing_latency_usec
+    /// 3. Total time since submission = job_processing_latency_usec
+    fn job_completed(&self, factory: &str, options: &JobOptions) {
+        if let Some(s) = self {
+            s.job_completed(factory, options);
+        }
+    }
 
-        let duration = now.duration_since(options.submit_time).unwrap().as_micros();
-        self.job_processing_latency_usec += duration;
+    /// Called when a job is discarded
+    fn job_discarded(&self, factory: &str) {
+        if let Some(s) = self {
+            s.job_discarded(factory);
+        }
+    }
 
-        if self.processed_job_count > 10000 {
-            self.job_processing_latency_usec /= self.processed_job_count as u128;
-            self.factory_processing_latency_usec /= self.processed_job_count as u128;
-            self.processed_job_count = 1;
+    /// Called when a job TTLs in the factory's queue
+    fn job_ttl_expired(&self, factory: &str, num_removed: usize) {
+        if let Some(s) = self {
+            s.job_ttl_expired(factory, num_removed);
+        }
+    }
+
+    /// Fixed-period recording of the factory's queue depth
+    fn record_queue_depth(&self, factory: &str, depth: usize) {
+        if let Some(s) = self {
+            s.record_queue_depth(factory, depth);
+        }
+    }
+
+    /// Fixed-period recording of the factory's number of processed messages
+    fn record_processing_messages_count(&self, factory: &str, count: usize) {
+        if let Some(s) = self {
+            s.record_processing_messages_count(factory, count);
+        }
+    }
+
+    /// Fixed-period recording of the factory's number of workers
+    fn record_worker_count(&self, factory: &str, count: usize) {
+        if let Some(s) = self {
+            s.record_worker_count(factory, count);
+        }
+    }
+
+    /// Fixed-period recording of the factory's maximum allowed queue size
+    fn record_queue_limit(&self, factory: &str, count: usize) {
+        if let Some(s) = self {
+            s.record_queue_limit(factory, count);
         }
     }
 }

--- a/ractor/src/factory/tests/basic.rs
+++ b/ractor/src/factory/tests/basic.rs
@@ -180,7 +180,7 @@ async fn test_dispatch_key_persistent() {
             discard_settings: DiscardSettings::None,
             lifecycle_hooks: None,
             worker_builder: Box::new(worker_builder),
-            collect_worker_stats: false,
+            stats: None,
         },
     )
     .await
@@ -192,6 +192,7 @@ async fn test_dispatch_key_persistent() {
                 key: TestKey { id: 1 },
                 msg: TestMessage::Ok,
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }
@@ -251,7 +252,7 @@ async fn test_dispatch_queuer() {
             discard_settings: DiscardSettings::None,
             lifecycle_hooks: None,
             worker_builder: Box::new(worker_builder),
-            collect_worker_stats: false,
+            stats: None,
         },
     )
     .await
@@ -263,6 +264,7 @@ async fn test_dispatch_queuer() {
                 key: TestKey { id },
                 msg: TestMessage::Ok,
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }
@@ -325,7 +327,7 @@ async fn test_dispatch_round_robin() {
             discard_settings: DiscardSettings::None,
             lifecycle_hooks: None,
             worker_builder: Box::new(worker_builder),
-            collect_worker_stats: false,
+            stats: None,
         },
     )
     .await
@@ -337,6 +339,7 @@ async fn test_dispatch_round_robin() {
                 key: TestKey { id: 1 },
                 msg: TestMessage::Ok,
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }
@@ -413,7 +416,7 @@ async fn test_dispatch_custom_hashing() {
             discard_settings: DiscardSettings::None,
             lifecycle_hooks: None,
             worker_builder: Box::new(worker_builder),
-            collect_worker_stats: false,
+            stats: None,
         },
     )
     .await
@@ -425,6 +428,7 @@ async fn test_dispatch_custom_hashing() {
                 key: TestKey { id: 1 },
                 msg: TestMessage::Ok,
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }
@@ -481,7 +485,7 @@ async fn test_dispatch_sticky_queueing() {
             discard_settings: DiscardSettings::None,
             lifecycle_hooks: None,
             worker_builder: Box::new(worker_builder),
-            collect_worker_stats: false,
+            stats: None,
         },
     )
     .await
@@ -494,6 +498,7 @@ async fn test_dispatch_sticky_queueing() {
                 key: TestKey { id: 1 },
                 msg: TestMessage::Ok,
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }
@@ -570,7 +575,7 @@ async fn test_discarding_old_records_on_queuer() {
             },
             lifecycle_hooks: None,
             worker_builder: Box::new(worker_builder),
-            collect_worker_stats: false,
+            stats: None,
         },
     )
     .await
@@ -582,6 +587,7 @@ async fn test_discarding_old_records_on_queuer() {
                 key: TestKey { id: 1 },
                 msg: TestMessage::Ok,
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }
@@ -714,7 +720,7 @@ async fn test_stuck_workers() {
             discard_settings: DiscardSettings::None,
             lifecycle_hooks: None,
             worker_builder: Box::new(worker_builder),
-            collect_worker_stats: false,
+            stats: None,
         },
     )
     .await
@@ -726,6 +732,7 @@ async fn test_stuck_workers() {
                 key: TestKey { id: 1 },
                 msg: TestMessage::Ok,
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }
@@ -803,7 +810,7 @@ async fn test_discarding_new_records_on_queuer() {
             },
             lifecycle_hooks: None,
             worker_builder: Box::new(worker_builder),
-            collect_worker_stats: false,
+            stats: None,
         },
     )
     .await
@@ -815,6 +822,7 @@ async fn test_discarding_new_records_on_queuer() {
                 key: TestKey { id: 1 },
                 msg: TestMessage::Count(i),
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }

--- a/ractor/src/factory/tests/dynamic_discarding.rs
+++ b/ractor/src/factory/tests/dynamic_discarding.rs
@@ -164,7 +164,7 @@ async fn test_dynamic_dispatch_basic() {
             },
             lifecycle_hooks: None,
             worker_builder: Box::new(worker_builder),
-            collect_worker_stats: false,
+            stats: None,
         },
     )
     .await
@@ -177,6 +177,7 @@ async fn test_dynamic_dispatch_basic() {
                 key: TestKey { id: 1 },
                 msg: TestMessage::Count(i),
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }
@@ -201,6 +202,7 @@ async fn test_dynamic_dispatch_basic() {
                 key: TestKey { id: 1 },
                 msg: TestMessage::Count(i),
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }

--- a/ractor/src/factory/tests/dynamic_pool.rs
+++ b/ractor/src/factory/tests/dynamic_pool.rs
@@ -131,7 +131,7 @@ async fn test_worker_pool_adjustment_manual() {
             discard_settings: DiscardSettings::None,
             lifecycle_hooks: None,
             worker_builder: Box::new(worker_builder),
-            collect_worker_stats: false,
+            stats: None,
         },
     )
     .await
@@ -144,6 +144,7 @@ async fn test_worker_pool_adjustment_manual() {
                 key: TestKey { id: 1 },
                 msg: TestMessage::Count(i),
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }
@@ -170,6 +171,7 @@ async fn test_worker_pool_adjustment_manual() {
                 key: TestKey { id: 1 },
                 msg: TestMessage::Count(i),
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }
@@ -229,7 +231,7 @@ async fn test_worker_pool_adjustment_automatic() {
             discard_settings: DiscardSettings::None,
             lifecycle_hooks: None,
             worker_builder: Box::new(worker_builder),
-            collect_worker_stats: false,
+            stats: None,
         },
     )
     .await
@@ -242,6 +244,7 @@ async fn test_worker_pool_adjustment_automatic() {
                 key: TestKey { id: 1 },
                 msg: TestMessage::Count(i),
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }
@@ -267,6 +270,7 @@ async fn test_worker_pool_adjustment_automatic() {
                 key: TestKey { id: 1 },
                 msg: TestMessage::Count(i),
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }

--- a/ractor/src/factory/tests/lifecycle.rs
+++ b/ractor/src/factory/tests/lifecycle.rs
@@ -137,7 +137,7 @@ async fn test_lifecycle_hooks() {
             discard_settings: DiscardSettings::None,
             lifecycle_hooks: Some(Box::new(hooks.clone())),
             worker_builder: Box::new(worker_builder),
-            collect_worker_stats: false,
+            stats: None,
         },
     )
     .await

--- a/ractor/src/factory/tests/priority_queueing.rs
+++ b/ractor/src/factory/tests/priority_queueing.rs
@@ -159,7 +159,7 @@ async fn test_basic_priority_queueing() {
                 counters: counters.clone(),
                 signal: signal.clone(),
             }),
-            collect_worker_stats: false,
+            stats: None,
         },
     )
     .await
@@ -175,6 +175,7 @@ async fn test_basic_priority_queueing() {
                 key: pri,
                 msg: TestMessage::Count(1),
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }
@@ -185,6 +186,7 @@ async fn test_basic_priority_queueing() {
                 key: pri,
                 msg: TestMessage::Count(1),
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send to factory");
     }

--- a/ractor/src/factory/tests/worker_lifecycle.rs
+++ b/ractor/src/factory/tests/worker_lifecycle.rs
@@ -125,7 +125,7 @@ async fn test_worker_death_restarts_and_gets_next_message() {
             },
             lifecycle_hooks: None,
             worker_builder: Box::new(worker_builder),
-            collect_worker_stats: false,
+            stats: None,
         },
     )
     .await
@@ -138,6 +138,7 @@ async fn test_worker_death_restarts_and_gets_next_message() {
             key: (),
             msg: MyWorkerMessage::Busy,
             options: JobOptions::default(),
+            accepted: None,
         }))
         .expect("Failed to send message to factory");
     // After it's done being "busy" have it blow up, but we need to push some jobs into the queue asap so that
@@ -147,6 +148,7 @@ async fn test_worker_death_restarts_and_gets_next_message() {
             key: (),
             msg: MyWorkerMessage::Boom,
             options: JobOptions::default(),
+            accepted: None,
         }))
         .expect("Failed to send message to factory");
 
@@ -158,6 +160,7 @@ async fn test_worker_death_restarts_and_gets_next_message() {
                 key: (),
                 msg: MyWorkerMessage::Increment,
                 options: JobOptions::default(),
+                accepted: None,
             }))
             .expect("Failed to send message to factory");
     }

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.11.2"
+version = "0.12.0"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"
@@ -16,15 +16,15 @@ rust-version = "1.64"
 
 [build-dependencies]
 protobuf-src = "2"
-prost-build = { version = "0.12" }
+prost-build = { version = "0.13" }
 
 [dependencies]
 ## Required dependencies
 bytes = { version = "1" }
-prost = { version = "0.12" }
-prost-types = { version = "0.12" }
-ractor = { version = "0.11.0", features = ["cluster"], path = "../ractor" }
-ractor_cluster_derive = { version = "0.11.0", path = "../ractor_cluster_derive" }
+prost = { version = "0.13" }
+prost-types = { version = "0.13" }
+ractor = { version = "0.12.0", features = ["cluster"], path = "../ractor" }
+ractor_cluster_derive = { version = "0.12.0", path = "../ractor_cluster_derive" }
 rand = "0.8"
 sha2 = "0.10"
 tokio = { version = "1", features = ["rt", "time", "sync", "macros", "net", "io-util", "tracing"]}

--- a/ractor_cluster/src/node/node_session/mod.rs
+++ b/ractor_cluster/src/node/node_session/mod.rs
@@ -186,7 +186,7 @@ impl NodeSession {
                         // record the name
                         let name_message = auth_protocol::NameMessage {
                             name: server_challenge_value.name.clone(),
-                            flags: server_challenge_value.flags.clone(),
+                            flags: server_challenge_value.flags,
                             connection_string: server_challenge_value.connection_string.clone(),
                         };
                         state.name = Some(name_message.clone());
@@ -285,7 +285,7 @@ impl NodeSession {
                                                     auth_protocol::authentication_message::Msg::ServerChallenge(
                                                         auth_protocol::Challenge {
                                                             name: self.this_node_name.name.clone(),
-                                                            flags: self.this_node_name.flags.clone(),
+                                                            flags: self.this_node_name.flags,
                                                             challenge: *challenge,
                                                             connection_string: self.this_node_name.connection_string.clone(),
                                                         },

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.11.2"
+version = "0.12.0"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
This patch adds a generic stats layer trait that can be implemented to provide whatever custom statistics collection medium downstream use-cases prefer.

Dynamic dispatch is utilized since we're going to use an `Arc` anyways and given the likelihood of a single implementation, LLVM will likely inline the type anyways. This saves the added generic overhead.