### PR TITLE
Add ability for a factory's internal state to be updated dynamically

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"

--- a/ractor/src/factory/discard.rs
+++ b/ractor/src/factory/discard.rs
@@ -28,7 +28,7 @@ pub enum DiscardMode {
 /// workers. The workers "think" it's static, but the factory handles the dynamics.
 /// This way the factory can keep the [DynamicDiscardHandler] as a single, uncloned
 /// instance. It also moves NUM_WORKER calculations to 1.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum WorkerDiscardSettings {
     None,
     Static { limit: usize, mode: DiscardMode },

--- a/ractor/src/factory/tests/dynamic_settings.rs
+++ b/ractor/src/factory/tests/dynamic_settings.rs
@@ -1,0 +1,197 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! Tests around dynamic setting changes in factories
+
+use std::sync::{
+    atomic::{AtomicU8, Ordering},
+    Arc,
+};
+
+use crate::concurrency::sleep;
+use crate::factory::*;
+use crate::{Actor, ActorProcessingErr, ActorRef};
+
+struct TestWorker;
+
+#[cfg_attr(feature = "async-trait", crate::async_trait)]
+impl Worker for TestWorker {
+    type State = ();
+    type Key = ();
+    type Message = ();
+    type Arguments = ();
+
+    async fn pre_start(
+        &self,
+        _wid: WorkerId,
+        _factory: &ActorRef<FactoryMessage<Self::Key, Self::Message>>,
+        _args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        tracing::debug!("Worker started");
+        Ok(())
+    }
+
+    async fn handle(
+        &self,
+        _wid: WorkerId,
+        _factory: &ActorRef<FactoryMessage<Self::Key, Self::Message>>,
+        _job: Job<Self::Key, Self::Message>,
+        _state: &mut Self::State,
+    ) -> Result<Self::Key, ActorProcessingErr> {
+        tracing::debug!("Worker received dispatch");
+        sleep(Duration::from_millis(10)).await;
+        Ok(())
+    }
+}
+
+struct TestWorkerBuilder;
+
+impl WorkerBuilder<TestWorker, ()> for TestWorkerBuilder {
+    fn build(&mut self, _wid: crate::factory::WorkerId) -> (TestWorker, ()) {
+        (TestWorker, ())
+    }
+}
+
+#[crate::concurrency::test]
+#[tracing_test::traced_test]
+async fn test_dynamic_settings() {
+    let counter_one = Arc::new(AtomicU8::new(0));
+    let counter_two = Arc::new(AtomicU8::new(0));
+
+    struct TestDiscardHandler {
+        counter: Arc<AtomicU8>,
+    }
+
+    impl DiscardHandler<(), ()> for TestDiscardHandler {
+        fn discard(&self, _reason: DiscardReason, _job: &mut Job<(), ()>) {
+            self.counter.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let factory_definition = Factory::<
+        (),
+        (),
+        (),
+        TestWorker,
+        routing::QueuerRouting<(), ()>,
+        queues::DefaultQueue<(), ()>,
+    >::default();
+    let args = FactoryArguments::builder()
+        .num_initial_workers(1)
+        .queue(Default::default())
+        .router(Default::default())
+        .worker_builder(Box::new(TestWorkerBuilder))
+        .discard_handler(Arc::new(TestDiscardHandler {
+            counter: counter_one.clone(),
+        }))
+        .discard_settings(DiscardSettings::Static {
+            limit: 0,
+            mode: DiscardMode::Newest,
+        })
+        .build();
+    let (factory, factory_handle) = Actor::spawn(None, factory_definition, args)
+        .await
+        .expect("Failed to spawn factory");
+
+    // check that there's 1 worker running
+    let worker_count = factory
+        .call(
+            FactoryMessage::GetAvailableCapacity,
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .expect("Failed to message factory")
+        .expect("Failed to get reply from factory");
+    assert_eq!(1, worker_count);
+
+    // send 2 messages, making sure we discard one.
+    for _ in 0..2 {
+        factory
+            .cast(FactoryMessage::Dispatch(Job {
+                accepted: None,
+                key: (),
+                msg: (),
+                options: JobOptions::default(),
+            }))
+            .expect("Failed to message factory");
+    }
+
+    // fetch the worker count, to make sure the factory has processed all
+    // the messages from above
+    _ = factory
+        .call(
+            FactoryMessage::GetAvailableCapacity,
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .expect("Failed to message factory")
+        .expect("Failed to get reply from factory");
+
+    // wait for worker to finish
+    sleep(Duration::from_millis(100)).await;
+
+    // update factory logic
+    factory
+        .cast(FactoryMessage::UpdateSettings(
+            UpdateSettingsRequest::builder()
+                .worker_count(2)
+                .discard_handler(Some(Arc::new(TestDiscardHandler {
+                    counter: counter_two.clone(),
+                })))
+                // these are the defaults, but exercise the path for sanity.
+                .capacity_controller(None)
+                .dead_mans_switch(None)
+                .discard_settings(DiscardSettings::Static {
+                    limit: 0,
+                    mode: DiscardMode::Newest,
+                })
+                .lifecycle_hooks(None)
+                .stats(None)
+                .build(),
+        ))
+        .expect("Failed to send request to update factory");
+
+    // Check updated worker count
+    let worker_count = factory
+        .call(
+            FactoryMessage::GetAvailableCapacity,
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .expect("Failed to message factory")
+        .expect("Failed to get reply from factory");
+    assert_eq!(2, worker_count);
+
+    // send 3 messages, making sure we discard one with the
+    // new handler
+    for _ in 0..3 {
+        factory
+            .cast(FactoryMessage::Dispatch(Job {
+                accepted: None,
+                key: (),
+                msg: (),
+                options: JobOptions::default(),
+            }))
+            .expect("Failed to message factory");
+    }
+
+    // Make sure messages processed
+    _ = factory
+        .call(
+            FactoryMessage::GetAvailableCapacity,
+            Some(Duration::from_secs(1)),
+        )
+        .await
+        .expect("Failed to message factory")
+        .expect("Failed to get reply from factory");
+
+    // Check both discard handler counters
+    assert_eq!(counter_one.load(Ordering::SeqCst), 1);
+    assert_eq!(counter_two.load(Ordering::SeqCst), 1);
+
+    // Cleanup
+    factory.stop(None);
+    factory_handle.await.unwrap();
+}

--- a/ractor/src/factory/tests/mod.rs
+++ b/ractor/src/factory/tests/mod.rs
@@ -9,6 +9,7 @@ mod basic;
 mod draining_requests;
 mod dynamic_discarding;
 mod dynamic_pool;
+mod dynamic_settings;
 mod lifecycle;
 mod priority_queueing;
 mod ratelim;

--- a/ractor/src/factory/worker.rs
+++ b/ractor/src/factory/worker.rs
@@ -496,10 +496,10 @@ where
     /// will cause an oldest job at the head of the queue will be dropped.
     ///
     /// Default is [WorkerDiscardSettings::None]
-    discard_settings: WorkerDiscardSettings,
+    pub(crate) discard_settings: WorkerDiscardSettings,
 
     /// A function to be called for each job to be dropped.
-    discard_handler: Option<Arc<dyn DiscardHandler<TKey, TMsg>>>,
+    pub(crate) discard_handler: Option<Arc<dyn DiscardHandler<TKey, TMsg>>>,
 
     /// Flag indicating if this worker has a ping currently pending
     is_ping_pending: bool,

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Sean Lawlor <slawlor>"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Sean Lawlor <slawlor>"]
 description = "Derives for ractor_cluster"
 license = "MIT"


### PR DESCRIPTION
This allows someone to say reload configeration settings, and internally tear-down and rebuild the factory without fully shutting down and restarting.

Some settings are not dynamically settable without tearing down and rebuilding the factory, unless we want to introduce more strong-types to the message type. This includes, unfortunately, the worker builder, queue, and router.

For settings on those two, there are two choices. (1) tear down and rebuild the factory or (2) thread in dynamic settings to your router and/or queue protocols such that they can internally change their functionality.