### PR TITLE
Add proper span handling to factories through extension trait

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.13.5"
+version = "0.14.0"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/src/factory/queues.rs
+++ b/ractor/src/factory/queues.rs
@@ -423,10 +423,7 @@ mod tests {
             key: 99,
             accepted: None,
             msg: (),
-            options: JobOptions {
-                ttl: Some(Duration::from_millis(1)),
-                ..Default::default()
-            },
+            options: JobOptions::new(Some(Duration::from_millis(1))),
         });
 
         let oldest = queue.discard_oldest();
@@ -480,10 +477,7 @@ mod tests {
             key: 99,
             accepted: None,
             msg: (),
-            options: JobOptions {
-                ttl: Some(Duration::from_millis(1)),
-                ..Default::default()
-            },
+            options: JobOptions::new(Some(Duration::from_millis(1))),
         });
 
         // should discard lowest pri first

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ractor_cluster"
-version = "0.13.5"
-authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
+version = "0.14.0"
+authors = ["Sean Lawlor <slawlor>"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"
 license = "MIT"
@@ -24,8 +24,8 @@ prost-build = { version = "0.13" }
 bytes = { version = "1" }
 prost = { version = "0.13" }
 prost-types = { version = "0.13" }
-ractor = { version = "0.13.0", features = ["cluster"], path = "../ractor" }
-ractor_cluster_derive = { version = "0.13.0", path = "../ractor_cluster_derive" }
+ractor = { version = "0.14.0", features = ["cluster"], path = "../ractor" }
+ractor_cluster_derive = { version = "0.14.0", path = "../ractor_cluster_derive" }
 rand = "0.8"
 sha2 = "0.10"
 tokio = { version = "1.30", features = ["rt", "time", "sync", "macros", "net", "io-util", "tracing"]}

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.13.5"
-authors = ["Sean Lawlor <seanlawlor@fb.com>"]
+version = "0.14.0"
+authors = ["Sean Lawlor <slawlor>"]
 description = "Derives for ractor_cluster"
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
## Context

With #266, automation span propagation was added to `ractor`. This is very helpful in tracing context through actors, such that contextual information can be persisted through a message's lifecycle. 

However, in factories, this is more subtle due to (a) internal queueing and (b) the worker's requirement to interface with the Factory directly (for ping/pong heartbeats). 

## The problem

Consider a message sent to a factory, which is a `Job`. When the job is picked up, the factory's message handler `handle()` will be instrumented with the span included in the message, silently by the framework for you. However should the factory choose to queue the message, then once that iteration of `handle()` is completed, the span context is lost. Then the factory may utilize a future message event to dequeue that previously enqueued message, and will instrument it with the context from the triggering event. 

In production, it has been noticed that not only can this attach the wrong span, to the wrong message, but it also can cause recursive spans since a worker can send a message to a factory (pong to a ping), which can trigger a queue'd item to be processed, therefore attaching Factory.handle() 'ping' -> Worker.handle() 'pong' -> Factory.handle() 'pong' -> Worker.handle() 'message', and up to infinite depths.

This is not only wrong, but dangerous at runtime (incorrect context risk). Therefore this fix is done by attaching the span to the `Job` directly, inside the `JobOptions` which are generally constructed via `Default::default()` in all call sites. Then a new helper-trait is added, which automatically will instrument the span on the correct Worker.handle() call but also can alleviate a lot of the general worker boilerplate for you (see simplified syntax in examples and tests)

## Important

Given the
1. Removal of the `Eq` bound on the `JobOptions` 
2. Addition of a new field into `JobOptions`
3. General change of the API contract for `JobOptions` to be more read-only, with only allowing the user to set the TTL

this change constitutes a major API break. Although most call sites will see a no-op change, we do need to do a major release to include this change.

# This change

In this PR, I'm doing 2 major changes

1. Adding the `tracing::Span` to the `JobOptions` in order to carry the span for the life of the job, until it's processed in the worker. Additionally we change the API for `JobOptions` to be primarily read-only, with exception only for setting the TTL. The rest is automatically handled for users.
2. Adding a `Worker` trait, which auto-implements the `Actor` trait specifically for a Factory. This trait supports much of the boiler-plate of constructing a worker in a factory and instruments the span if it's provided on the workers handler.