### PR TITLE
Marking that the converter function in the derived actor is cross-thread safe since it's just an Into() call.

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"
@@ -14,7 +14,7 @@ categories = ["asynchronous"]
 rust-version = "1.64"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)', 'cfg(rust_analyzer)'] }
 
 [features]
 ### Other features

--- a/ractor/src/actor/derived_actor.rs
+++ b/ractor/src/actor/derived_actor.rs
@@ -140,10 +140,18 @@ use std::sync::Arc;
 ///     kitchen_actor_handle.await.unwrap();
 /// }
 /// ```
-#[derive(Clone)]
 pub struct DerivedActorRef<TFrom> {
-    converter: Arc<dyn Fn(TFrom) -> Result<(), MessagingErr<TFrom>>>,
-    inner: ActorCell,
+    converter: Arc<dyn Fn(TFrom) -> Result<(), MessagingErr<TFrom>> + Send + Sync + 'static>,
+    pub(crate) inner: ActorCell,
+}
+
+impl<TFrom> Clone for DerivedActorRef<TFrom> {
+    fn clone(&self) -> Self {
+        Self {
+            converter: self.converter.clone(),
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl<TFrom> std::fmt::Debug for DerivedActorRef<TFrom> {

--- a/ractor/src/factory/factoryimpl.rs
+++ b/ractor/src/factory/factoryimpl.rs
@@ -11,8 +11,6 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use bon::Builder;
-
 use self::routing::RouteResult;
 use crate::concurrency::Duration;
 use crate::concurrency::Instant;
@@ -99,7 +97,7 @@ where
 }
 
 /// Arguments for configuring and starting a [Factory] actor instance.
-#[derive(Builder)]
+#[derive(bon::Builder)]
 #[builder(on(String, into))]
 pub struct FactoryArguments<TKey, TMsg, TWorkerStart, TWorker, TRouter, TQueue>
 where

--- a/ractor/src/time/mod.rs
+++ b/ractor/src/time/mod.rs
@@ -216,3 +216,39 @@ where
         kill_after(period, self.get_cell())
     }
 }
+
+/// Add the timing functionality on top of the [crate::ActorRef]
+impl<TMessage> crate::DerivedActorRef<TMessage>
+where
+    TMessage: crate::Message,
+{
+    /// Alias of [send_interval]
+    pub fn send_interval<F>(&self, period: Duration, msg: F) -> JoinHandle<()>
+    where
+        F: Fn() -> TMessage + Send + 'static,
+    {
+        send_interval::<TMessage, F>(period, self.get_cell(), msg)
+    }
+
+    /// Alias of [send_after]
+    pub fn send_after<F>(
+        &self,
+        period: Duration,
+        msg: F,
+    ) -> JoinHandle<Result<(), MessagingErr<TMessage>>>
+    where
+        F: FnOnce() -> TMessage + Send + 'static,
+    {
+        send_after::<TMessage, F>(period, self.get_cell(), msg)
+    }
+
+    /// Alias of [exit_after]
+    pub fn exit_after(&self, period: Duration) -> JoinHandle<()> {
+        exit_after(period, self.get_cell())
+    }
+
+    /// Alias of [kill_after]
+    pub fn kill_after(&self, period: Duration) -> JoinHandle<()> {
+        kill_after(period, self.get_cell())
+    }
+}

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Sean Lawlor <slawlor>"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.14.4"
+version = "0.14.5"
 authors = ["Sean Lawlor <slawlor>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
This PR also adds equivalent exposure to DerivedActorRef that is available on ActorRef