### PR TITLE
Add support for draining an actor's message queue.

### DIFF
--- a/ractor/src/actor/mod.rs
+++ b/ractor/src/actor/mod.rs
@@ -54,6 +54,7 @@
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 
+use actor_properties::MuxedMessage;
 use futures::TryFutureExt;
 
 use crate::concurrency::JoinHandle;
@@ -880,7 +881,7 @@ where
                         }
                     }
                 }
-                actor_cell::ActorPortMessage::Message(msg) => {
+                actor_cell::ActorPortMessage::Message(MuxedMessage::Message(msg)) => {
                     let future = Self::handle_message(myself.clone(), state, handler, msg);
                     match ports.run_with_signal(future).await {
                         Ok(Ok(())) => Ok(ActorLoopResult::ok()),
@@ -889,6 +890,11 @@ where
                             Ok(ActorLoopResult::signal(Self::handle_signal(myself, signal)))
                         }
                     }
+                }
+                actor_cell::ActorPortMessage::Message(MuxedMessage::Drain) => {
+                    // Drain is a stub marker that the actor should now stop, we've processed
+                    // all the messages and we want the actor to die now
+                    Ok(ActorLoopResult::stop(Some("Drained".to_string())))
                 }
             },
             Err(MessagingErr::ChannelClosed) => {

--- a/ractor/src/factory/mod.rs
+++ b/ractor/src/factory/mod.rs
@@ -253,6 +253,13 @@ where
     /// Notify the factory that it's being drained, and to finish jobs
     /// currently in the queue, but discard new work, and once drained
     /// exit
+    ///
+    /// NOTE: This is different from draining the actor itself, which allows the
+    /// pending message queue to flush and then exit. Since the factory
+    /// holds an internal queue for jobs, it's possible that the internal
+    /// state still has work to do while the factory's input queue is drained.
+    /// Therefore in order to propertly drain a factory, you should use the
+    /// `DrainRequests` version so the internal pending queue is properly flushed.
     DrainRequests,
 }
 


### PR DESCRIPTION
This is done by multiplexing the low-pri messaging port and when an internal draining message is received, we've emptied the actor's queue and can shut down.

Test coverage added.