### PR TITLE
fix issue where remote actors in PG's were always joined into the default scope locally

### DIFF
--- a/ractor_cluster/src/node/node_session/mod.rs
+++ b/ractor_cluster/src/node/node_session/mod.rs
@@ -533,11 +533,12 @@ impl NodeSession {
                     // join the remote actors to the local PG group
                     if !cells.is_empty() {
                         tracing::debug!(
-                            "PG Join group '{}' for {} remote actors",
+                            "PG Join scope '{}' and group '{}' for {} remote actors",
+                            join.scope,
                             join.group,
                             cells.len()
                         );
-                        ractor::pg::join(join.group, cells);
+                        ractor::pg::join_scoped(join.scope, join.group, cells);
                     }
                 }
                 control_protocol::control_message::Msg::PgLeave(leave) => {
@@ -550,11 +551,12 @@ impl NodeSession {
                     // join the remote actors to the local PG group
                     if !cells.is_empty() {
                         tracing::debug!(
-                            "PG Leave group '{}' for {} remote actors",
+                            "PG Leave scope '{}' and group '{}' for {} remote actors",
+                            leave.scope,
                             leave.group,
                             cells.len()
                         );
-                        ractor::pg::leave(leave.group, cells);
+                        ractor::pg::leave_scoped(leave.scope, leave.group, cells);
                     }
                 }
                 control_protocol::control_message::Msg::EnumerateNodeSessions(whos_asking) => {

--- a/ractor_cluster/src/node/node_session/tests.rs
+++ b/ractor_cluster/src/node/node_session/tests.rs
@@ -784,11 +784,20 @@ async fn node_session_handle_control() {
         .await
         .expect("Failed to process control message");
     assert_eq!(1, state.remote_actors.len());
-    let id_set = ractor::pg::get_members(&group_name.to_string())
+    let id_set = ractor::pg::get_scoped_members(&scope_name.to_string(), &group_name.to_string())
         .into_iter()
         .map(|a| a.get_id())
         .collect::<HashSet<_>>();
     assert!(id_set.contains(&ActorId::Remote {
+        node_id: 1,
+        pid: 43
+    }));
+
+    let id_set = ractor::pg::get_members(&group_name.to_string())
+        .into_iter()
+        .map(|a| a.get_id())
+        .collect::<HashSet<_>>();
+    assert!(!id_set.contains(&ActorId::Remote {
         node_id: 1,
         pid: 43
     }));
@@ -814,6 +823,14 @@ async fn node_session_handle_control() {
         .await
         .expect("Failed to process control message");
     assert_eq!(1, state.remote_actors.len());
+    let id_set = ractor::pg::get_scoped_members(&scope_name.to_string(), &group_name.to_string())
+        .into_iter()
+        .map(|a| a.get_id())
+        .collect::<HashSet<_>>();
+    assert!(!id_set.contains(&ActorId::Remote {
+        node_id: 1,
+        pid: 43
+    }));
     let id_set = ractor::pg::get_members(&group_name.to_string())
         .into_iter()
         .map(|a| a.get_id())


### PR DESCRIPTION
Currently remote actors are always joined into the default process group.

This patch properly joins them into the scoped groups that are transmitted by the remote node.