### PR TITLE
Add monitor API back

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,9 @@ jobs:
           - name: Test ractor_cluster with async_trait
             package: ractor_cluster
             flags: -F async-trait
+          - name: Test ractor with the monitor API
+            package: ractor
+            flags: -F monitors
             
     steps:
       - uses: actions/checkout@main

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Install `ractor` by adding the following to your Cargo.toml dependencies.
 
 ```toml
 [dependencies]
-ractor = "0.13"
+ractor = "0.14"
 ```
 
 The minimum supported Rust version (MSRV) of `ractor` is `1.64`. However to utilize the native `async fn` support in traits and not rely on the `async-trait` crate's desugaring functionliaty, you need to be on Rust version `>= 1.75`. The stabilization of `async fn` in traits [was recently added](https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html).
@@ -77,6 +77,8 @@ The minimum supported Rust version (MSRV) of `ractor` is `1.64`. However to util
 
 1. `cluster`, which exposes various functionality required for `ractor_cluster` to set up and manage a cluster of actors over a network link. This is work-in-progress and is being tracked in [#16](https://github.com/slawlor/ractor/issues/16).
 2. `async-std`, which enables usage of `async-std`'s asynchronous runtime instead of the `tokio` runtime. **However** `tokio` with the `sync` feature remains a dependency because we utilize the messaging synchronization primatives from `tokio` regardless of runtime as they are not specific to the `tokio` runtime. This work is tracked in [#173](https://github.com/slawlor/ractor/pull/173). You can remove default features to "minimize" the tokio dependencies to just the synchronization primatives.
+3. `monitors`, Adds support for an erlang-style monitoring api which is an alternative to direct linkage. Akin to [Process Monitors](https://www.erlang.org/doc/system/ref_man_processes.html#monitors)
+4. `message_span_propogation`, Propagates the span through the message between actors to keep tracing context.
 
 ## Working with Actors
 

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.14.3"
+version = "0.14.4"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"
@@ -19,6 +19,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 [features]
 ### Other features
 cluster = []
+monitors = []
 message_span_propogation = []
 tokio_runtime = ["tokio/time", "tokio/rt", "tokio/macros", "tokio/tracing"]
 blanket_serde = ["serde", "pot", "cluster"]

--- a/ractor/src/actor/actor_cell.rs
+++ b/ractor/src/actor/actor_cell.rs
@@ -394,24 +394,17 @@ impl ActorCell {
     /// with non-cloneable information removed.
     ///
     /// * `who`: The actor to monitor
+    #[cfg(feature = "monitors")]
     pub fn monitor(&self, who: ActorCell) {
         who.inner.tree.set_monitor(self.clone());
-        self.inner.tree.mark_monitored(who);
     }
 
     /// Stop monitoring the provided [super::Actor] for supervision events.
     ///
     /// * `who`: The actor to stop monitoring
+    #[cfg(feature = "monitors")]
     pub fn unmonitor(&self, who: ActorCell) {
-        self.inner.tree.unmark_monitored(who.get_id());
         who.inner.tree.remove_monitor(self.get_id());
-    }
-
-    /// Clear all the [self::Actor]s which are monitored by this [self::Actor]
-    pub fn clear_monitors(&self) {
-        for id in self.inner.tree.monitored_actors() {
-            self.unmonitor(id);
-        }
     }
 
     /// Kill this [super::Actor] forcefully (terminates async work)

--- a/ractor/src/actor/messages.rs
+++ b/ractor/src/actor/messages.rs
@@ -126,6 +126,26 @@ impl SupervisionEvent {
     pub fn actor_id(&self) -> Option<super::actor_id::ActorId> {
         self.actor_cell().map(|cell| cell.get_id())
     }
+
+    /// Clone the supervision event, without requiring inner data
+    /// be cloneable. This means that the actor error (if present) is converted
+    /// to a string and copied as well as the state upon termination being not
+    /// propogated. If the state were cloneable, we could propogate it, however
+    /// that restriction is overly restrictive, so we've avoided it.
+    pub(crate) fn clone_no_data(&self) -> Self {
+        match self {
+            Self::ActorStarted(who) => Self::ActorStarted(who.clone()),
+            Self::ActorFailed(who, what) => {
+                Self::ActorFailed(who.clone(), From::from(format!("{what}")))
+            }
+            Self::ProcessGroupChanged(what) => Self::ProcessGroupChanged(what.clone()),
+            Self::ActorTerminated(who, _state, msg) => {
+                Self::ActorTerminated(who.clone(), None, msg.as_ref().cloned())
+            }
+            #[cfg(feature = "cluster")]
+            Self::PidLifecycleEvent(evt) => Self::PidLifecycleEvent(evt.clone()),
+        }
+    }
 }
 
 impl Debug for SupervisionEvent {

--- a/ractor/src/actor/messages.rs
+++ b/ractor/src/actor/messages.rs
@@ -132,6 +132,7 @@ impl SupervisionEvent {
     /// to a string and copied as well as the state upon termination being not
     /// propogated. If the state were cloneable, we could propogate it, however
     /// that restriction is overly restrictive, so we've avoided it.
+    #[cfg(feature = "monitors")]
     pub(crate) fn clone_no_data(&self) -> Self {
         match self {
             Self::ActorStarted(who) => Self::ActorStarted(who.clone()),

--- a/ractor/src/actor/mod.rs
+++ b/ractor/src/actor/mod.rs
@@ -772,9 +772,6 @@ where
             // notify supervisors of the actor's death
             myself.notify_supervisor_and_monitors(evt);
 
-            // clear any monitor actors
-            myself.clear_monitors();
-
             // unlink superisors
             if let Some(sup) = supervisor {
                 myself.unlink(sup);

--- a/ractor/src/actor/mod.rs
+++ b/ractor/src/actor/mod.rs
@@ -772,6 +772,9 @@ where
             // notify supervisors of the actor's death
             myself.notify_supervisor_and_monitors(evt);
 
+            // clear any monitor actors
+            myself.clear_monitors();
+
             // unlink superisors
             if let Some(sup) = supervisor {
                 myself.unlink(sup);

--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -1570,6 +1570,7 @@ async fn draining_children_will_shutdown_parent_too() {
 
 #[crate::concurrency::test]
 #[tracing_test::traced_test]
+#[cfg(feature = "monitors")]
 async fn test_simple_monitor() {
     struct Peer;
     struct Monitor {

--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -1567,3 +1567,109 @@ async fn draining_children_will_shutdown_parent_too() {
     // Child's post-stop should have been called.
     assert_eq!(1, flag.load(Ordering::Relaxed));
 }
+
+#[crate::concurrency::test]
+#[tracing_test::traced_test]
+async fn test_simple_monitor() {
+    struct Peer;
+    struct Monitor {
+        counter: Arc<AtomicU8>,
+    }
+
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    impl Actor for Peer {
+        type Msg = ();
+        type State = ();
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _: ActorRef<Self::Msg>,
+            _: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+
+        async fn handle(
+            &self,
+            myself: ActorRef<Self::Msg>,
+            _: Self::Msg,
+            _: &mut Self::State,
+        ) -> Result<(), ActorProcessingErr> {
+            myself.stop(Some("oh no!".to_string()));
+            Ok(())
+        }
+    }
+
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    impl Actor for Monitor {
+        type Msg = ();
+        type State = ();
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _: ActorRef<Self::Msg>,
+            _: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+
+        async fn handle_supervisor_evt(
+            &self,
+            _: ActorRef<Self::Msg>,
+            evt: SupervisionEvent,
+            _: &mut Self::State,
+        ) -> Result<(), ActorProcessingErr> {
+            if let SupervisionEvent::ActorTerminated(_who, _state, Some(msg)) = evt {
+                if msg.as_str() == "oh no!" {
+                    self.counter.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            Ok(())
+        }
+    }
+
+    let count = Arc::new(AtomicU8::new(0));
+
+    let (p, ph) = Actor::spawn(None, Peer, ())
+        .await
+        .expect("Failed to start peer");
+    let (m, mh) = Actor::spawn(
+        None,
+        Monitor {
+            counter: count.clone(),
+        },
+        (),
+    )
+    .await
+    .expect("Faield to start monitor");
+
+    m.monitor(p.get_cell());
+
+    // stopping the peer should notify the monitor, who can capture the state
+    p.cast(()).expect("Failed to contact peer");
+    periodic_check(
+        || count.load(Ordering::Relaxed) == 1,
+        Duration::from_secs(1),
+    )
+    .await;
+    ph.await.unwrap();
+
+    let (p, ph) = Actor::spawn(None, Peer, ())
+        .await
+        .expect("Failed to start peer");
+    m.monitor(p.get_cell());
+    m.unmonitor(p.get_cell());
+
+    p.cast(()).expect("Failed to contact peer");
+    ph.await.unwrap();
+
+    // The count doesn't increment when the peer exits (we give some time
+    // to schedule the supervision evt)
+    crate::concurrency::sleep(Duration::from_millis(100)).await;
+    assert_eq!(1, count.load(Ordering::Relaxed));
+
+    m.stop(None);
+    mh.await.unwrap();
+}

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ractor = "0.13"
+//! ractor = "0.14"
 //! ```
 //!
 //! The minimum supported Rust version (MSRV) is 1.64. However if you disable the `async-trait` feature, then you need Rust >= 1.75 due to the native
@@ -128,6 +128,9 @@
 //! NOTE: panic's in `pre_start` of an actor will cause failures to spawn, rather than supervision notified failures as the actor hasn't "linked"
 //! to its supervisor yet. However failures in `post_start`, `handle`, `handle_supervisor_evt`, `post_stop` will notify the supervisor should a failure
 //! occur. See [crate::Actor] documentation for more information
+//!
+//! There is additionally a "monitor" API which gives non-direct-supervision logic style monitoring akin to Erlang's [process monitors](https://www.erlang.org/doc/system/ref_man_processes.html#monitors).
+//! This functionality is opt-in via feature `monitors` on the `ractor` crate.
 //!
 //! ## Messaging actors
 //!

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.14.3"
+version = "0.14.4"
 authors = ["Sean Lawlor <slawlor>"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"
@@ -15,6 +15,8 @@ build = "src/build.rs"
 rust-version = "1.64"
 
 [features]
+monitors = ["ractor/monitors"]
+message_span_propogation = ["ractor/message_span_propogation"]
 async-trait = ["dep:async-trait", "ractor/async-trait"]
 
 default = []

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.14.3"
+version = "0.14.4"
 authors = ["Sean Lawlor <slawlor>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
This PR re-adds the monitor API, but with an option in the map to save allocations when unused.

Additionally we move to Option<HashMap> types to save on allocations for regular supervisions (if the actor doesn't supervise anything, we don't need to create the empty map)

This was originally removed in #260 to save on memory, but it was used by the community and therefore a valuable API as noted in #307

TBD mem measurement