### PR TITLE
Bind to [::] to listen for both IPv4 and IPv6 connection

### DIFF
--- a/ractor_cluster/src/net/listener.rs
+++ b/ractor_cluster/src/net/listener.rs
@@ -57,7 +57,7 @@ impl Actor for Listener {
         myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
-        let addr = format!("0.0.0.0:{}", self.port);
+        let addr = format!("[::]:{}", self.port);
         let listener = match TcpListener::bind(&addr).await {
             Ok(l) => l,
             Err(err) => {


### PR DESCRIPTION
Or perhaps this should be configurable? For example it can take a `Into<SocketAddr>`