### PR TITLE
Add child operations from supervision tree AND type_id support

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/src/actor/actor_properties.rs
+++ b/ractor/src/actor/actor_properties.rs
@@ -174,6 +174,14 @@ impl ActorProperties {
             .map_err(|_| MessagingErr::SendErr(()))
     }
 
+    /// Start draining, and wait for the actor to exit
+    pub(crate) async fn drain_and_wait(&self) -> Result<(), MessagingErr<()>> {
+        let rx = self.wait_handler.notified();
+        self.drain()?;
+        rx.await;
+        Ok(())
+    }
+
     #[cfg(feature = "cluster")]
     pub(crate) fn send_serialized(
         &self,

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
This patch does 2 things

1. Adds ability to access the type id and runtime check the message type of an `ActorCell`. RE: #276
2. Adds ability to stop & drain children actors, by traversing the supervision tree, instead of requiring users to hold the handles themselves in the states. RE: #226