### PR TITLE
Large cleanup

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.12.4"
+version = "0.13.0"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"
@@ -26,6 +26,7 @@ default = ["tokio_runtime", "async-trait"]
 
 [dependencies]
 ## Required dependencies
+bon = "2"
 dashmap = "6"
 futures = "0.3"
 once_cell = "1"

--- a/ractor/src/actor/actor_cell.rs
+++ b/ractor/src/actor/actor_cell.rs
@@ -201,11 +201,24 @@ pub struct ActorCell {
 
 impl std::fmt::Debug for ActorCell {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(name) = self.get_name() {
-            write!(f, "Actor '{}' (id: {})", name, self.get_id())
-        } else {
-            write!(f, "Actor with id: {}", self.get_id())
-        }
+        f.debug_struct("Actor")
+            .field("name", &self.get_name())
+            .field("id", &self.get_id())
+            .finish()
+    }
+}
+
+impl PartialEq for ActorCell {
+    fn eq(&self, other: &Self) -> bool {
+        other.get_id() == self.get_id()
+    }
+}
+
+impl Eq for ActorCell {}
+
+impl std::hash::Hash for ActorCell {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.get_id().hash(state)
     }
 }
 

--- a/ractor/src/actor/actor_id.rs
+++ b/ractor/src/actor/actor_id.rs
@@ -31,17 +31,26 @@ impl ActorId {
     /// Determine if this actor id is a local or remote actor
     ///
     /// Returns [true] if it is a local actor, [false] otherwise
-    pub fn is_local(&self) -> bool {
+    pub const fn is_local(&self) -> bool {
         matches!(self, ActorId::Local(_))
     }
 
     /// Retrieve the actor's PID
     ///
     /// Returns the actor's [u64] instance identifier (process id).
-    pub fn pid(&self) -> u64 {
+    pub const fn pid(&self) -> u64 {
         match self {
             ActorId::Local(pid) => *pid,
             ActorId::Remote { pid, .. } => *pid,
+        }
+    }
+
+    /// Retrieve the node id of this PID. 0 = a local actor, while
+    /// any non-zero value is the ide of the remote node running this actor
+    pub const fn node(&self) -> u64 {
+        match self {
+            ActorId::Local(_) => 0,
+            ActorId::Remote { node_id, .. } => *node_id,
         }
     }
 }

--- a/ractor/src/actor/actor_ref.rs
+++ b/ractor/src/actor/actor_ref.rs
@@ -5,7 +5,6 @@
 
 //! [ActorRef] is a strongly-typed wrapper over an [ActorCell]
 
-use std::any::TypeId;
 use std::marker::PhantomData;
 
 use crate::{ActorName, Message, MessagingErr, SupervisionEvent};
@@ -57,7 +56,7 @@ impl<TActor> From<ActorRef<TActor>> for ActorCell {
 
 impl<TMessage> std::fmt::Debug for ActorRef<TMessage> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.inner)
+        self.inner.fmt(f)
     }
 }
 
@@ -101,13 +100,11 @@ where
     pub fn where_is(name: ActorName) -> Option<crate::actor::ActorRef<TMessage>> {
         if let Some(actor) = crate::registry::where_is(name) {
             // check the type id when pulling from the registry
-            if actor.get_type_id() == TypeId::of::<TMessage>() {
-                Some(actor.into())
-            } else {
-                None
+            let check = actor.is_message_type_of::<TMessage>();
+            if check.is_none() || matches!(check, Some(true)) {
+                return Some(actor.into());
             }
-        } else {
-            None
         }
+        None
     }
 }

--- a/ractor/src/actor/messages.rs
+++ b/ractor/src/actor/messages.rs
@@ -26,7 +26,7 @@ pub struct BoxedState {
 
 impl Debug for BoxedState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "BoxedState")
+        f.debug_struct("BoxedState").finish()
     }
 }
 
@@ -61,17 +61,12 @@ impl BoxedState {
 }
 
 /// Messages to stop an actor
+#[derive(Debug)]
 pub enum StopMessage {
     /// Normal stop
     Stop,
     /// Stop with a reason
     Reason(String),
-}
-
-impl Debug for StopMessage {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Stop message: {self}")
-    }
 }
 
 impl std::fmt::Display for StopMessage {
@@ -172,16 +167,10 @@ impl std::fmt::Display for SupervisionEvent {
 }
 
 /// A signal message which takes priority above all else
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Signal {
     /// Terminate the agent, cancelling all async work immediately
     Kill,
-}
-
-impl Debug for Signal {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Signal: {self}")
-    }
 }
 
 impl std::fmt::Display for Signal {

--- a/ractor/src/actor/mod.rs
+++ b/ractor/src/actor/mod.rs
@@ -102,7 +102,7 @@ pub(crate) fn get_panic_string(e: Box<dyn std::any::Any + Send>) -> ActorProcess
 /// * `post_stop`
 /// * `handle`
 /// * `handle_serialized` (Available with `cluster` feature only)
-/// * `handle_supervision_evt`
+/// * `handle_supervisor_evt`
 ///
 /// return a [Result<_, ActorProcessingError>] where the error type is an
 /// alias of [Box<dyn std::error::Error + Send + Sync + 'static>]. This is treated
@@ -481,11 +481,10 @@ where
 
 impl<TActor: Actor> Debug for ActorRuntime<TActor> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(name) = self.name.as_ref() {
-            write!(f, "ActorRuntime('{}' - {})", name, self.id)
-        } else {
-            write!(f, "ActorRuntime({})", self.id)
-        }
+        f.debug_struct("ActorRuntime")
+            .field("name", &self.name)
+            .field("id", &self.id)
+            .finish()
     }
 }
 

--- a/ractor/src/actor/tests/mod.rs
+++ b/ractor/src/actor/tests/mod.rs
@@ -956,6 +956,8 @@ fn returns_actor_references() {
     ];
 
     for (want, event) in tests {
+        // Cloned cells are "equal" since they point to the same actor id
+        assert_eq!(event.actor_cell(), event.actor_cell().clone());
         assert_eq!(event.actor_cell().is_some(), want);
         assert_eq!(event.actor_id().is_some(), want);
     }

--- a/ractor/src/factory/mod.rs
+++ b/ractor/src/factory/mod.rs
@@ -118,7 +118,7 @@
 //! /// Used by the factory to build new [ExampleWorker]s.
 //! struct ExampleWorkerBuilder;
 //! impl WorkerBuilder<ExampleWorker, ()> for ExampleWorkerBuilder {
-//!     fn build(&self, _wid: usize) -> (ExampleWorker, ()) {
+//!     fn build(&mut self, _wid: usize) -> (ExampleWorker, ()) {
 //!         (ExampleWorker, ())
 //!     }
 //! }
@@ -132,8 +132,11 @@
 //!         routing::QueuerRouting<(), ExampleMessage>,
 //!         queues::DefaultQueue<(), ExampleMessage>
 //!     >::default();
-//!     let factory_args = FactoryArgumentsBuilder::new(ExampleWorkerBuilder, Default::default(), Default::default())
-//!         .with_number_of_initial_workers(5)
+//!     let factory_args = FactoryArguments::builder()
+//!         .worker_builder(Box::new(ExampleWorkerBuilder))
+//!         .queue(Default::default())
+//!         .router(Default::default())
+//!         .num_initial_workers(5)
 //!         .build();
 //!     
 //!     let (factory, handle) = Actor::spawn(None, factory_def, factory_args)

--- a/ractor/src/factory/queues.rs
+++ b/ractor/src/factory/queues.rs
@@ -47,7 +47,7 @@ where
     /// Remove expired items from the queue
     ///
     /// * `discard_handler` - The handler to call for each discarded job. Will be called
-    ///   with [DiscardReason::Loadshed].
+    ///   with [DiscardReason::TtlExpired].
     ///
     /// Returns the number of elements removed from the queue
     fn remove_expired_items(

--- a/ractor/src/factory/tests/dynamic_discarding.rs
+++ b/ractor/src/factory/tests/dynamic_discarding.rs
@@ -97,7 +97,7 @@ struct SlowTestWorkerBuilder {
 }
 
 impl WorkerBuilder<TestWorker, ()> for SlowTestWorkerBuilder {
-    fn build(&self, wid: usize) -> (TestWorker, ()) {
+    fn build(&mut self, wid: usize) -> (TestWorker, ()) {
         (
             TestWorker {
                 counter: self.counters[wid].clone(),

--- a/ractor/src/factory/tests/dynamic_pool.rs
+++ b/ractor/src/factory/tests/dynamic_pool.rs
@@ -93,7 +93,7 @@ struct TestWorkerBuilder {
 }
 
 impl WorkerBuilder<TestWorker, ()> for TestWorkerBuilder {
-    fn build(&self, _wid: usize) -> (TestWorker, ()) {
+    fn build(&mut self, _wid: usize) -> (TestWorker, ()) {
         (
             TestWorker {
                 id_map: self.id_map.clone(),

--- a/ractor/src/factory/tests/lifecycle.rs
+++ b/ractor/src/factory/tests/lifecycle.rs
@@ -141,7 +141,7 @@ impl Actor for TestWorker {
 struct TestWorkerBuilder;
 
 impl WorkerBuilder<TestWorker, ()> for TestWorkerBuilder {
-    fn build(&self, _wid: crate::factory::WorkerId) -> (TestWorker, ()) {
+    fn build(&mut self, _wid: crate::factory::WorkerId) -> (TestWorker, ()) {
         (TestWorker, ())
     }
 }

--- a/ractor/src/factory/tests/worker_lifecycle.rs
+++ b/ractor/src/factory/tests/worker_lifecycle.rs
@@ -87,7 +87,7 @@ struct MyWorkerBuilder {
 }
 
 impl WorkerBuilder<MyWorker, ()> for MyWorkerBuilder {
-    fn build(&self, _wid: crate::factory::WorkerId) -> (MyWorker, ()) {
+    fn build(&mut self, _wid: crate::factory::WorkerId) -> (MyWorker, ()) {
         (
             MyWorker {
                 counter: self.counter.clone(),

--- a/ractor/src/factory/worker.rs
+++ b/ractor/src/factory/worker.rs
@@ -9,6 +9,8 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use bon::Builder;
+
 use crate::concurrency::{Duration, Instant, JoinHandle};
 use crate::{Actor, ActorId, ActorProcessingErr};
 use crate::{ActorRef, Message, MessagingErr};
@@ -22,12 +24,15 @@ use super::WorkerId;
 use super::{DiscardHandler, DiscardReason, JobOptions};
 
 /// The configuration for the dead-man's switch functionality
-#[derive(Debug)]
+#[derive(Builder, Debug)]
 pub struct DeadMansSwitchConfiguration {
     /// Duration before determining worker is stuck
     pub detection_timeout: Duration,
     /// Flag denoting if the stuck worker should be killed
     /// and restarted
+    ///
+    /// Default = [true]
+    #[builder(default = true)]
     pub kill_worker: bool,
 }
 
@@ -46,7 +51,7 @@ where
     ///
     /// Returns a tuple of the worker and a custom startup definition giving the worker
     /// owned control of some structs that it may need to work.
-    fn build(&self, wid: WorkerId) -> (TWorker, TWorkerStart);
+    fn build(&mut self, wid: WorkerId) -> (TWorker, TWorkerStart);
 }
 
 /// Controls the size of the worker pool by dynamically growing/shrinking the pool

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.12.4"
+version = "0.13.0"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"
@@ -23,8 +23,8 @@ prost-build = { version = "0.13" }
 bytes = { version = "1" }
 prost = { version = "0.13" }
 prost-types = { version = "0.13" }
-ractor = { version = "0.12.0", features = ["cluster"], path = "../ractor" }
-ractor_cluster_derive = { version = "0.12.0", path = "../ractor_cluster_derive" }
+ractor = { version = "0.13.0", features = ["cluster"], path = "../ractor" }
+ractor_cluster_derive = { version = "0.13.0", path = "../ractor_cluster_derive" }
 rand = "0.8"
 sha2 = "0.10"
 tokio = { version = "1", features = ["rt", "time", "sync", "macros", "net", "io-util", "tracing"]}

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.12.4"
+version = "0.13.0"
 authors = ["Sean Lawlor <seanlawlor@fb.com>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
1. [COMPAT BREAK] Switch to `bon::Builder` for factory arguments and settings which gives compile-time, vs run-time, safety constructing types.
2. Cleanup a lot of debug impl's
3. Cleanup comments in various places.

And bump the version to 0.13.0 because of the migration to bon