### PR TITLE
Bump ractor dependencies to match their actual use (#285)

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -26,7 +26,7 @@ default = ["tokio_runtime", "async-trait"]
 
 [dependencies]
 ## Required dependencies
-bon = "2"
+bon = "2.2"
 dashmap = "6"
 futures = "0.3"
 once_cell = "1"
@@ -36,7 +36,7 @@ strum = { version = "0.26", features = ["derive"] }
 # Tracing feature requires --cfg=tokio_unstable
 async-std = { version = "1", features = ["attributes"], optional = true }
 async-trait = { version = "0.1", optional = true }
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1.40", features = ["sync"] }
 tracing = { version = "0.1", features = ["attributes"] }
 
 ## Blanket Serde


### PR DESCRIPTION
This addresses issue #285. I went over ractor's dependencies and bumped them where the minimum required version didn't match actual use in code - e.g. use of `JoinSet::join_all` that was only introduced in tokio 1.40.0.

This change is non-breaking - a project that uses ractor and successfully builds must already use versions of tokio/bon at least as recent as these bumped versions.