### PR TITLE
fix: get_children should not break supervision tree integrity

### DIFF
--- a/ractor/src/actor/supervision.rs
+++ b/ractor/src/actor/supervision.rs
@@ -57,7 +57,11 @@ impl SupervisionTree {
     /// from the supervision tree since the supervisor is shutting down
     /// and can't deal with superivison events anyways
     pub(crate) fn terminate_all_children(&self) {
-        let cells = self.take_children();
+        let mut guard = self.children.lock().unwrap();
+        let cells = guard.values().cloned().collect::<Vec<_>>();
+        guard.clear();
+        // drop the guard to not deadlock on double-link
+        drop(guard);
         for cell in cells {
             cell.terminate();
             cell.clear_supervisor();
@@ -66,7 +70,7 @@ impl SupervisionTree {
 
     /// Stop all the linked children, but does NOT unlink them (stop flow will do that)
     pub(crate) fn stop_all_children(&self, reason: Option<String>) {
-        let cells = self.take_children();
+        let cells = self.get_children();
         for cell in cells {
             cell.stop(reason.clone());
         }
@@ -74,7 +78,7 @@ impl SupervisionTree {
 
     /// Drain all the linked children, but does NOT unlink them
     pub(crate) fn drain_all_children(&self) {
-        let cells = self.take_children();
+        let cells = self.get_children();
         for cell in cells {
             _ = cell.drain();
         }
@@ -87,7 +91,7 @@ impl SupervisionTree {
         reason: Option<String>,
         timeout: Option<crate::concurrency::Duration>,
     ) {
-        let cells = self.take_children();
+        let cells = self.get_children();
         let mut js = crate::concurrency::JoinSet::new();
         for cell in cells {
             let lreason = reason.clone();
@@ -109,7 +113,7 @@ impl SupervisionTree {
         &self,
         timeout: Option<crate::concurrency::Duration>,
     ) {
-        let cells = self.take_children();
+        let cells = self.get_children();
         let mut js = crate::concurrency::JoinSet::new();
         for cell in cells {
             let ltimeout = timeout;
@@ -132,15 +136,6 @@ impl SupervisionTree {
         } else {
             false
         }
-    }
-
-    pub(crate) fn take_children(&self) -> Vec<ActorCell> {
-        let mut guard = self.children.lock().unwrap();
-        let cells = guard.values().cloned().collect::<Vec<_>>();
-        guard.clear();
-        // drop the guard to not deadlock on double-link
-        drop(guard);
-        cells
     }
 
     /// Return all linked children

--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -1557,6 +1557,9 @@ async fn draining_children_will_shutdown_parent_too() {
     // notify the parent (supervisor) and take that down too
     supervisor_ref.drain_children();
 
+    // children were not unlinked by draining them (fixed from #310)
+    assert!(!supervisor_ref.get_children().is_empty());
+
     // Wait for exit
     s_handle.await.unwrap();
     c_handle.await.unwrap();


### PR DESCRIPTION
This fixes #310 

Please suggest where and what tests I can add.