### PR TITLE
Add utility functions for spawning actors

### DIFF
--- a/ractor/src/actor/tests/supervisor.rs
+++ b/ractor/src/actor/tests/supervisor.rs
@@ -87,9 +87,8 @@ async fn test_supervision_panic_in_post_startup() {
         .await
         .expect("Supervisor panicked on startup");
 
-    let supervisor_cell: ActorCell = supervisor_ref.clone().into();
-
-    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, (), supervisor_cell)
+    let (child_ref, c_handle) = supervisor_ref
+        .spawn_linked(None, Child, ())
         .await
         .expect("Child panicked on startup");
 
@@ -1088,9 +1087,8 @@ async fn test_supervisor_captures_dead_childs_state() {
         .await
         .expect("Supervisor panicked on startup");
 
-    let supervisor_cell: ActorCell = supervisor_ref.clone().into();
-
-    let (child_ref, c_handle) = Actor::spawn_linked(None, Child, (), supervisor_cell)
+    let (child_ref, c_handle) = supervisor_ref
+        .spawn_linked(None, Child, ())
         .await
         .expect("Child panicked on startup");
 

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -12,6 +12,7 @@ use crate::{Actor, ActorProcessingErr, SpawnErr};
 #[crate::concurrency::test]
 #[tracing_test::traced_test]
 async fn test_basic_registation() {
+    #[derive(Default)]
     struct EmptyActor;
 
     #[cfg_attr(feature = "async-trait", crate::async_trait)]
@@ -29,7 +30,7 @@ async fn test_basic_registation() {
         }
     }
 
-    let (actor, handle) = Actor::spawn(Some("my_actor".to_string()), EmptyActor, ())
+    let (actor, _) = crate::spawn_named::<EmptyActor>("my_actor".to_string(), ())
         .await
         .expect("Actor failed to start");
 
@@ -38,8 +39,10 @@ async fn test_basic_registation() {
     // Coverage for Issue #70
     assert!(crate::ActorRef::<()>::where_is("my_actor".to_string()).is_some());
 
-    actor.stop(None);
-    handle.await.expect("Failed to clean stop the actor");
+    actor
+        .stop_and_wait(None, None)
+        .await
+        .expect("Failed to wait for stop");
 }
 
 #[crate::concurrency::test]


### PR DESCRIPTION
Utilities added on

* The ActorRef for spawning children (instance method of `spawn_linked`) 
* The crate root for spawning unmanaged actors

Tests updated to cover functionality.