### PR TITLE
fix: Ensure pending messages are delivered when OutputPort is dropped.

### DIFF
--- a/ractor/src/port/output/mod.rs
+++ b/ractor/src/port/output/mod.rs
@@ -100,19 +100,6 @@ where
     }
 }
 
-impl<TMsg> Drop for OutputPort<TMsg>
-where
-    TMsg: OutputMessage,
-{
-    fn drop(&mut self) {
-        let mut subs = self.subscriptions.write().unwrap();
-        for sub in subs.iter_mut() {
-            sub.stop();
-        }
-        subs.clear();
-    }
-}
-
 // ============== Subscription implementation ============== //
 
 /// The output port's subscription handle. It holds a handle to a [JoinHandle]
@@ -126,11 +113,6 @@ impl OutputPortSubscription {
     /// Determine if the subscription is dead
     pub(crate) fn is_dead(&self) -> bool {
         self.handle.is_finished()
-    }
-
-    /// Stop the subscription, by aborting the underlying [JoinHandle]
-    pub(crate) fn stop(&mut self) {
-        self.handle.abort();
     }
 
     /// Create a new subscription

--- a/ractor/src/port/output/tests.rs
+++ b/ractor/src/port/output/tests.rs
@@ -158,6 +158,84 @@ async fn test_50_receivers() {
         .unwrap();
 }
 
+#[crate::concurrency::test]
+#[tracing_test::traced_test]
+async fn test_delivery() {
+    struct TestActor;
+    enum TestActorMessage {
+        Stop,
+    }
+    #[cfg(feature = "cluster")]
+    impl crate::Message for TestActorMessage {}
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    impl Actor for TestActor {
+        type Msg = TestActorMessage;
+        type Arguments = ();
+        type State = u8;
+
+        async fn pre_start(
+            &self,
+            _this_actor: crate::ActorRef<Self::Msg>,
+            _: (),
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(0u8)
+        }
+
+        async fn handle(
+            &self,
+            myself: ActorRef<Self::Msg>,
+            message: Self::Msg,
+            state: &mut Self::State,
+        ) -> Result<(), ActorProcessingErr> {
+            println!("Test actor received a message");
+            match message {
+                Self::Msg::Stop => {
+                    if *state > 3 {
+                        myself.stop(None);
+                    }
+                }
+            }
+            *state += 1;
+            Ok(())
+        }
+    }
+
+    let handles: Vec<(ActorRef<TestActorMessage>, JoinHandle<()>)> =
+        join_all((0..50).map(|_| async move {
+            Actor::spawn(None, TestActor, ())
+                .await
+                .expect("Failed to start test actor")
+        }))
+            .await;
+
+    let mut actor_refs = vec![];
+    let mut actor_handles = vec![];
+    for item in handles.into_iter() {
+        let (a, b) = item;
+        actor_refs.push(a);
+        actor_handles.push(b);
+    }
+
+    let output = OutputPort::<()>::default();
+    for actor in actor_refs.into_iter() {
+        output.subscribe(actor, |_| Some(TestActorMessage::Stop));
+    }
+
+    let all_handle = crate::concurrency::spawn(async move { join_all(actor_handles).await });
+
+    // send 4 sends, should exit
+    for _ in 0..5 {
+        output.send(());
+    }
+    drop(output);
+
+    timeout(Duration::from_millis(100), all_handle)
+        .await
+        .expect("Test actor failed in exit")
+        .unwrap();
+}
+
+
 #[allow(unused_imports)]
 use output_port_subscriber_tests::*;
 


### PR DESCRIPTION
# Summary

This PR ensures that pending messages are delivered when an `OutputPort` is dropped. 

# Overview

This PR removes the `Drop` implementation from `OutputPort<T>`, which called the `stop` function on all subscribers:

https://github.com/slawlor/ractor/blob/1949d929df17916028cdc3c69be13db725f42694/ractor/src/port/output/mod.rs#L107-L113

Calling the `stop` function would abort the `JoinHandle` of the subscriber:

https://github.com/slawlor/ractor/blob/1949d929df17916028cdc3c69be13db725f42694/ractor/src/port/output/mod.rs#L132-L134

which would immediately terminate the tokio task responsible for delivering messages to the subscriber:

https://github.com/slawlor/ractor/blob/1949d929df17916028cdc3c69be13db725f42694/ractor/src/port/output/mod.rs#L147-L156

Removing the `Drop` implementation still results in the tasks properly shutting down, as per the [`tokio` documentation for closing broadcast channels](https://docs.rs/tokio/latest/tokio/sync/broadcast/index.html#closing):

> ## Closing
> When all [Sender](https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Sender.html) handles have been dropped, no new values may be sent. At this point, the channel is “closed”. Once a receiver has received all values retained by the channel, the next call to [recv](https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Receiver.html#method.recv) will return with [RecvError::Closed](https://docs.rs/tokio/latest/tokio/sync/broadcast/error/enum.RecvError.html#variant.Closed).

The implementation of the receive pump will exit when the channel does not return an `Ok` result:

https://github.com/slawlor/ractor/blob/1949d929df17916028cdc3c69be13db725f42694/ractor/src/port/output/mod.rs#L148