### PR TITLE
Add silent-retry support for factory messages + support for factories without `async-trait`

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/src/actor/actor_cell.rs
+++ b/ractor/src/actor/actor_cell.rs
@@ -103,7 +103,7 @@ impl ActorPortSet {
     /// Returns [Ok(`TState`)] when the future completes without
     /// signal interruption, [Err(Signal)] in the event the
     /// signal interrupts the async work.
-    pub async fn run_with_signal<TState>(
+    pub(crate) async fn run_with_signal<TState>(
         &mut self,
         future: impl std::future::Future<Output = TState>,
     ) -> Result<TState, Signal>
@@ -148,7 +148,9 @@ impl ActorPortSet {
     ///
     /// Returns [Ok(ActorPortMessage)] on a successful message reception, [MessagingErr]
     /// in the event any of the channels is closed.
-    pub async fn listen_in_priority(&mut self) -> Result<ActorPortMessage, MessagingErr<()>> {
+    pub(crate) async fn listen_in_priority(
+        &mut self,
+    ) -> Result<ActorPortMessage, MessagingErr<()>> {
         #[cfg(feature = "async-std")]
         {
             crate::concurrency::select! {

--- a/ractor/src/actor/messages.rs
+++ b/ractor/src/actor/messages.rs
@@ -24,6 +24,12 @@ pub struct BoxedState {
     pub msg: Option<Box<dyn Any + Send>>,
 }
 
+impl Debug for BoxedState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "BoxedState")
+    }
+}
+
 impl BoxedState {
     /// Create a new [BoxedState] from a strongly-typed message
     pub fn new<T>(msg: T) -> Self

--- a/ractor/src/actor/mod.rs
+++ b/ractor/src/actor/mod.rs
@@ -50,6 +50,7 @@
 //! log to `stderr` for tracing. You can additionally setup a [panic hook](https://doc.rust-lang.org/std/panic/fn.set_hook.html)
 //! to do things like capturing backtraces on the unwinding panic.
 
+use std::fmt::Debug;
 #[cfg(not(feature = "async-trait"))]
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
@@ -476,6 +477,16 @@ where
     handler: TActor,
     id: ActorId,
     name: Option<String>,
+}
+
+impl<TActor: Actor> Debug for ActorRuntime<TActor> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(name) = self.name.as_ref() {
+            write!(f, "ActorRuntime('{}' - {})", name, self.id)
+        } else {
+            write!(f, "ActorRuntime({})", self.id)
+        }
+    }
 }
 
 impl<TActor> ActorRuntime<TActor>

--- a/ractor/src/actor/tests/mod.rs
+++ b/ractor/src/actor/tests/mod.rs
@@ -967,7 +967,7 @@ fn returns_actor_references() {
 async fn actor_failing_in_spawn_err_doesnt_poison_registries() {
     struct Test;
 
-    #[crate::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Test {
         type Msg = ();
         type State = ();
@@ -980,7 +980,7 @@ async fn actor_failing_in_spawn_err_doesnt_poison_registries() {
 
     struct Test2;
 
-    #[crate::async_trait]
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl Actor for Test2 {
         type Msg = ();
         type State = ();

--- a/ractor/src/factory/discard.rs
+++ b/ractor/src/factory/discard.rs
@@ -145,7 +145,22 @@ pub trait DynamicDiscardController: Send + Sync + 'static {
     /// `base_controller.factory.{FACTORY_NAME}.{STAT}`
     ///
     /// If no factory name is set, then "all" will be inserted
+    #[cfg(feature = "async-trait")]
     async fn compute(&mut self, current_threshold: usize) -> usize;
+
+    /// Compute the new threshold for discarding
+    ///
+    /// If you want to utilize metrics exposed in [crate::factory::stats] you can gather them
+    /// by utilizing `stats_facebook::service_data::get_service_data_singleton` to retrieve a
+    /// accessor to `ServiceData` which you can then resolve stats by name (either timeseries or
+    /// counters)
+    ///
+    /// The namespace of stats collected on the base controller factory are
+    /// `base_controller.factory.{FACTORY_NAME}.{STAT}`
+    ///
+    /// If no factory name is set, then "all" will be inserted
+    #[cfg(not(feature = "async-trait"))]
+    fn compute(&mut self, current_threshold: usize) -> futures::future::BoxFuture<'_, usize>;
 }
 
 /// Reason for discarding a job

--- a/ractor/src/factory/discard.rs
+++ b/ractor/src/factory/discard.rs
@@ -9,7 +9,7 @@ use super::JobKey;
 use crate::Message;
 
 /// The discard mode of a factory
-#[derive(Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum DiscardMode {
     /// Discard oldest incoming jobs under backpressure
     Oldest,
@@ -28,6 +28,7 @@ pub enum DiscardMode {
 /// workers. The workers "think" it's static, but the factory handles the dynamics.
 /// This way the factory can keep the [DynamicDiscardHandler] as a single, uncloned
 /// instance. It also moves NUM_WORKER calculations to 1.
+#[derive(Debug)]
 pub(crate) enum WorkerDiscardSettings {
     None,
     Static { limit: usize, mode: DiscardMode },
@@ -84,6 +85,26 @@ pub enum DiscardSettings {
     },
 }
 
+impl std::fmt::Debug for DiscardSettings {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DiscardSettings::None => {
+                write!(f, "DiscardSettings::None")
+            }
+            DiscardSettings::Static { limit, mode } => f
+                .debug_struct("DiscardSettings::Static")
+                .field("limit", limit)
+                .field("mode", mode)
+                .finish(),
+            DiscardSettings::Dynamic { limit, mode, .. } => f
+                .debug_struct("DiscardSettings::Dynamic")
+                .field("limit", limit)
+                .field("mode", mode)
+                .finish(),
+        }
+    }
+}
+
 impl DiscardSettings {
     pub(crate) fn get_worker_settings(&self) -> WorkerDiscardSettings {
         match &self {
@@ -128,6 +149,7 @@ pub trait DynamicDiscardController: Send + Sync + 'static {
 }
 
 /// Reason for discarding a job
+#[derive(Debug)]
 pub enum DiscardReason {
     /// The job TTLd
     TtlExpired,

--- a/ractor/src/factory/factoryimpl.rs
+++ b/ractor/src/factory/factoryimpl.rs
@@ -7,6 +7,7 @@
 
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -38,7 +39,7 @@ const PING_FREQUENCY: Duration = Duration::from_millis(150);
 const PING_FREQUENCY: Duration = Duration::from_millis(10_000);
 const CALCULATE_FREQUENCY: Duration = Duration::from_millis(100);
 
-#[derive(Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 enum DrainState {
     NotDraining,
     Draining,
@@ -49,6 +50,7 @@ enum DrainState {
 ///
 /// This is a placeholder instance which contains all of the type specifications
 /// for the factories properties
+#[derive(Debug)]
 pub struct Factory<TKey, TMsg, TWorkerStart, TWorker, TRouter, TQueue>
 where
     TKey: JobKey,
@@ -148,6 +150,30 @@ where
     pub stats: Option<Arc<dyn FactoryStatsLayer>>,
 }
 
+impl<TKey, TMsg, TWorkerStart, TWorker, TRouter, TQueue> Debug
+    for FactoryArguments<TKey, TMsg, TWorkerStart, TWorker, TRouter, TQueue>
+where
+    TKey: JobKey,
+    TMsg: Message,
+    TWorkerStart: Message,
+    TWorker: Actor<
+        Msg = WorkerMessage<TKey, TMsg>,
+        Arguments = WorkerStartContext<TKey, TMsg, TWorkerStart>,
+    >,
+    TRouter: Router<TKey, TMsg>,
+    TQueue: Queue<TKey, TMsg>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FactoryArguments")
+            .field("num_initial_workers", &self.num_initial_workers)
+            .field("router", &std::any::type_name::<TRouter>())
+            .field("queue", &std::any::type_name::<TQueue>())
+            .field("discard_settings", &self.discard_settings)
+            .field("dead_mans_switch", &self.dead_mans_switch)
+            .finish()
+    }
+}
+
 /// Builder for [FactoryArguments] which can be used to build the
 /// [Factory]'s startup arguments.
 pub struct FactoryArgumentsBuilder<TKey, TMsg, TWorkerStart, TWorker, TRouter, TQueue>
@@ -174,6 +200,30 @@ where
     capacity_controller: Option<Box<dyn WorkerCapacityController>>,
     lifecycle_hooks: Option<Box<dyn FactoryLifecycleHooks<TKey, TMsg>>>,
     stats: Option<Arc<dyn FactoryStatsLayer>>,
+}
+
+impl<TKey, TMsg, TWorkerStart, TWorker, TRouter, TQueue> Debug
+    for FactoryArgumentsBuilder<TKey, TMsg, TWorkerStart, TWorker, TRouter, TQueue>
+where
+    TKey: JobKey,
+    TMsg: Message,
+    TWorkerStart: Message,
+    TWorker: Actor<
+        Msg = WorkerMessage<TKey, TMsg>,
+        Arguments = WorkerStartContext<TKey, TMsg, TWorkerStart>,
+    >,
+    TRouter: Router<TKey, TMsg>,
+    TQueue: Queue<TKey, TMsg>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FactoryArgumentsBuilder")
+            .field("num_initial_workers", &self.num_initial_workers)
+            .field("router", &std::any::type_name::<TRouter>())
+            .field("queue", &std::any::type_name::<TQueue>())
+            .field("discard_settings", &self.discard_settings)
+            .field("dead_mans_switch", &self.dead_mans_switch)
+            .finish()
+    }
 }
 
 impl<TKey, TMsg, TWorkerStart, TWorker, TRouter, TQueue>
@@ -371,6 +421,32 @@ where
     dead_mans_switch: Option<DeadMansSwitchConfiguration>,
     capacity_controller: Option<Box<dyn WorkerCapacityController>>,
     lifecycle_hooks: Option<Box<dyn FactoryLifecycleHooks<TKey, TMsg>>>,
+}
+
+impl<TKey, TMsg, TWorkerStart, TWorker, TRouter, TQueue> Debug
+    for FactoryState<TKey, TMsg, TWorker, TWorkerStart, TRouter, TQueue>
+where
+    TKey: JobKey,
+    TMsg: Message,
+    TWorkerStart: Message,
+    TWorker: Actor<
+        Msg = WorkerMessage<TKey, TMsg>,
+        Arguments = WorkerStartContext<TKey, TMsg, TWorkerStart>,
+    >,
+    TRouter: Router<TKey, TMsg>,
+    TQueue: Queue<TKey, TMsg>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FactoryState")
+            .field("factory_name", &self.factory_name)
+            .field("pool_size", &self.pool_size)
+            .field("router", &std::any::type_name::<TRouter>())
+            .field("queue", &std::any::type_name::<TQueue>())
+            .field("discard_settings", &self.discard_settings)
+            .field("dead_mans_switch", &self.dead_mans_switch)
+            .field("drain_state", &self.drain_state)
+            .finish()
+    }
 }
 
 impl<TKey, TMsg, TWorker, TWorkerStart, TRouter, TQueue>

--- a/ractor/src/factory/lifecycle.rs
+++ b/ractor/src/factory/lifecycle.rs
@@ -13,6 +13,8 @@ use crate::ActorProcessingErr;
 use crate::ActorRef;
 use crate::Message;
 use crate::State;
+#[cfg(not(feature = "async-trait"))]
+use futures::{future::BoxFuture, FutureExt};
 
 /// Hooks for [crate::factory::Factory] lifecycle events based on the
 /// underlying actor's lifecycle.
@@ -31,10 +33,40 @@ where
     ///
     /// WARNING: An error or panic returned here WILL shutdown the factory and notify supervisors
     #[allow(unused_variables)]
+    #[cfg(feature = "async-trait")]
     async fn on_factory_started(
         &self,
         factory_ref: ActorRef<FactoryMessage<TKey, TMsg>>,
     ) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+
+    /// Called when the factory has completed it's startup routine but
+    /// PRIOR to processing any messages. Just before this point, the factory
+    /// is ready to accept and process requests and all workers are started.
+    ///
+    /// This hook is there to provide custom startup logic you want to make sure has run
+    /// prior to processing messages on workers
+    ///
+    /// WARNING: An error or panic returned here WILL shutdown the factory and notify supervisors
+    #[allow(unused_variables)]
+    #[cfg(not(feature = "async-trait"))]
+    fn on_factory_started(
+        &self,
+        factory_ref: ActorRef<FactoryMessage<TKey, TMsg>>,
+    ) -> BoxFuture<'_, Result<(), ActorProcessingErr>> {
+        async { Ok(()) }.boxed()
+    }
+
+    /// Called when the factory has completed it's shutdown routine but
+    /// PRIOR to fully exiting and notifying any relevant supervisors. Just prior
+    /// to this call the factory has processed its last message and will process
+    /// no more messages.
+    ///
+    /// This hook is there to provide custom shutdown logic you want to make sure has run
+    /// prior to the factory fully exiting
+    #[cfg(feature = "async-trait")]
+    async fn on_factory_stopped(&self) -> Result<(), ActorProcessingErr> {
         Ok(())
     }
 
@@ -45,7 +77,25 @@ where
     ///
     /// This hook is there to provide custom shutdown logic you want to make sure has run
     /// prior to the factory fully exiting
-    async fn on_factory_stopped(&self) -> Result<(), ActorProcessingErr> {
+    #[cfg(not(feature = "async-trait"))]
+    fn on_factory_stopped(&self) -> BoxFuture<'_, Result<(), ActorProcessingErr>> {
+        async { Ok(()) }.boxed()
+    }
+
+    /// Called when the factory has received a signal to drain requests and exit after
+    /// draining has completed.
+    ///
+    /// This hook is to provide the ability to notify external services that the factory
+    /// is in the process of shutting down. If the factory is never "drained" formally,
+    /// this hook won't be called.
+    ///
+    /// WARNING: An error or panic returned here WILL shutdown the factory and notify supervisors
+    #[allow(unused_variables)]
+    #[cfg(feature = "async-trait")]
+    async fn on_factory_draining(
+        &self,
+        factory_ref: ActorRef<FactoryMessage<TKey, TMsg>>,
+    ) -> Result<(), ActorProcessingErr> {
         Ok(())
     }
 
@@ -58,10 +108,11 @@ where
     ///
     /// WARNING: An error or panic returned here WILL shutdown the factory and notify supervisors
     #[allow(unused_variables)]
-    async fn on_factory_draining(
+    #[cfg(not(feature = "async-trait"))]
+    fn on_factory_draining(
         &self,
         factory_ref: ActorRef<FactoryMessage<TKey, TMsg>>,
-    ) -> Result<(), ActorProcessingErr> {
-        Ok(())
+    ) -> BoxFuture<'_, Result<(), ActorProcessingErr>> {
+        async { Ok(()) }.boxed()
     }
 }

--- a/ractor/src/factory/mod.rs
+++ b/ractor/src/factory/mod.rs
@@ -194,7 +194,7 @@ pub use discard::{
     DiscardHandler, DiscardMode, DiscardReason, DiscardSettings, DynamicDiscardController,
 };
 pub use factoryimpl::{Factory, FactoryArguments, FactoryArgumentsBuilder};
-pub use job::{Job, JobKey, JobOptions};
+pub use job::{Job, JobKey, JobOptions, MessageRetryStrategy, RetriableMessage};
 pub use lifecycle::FactoryLifecycleHooks;
 pub use worker::{
     DeadMansSwitchConfiguration, WorkerBuilder, WorkerCapacityController, WorkerMessage,
@@ -212,6 +212,7 @@ pub type WorkerId = usize;
 /// in-host communication. This means if you're communicating to a factory you would
 /// send only a serialized [Job] which would automatically be converted to a
 /// [FactoryMessage::Dispatch(Job)]
+#[derive(Debug)]
 pub enum FactoryMessage<TKey, TMsg>
 where
     TKey: JobKey,

--- a/ractor/src/factory/queues.rs
+++ b/ractor/src/factory/queues.rs
@@ -6,6 +6,7 @@
 //! Queue implementations for Factories
 
 use std::collections::VecDeque;
+use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -148,6 +149,16 @@ where
     q: VecDeque<Job<TKey, TMsg>>,
 }
 
+impl<TKey, TMsg> Debug for DefaultQueue<TKey, TMsg>
+where
+    TKey: JobKey,
+    TMsg: Message,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DefaultQueue({} items)", self.q.len())
+    }
+}
+
 impl<TKey, TMsg> Default for DefaultQueue<TKey, TMsg>
 where
     TKey: JobKey,
@@ -227,6 +238,19 @@ where
     queues: [VecDeque<Job<TKey, TMsg>>; NUM_PRIORITIES],
     priority_manager: TPriorityManager,
     _p: PhantomData<fn() -> TPriority>,
+}
+
+impl<TKey, TMsg, TPriority, TPriorityManager, const NUM_PRIORITIES: usize> Debug
+    for PriorityQueue<TKey, TMsg, TPriority, TPriorityManager, NUM_PRIORITIES>
+where
+    TKey: JobKey,
+    TMsg: Message,
+    TPriority: Priority,
+    TPriorityManager: PriorityManager<TKey, TPriority>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PriorityQueue({} items)", self.len())
+    }
 }
 
 impl<TKey, TMsg, TPriority, TPriorityManager, const NUM_PRIORITIES: usize>

--- a/ractor/src/factory/routing.rs
+++ b/ractor/src/factory/routing.rs
@@ -25,6 +25,7 @@ where
 }
 
 /// The possible results from a routing operation.
+#[derive(Debug)]
 pub enum RouteResult<TKey, TMsg>
 where
     TKey: JobKey,
@@ -92,6 +93,7 @@ where
 macro_rules! impl_routing_mode {
     ($routing_mode: ident, $doc:expr) => {
         #[doc = $doc]
+        #[derive(Debug)]
         pub struct $routing_mode<TKey, TMsg>
         where
             TKey: JobKey,
@@ -256,6 +258,7 @@ where
 /// Factory will dispatch to the next worker in order.
 ///
 /// Workers will have jobs placed into their incoming message queue's
+#[derive(Debug)]
 pub struct RoundRobinRouting<TKey, TMsg>
 where
     TKey: JobKey,
@@ -324,6 +327,7 @@ where
 ///
 /// The factory maintains no queue in this scenario, and jobs are pushed
 /// to worker's queues.
+#[derive(Debug)]
 pub struct CustomRouting<TKey, TMsg, THasher>
 where
     TKey: JobKey,

--- a/ractor/src/factory/tests/dynamic_discarding.rs
+++ b/ractor/src/factory/tests/dynamic_discarding.rs
@@ -3,6 +3,8 @@
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree.
 
+#[cfg(not(feature = "async-trait"))]
+use futures::{future::BoxFuture, FutureExt};
 use std::sync::atomic::AtomicU16;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -120,8 +122,14 @@ struct DiscardController {}
 
 #[cfg_attr(feature = "async-trait", crate::async_trait)]
 impl DynamicDiscardController for DiscardController {
+    #[cfg(feature = "async-trait")]
     async fn compute(&mut self, _current_threshold: usize) -> usize {
         10
+    }
+
+    #[cfg(not(feature = "async-trait"))]
+    fn compute(&mut self, _current_threshold: usize) -> BoxFuture<'_, usize> {
+        async { 10 }.boxed()
     }
 }
 

--- a/ractor/src/factory/tests/dynamic_pool.rs
+++ b/ractor/src/factory/tests/dynamic_pool.rs
@@ -8,6 +8,9 @@
 
 use std::sync::Arc;
 
+#[cfg(not(feature = "async-trait"))]
+use futures::{future::BoxFuture, FutureExt};
+
 use crate::concurrency::Duration;
 use crate::Actor;
 use crate::ActorProcessingErr;
@@ -200,8 +203,14 @@ async fn test_worker_pool_adjustment_automatic() {
 
     #[cfg_attr(feature = "async-trait", crate::async_trait)]
     impl WorkerCapacityController for DynamicWorkerController {
+        #[cfg(feature = "async-trait")]
         async fn get_pool_size(&mut self, _current: usize) -> usize {
             10
+        }
+
+        #[cfg(not(feature = "async-trait"))]
+        fn get_pool_size(&mut self, _current: usize) -> BoxFuture<'_, usize> {
+            async { 10 }.boxed()
         }
     }
 

--- a/ractor/src/factory/worker.rs
+++ b/ractor/src/factory/worker.rs
@@ -6,6 +6,7 @@
 //! Factory worker properties
 
 use std::collections::{HashMap, VecDeque};
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use crate::concurrency::{Duration, Instant, JoinHandle};
@@ -21,6 +22,7 @@ use super::WorkerId;
 use super::{DiscardHandler, DiscardReason, JobOptions};
 
 /// The configuration for the dead-man's switch functionality
+#[derive(Debug)]
 pub struct DeadMansSwitchConfiguration {
     /// Duration before determining worker is stuck
     pub detection_timeout: Duration,
@@ -61,6 +63,7 @@ pub trait WorkerCapacityController: 'static + Send + Sync {
 }
 
 /// Message to a worker
+#[derive(Debug)]
 pub enum WorkerMessage<TKey, TMsg>
 where
     TKey: JobKey,
@@ -86,6 +89,7 @@ where
 }
 
 /// Startup context data (`Arguments`) which are passed to a worker on start
+#[derive(Debug)]
 pub struct WorkerStartContext<TKey, TMsg, TCustomStart>
 where
     TKey: JobKey,
@@ -146,6 +150,22 @@ where
 
     /// Flag indicating if this worker is currently "draining" work due to resizing
     pub(crate) is_draining: bool,
+}
+
+impl<TKey, TMsg> Debug for WorkerProperties<TKey, TMsg>
+where
+    TKey: JobKey,
+    TMsg: Message,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkerProperties")
+            .field("wid", &self.wid)
+            .field("actor", &self.actor)
+            .field("factory_name", &self.factory_name)
+            .field("discard_settings", &self.discard_settings)
+            .field("is_draining", &self.is_draining)
+            .finish()
+    }
 }
 
 impl<TKey, TMsg> WorkerProperties<TKey, TMsg>

--- a/ractor/src/factory/worker.rs
+++ b/ractor/src/factory/worker.rs
@@ -59,7 +59,17 @@ pub trait WorkerCapacityController: 'static + Send + Sync {
     ///
     /// Returns the "new" pool size. If returns 0, adjustment will be
     /// ignored
+    #[cfg(feature = "async-trait")]
     async fn get_pool_size(&mut self, current: usize) -> usize;
+
+    /// Retrieve the new pool size
+    ///
+    /// * `current` - The current pool size
+    ///
+    /// Returns the "new" pool size. If returns 0, adjustment will be
+    /// ignored
+    #[cfg(not(feature = "async-trait"))]
+    fn get_pool_size(&mut self, current: usize) -> futures::future::BoxFuture<'_, usize>;
 }
 
 /// Message to a worker

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -165,7 +165,6 @@ pub(crate) mod common_test;
 pub use common_test::*;
 pub mod concurrency;
 pub mod errors;
-#[cfg(feature = "async-trait")]
 pub mod factory;
 pub mod macros;
 pub mod message;

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -143,12 +143,18 @@
 //!    are how an actor's supervisor(s) are notified of events of their children and can handle lifetime events for them.
 //! 4. Messages: Regular, user-defined, messages are the last channel of communication to actors. They are the lowest priority of the 4 message types and denote general actor work. The first
 //!    3 messages types (signals, stop, supervision) are generally quiet unless it's a lifecycle event for the actor, but this channel is the "work" channel doing what your actor wants to do!
-
-#![warn(unused_imports)]
-// #![warn(unsafe_code)]
-#![warn(missing_docs)]
-#![warn(unused_crate_dependencies)]
-// #![cfg_attr(docsrs, feature(doc_cfg))]
+#![warn(
+    dead_code,
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    rustdoc::all,
+    rustdoc::missing_crate_level_docs,
+    unreachable_pub,
+    unused_imports,
+    unused_variables,
+    unused_crate_dependencies
+)]
 
 // ======================== Modules ======================== //
 

--- a/ractor/src/message.rs
+++ b/ractor/src/message.rs
@@ -26,6 +26,7 @@ impl std::error::Error for BoxedDowncastErr {}
 
 /// Represents a serialized call or cast message
 #[cfg(feature = "cluster")]
+#[derive(Debug)]
 pub enum SerializedMessage {
     /// A cast (one-way) with the serialized payload
     Cast {
@@ -64,6 +65,16 @@ pub struct BoxedMessage {
     #[cfg(feature = "cluster")]
     pub serialized_msg: Option<SerializedMessage>,
     pub(crate) span: Option<tracing::Span>,
+}
+
+impl std::fmt::Debug for BoxedMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.msg.is_some() {
+            write!(f, "BoxedMessage(Local)")
+        } else {
+            write!(f, "BoxedMessage(Serialized)")
+        }
+    }
 }
 
 /// Message type for an actor. Generally an enum

--- a/ractor/src/pg/mod.rs
+++ b/ractor/src/pg/mod.rs
@@ -91,7 +91,7 @@ pub const ALL_GROUPS_NOTIFICATION: &str = "__world_group_";
 mod tests;
 
 /// Represents a change in a process group's membership
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum GroupChangeMessage {
     /// Some actors joined a group
     Join(ScopeName, GroupName, Vec<ActorCell>),
@@ -119,7 +119,7 @@ impl GroupChangeMessage {
 
 /// Represents the combination of a `ScopeName` and a `GroupName`
 /// that uniquely identifies a specific group in a specific scope
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ScopeGroupKey {
     /// the `ScopeName`
     scope: ScopeName,

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
This pull request adds a few things.

1. I'm enabling a lot more warning messages on the core `ractor` crate in order to maintain a higher code quality. This induced a lot of needlessly `pub` functions to be marked as `pub(crate)` since the visibility was controlled by the parent struct anyways. Additionally a lot of `Debug` implementations are added for publicly exported types.
2. This adds a new type called `RetriableMessage` which when used in conjunction with a `Factory` allows us to automatically retry a message should it be dropped due to a factory worker failing (or panicking). Tests added on this functionality.
3. Lastly as requested in #272 and #248, with the stabilization of async traits natively, factories were gated behind the `async-trait` feature since we utilized `dyn Trait` with async methods, which is **not** natively supported. For those specific traits (`DynamicDiscardController`, `FactoryLifecycleHooks`, and `WorkerCapacityController`) I've migrated them to `BoxFuture<'_, TOutput>` in order to ungate factory usage with native async traits. This is thankfully possible due to the large factory rewrite that occurred in #237 which greatly improved the factory ergnomics.


Resolves #272 