### PR TITLE
fix: get supervisor method typo

### DIFF
--- a/ractor/src/actor/actor_cell.rs
+++ b/ractor/src/actor/actor_cell.rs
@@ -545,7 +545,7 @@ impl ActorCell {
     ///
     /// Returns [None] if this actor has no supervisor at the given instance or
     /// [Some(ActorCell)] supervisor if one is configured.
-    pub fn try_get_superivisor(&self) -> Option<ActorCell> {
+    pub fn try_get_supervisor(&self) -> Option<ActorCell> {
         self.inner.tree.try_get_supervisor()
     }
 

--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -97,7 +97,7 @@ async fn test_supervision_panic_in_post_startup() {
         .await
         .expect("Child panicked on startup");
 
-    let maybe_sup = child_ref.try_get_superivisor();
+    let maybe_sup = child_ref.try_get_supervisor();
     assert!(maybe_sup.is_some());
     assert_eq!(maybe_sup.map(|a| a.get_id()), Some(supervisor_ref.get_id()));
 


### PR DESCRIPTION
There is an additional i in the get supervisor method which is not an issue but it's not correct.