### PR TITLE
Support dynamic NodeServer port allocation

### DIFF
--- a/ractor_cluster/src/net/listener.rs
+++ b/ractor_cluster/src/net/listener.rs
@@ -74,19 +74,16 @@ impl Actor for Listener {
     async fn post_start(
         &self,
         myself: ActorRef<Self::Msg>,
-        state: &mut Self::State
+        state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
-
         // If the used port differs from the user-specified port, inform the supervisor.
         if let Some(listener) = &state.listener {
             if let Ok(local_addr) = listener.local_addr() {
                 if local_addr.port() != self.port {
                     if let Some(supervisor) = myself.try_get_supervisor() {
-                        supervisor.send_message(
-                            NodeServerMessage::PortChanged {
-                                port: local_addr.port()
-                            }
-                        )?;
+                        supervisor.send_message(NodeServerMessage::PortChanged {
+                            port: local_addr.port(),
+                        })?;
                     }
                 }
             }

--- a/ractor_cluster/src/net/listener.rs
+++ b/ractor_cluster/src/net/listener.rs
@@ -54,7 +54,7 @@ impl Actor for Listener {
 
     async fn pre_start(
         &self,
-        myself: ActorRef<Self::Msg>,
+        _myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
         let addr = format!("[::]:{}", self.port);
@@ -65,13 +65,37 @@ impl Actor for Listener {
             }
         };
 
-        // startup the event processing loop by sending an initial msg
-        let _ = myself.cast(ListenerMessage);
-
         // create the initial state
         Ok(Self::State {
             listener: Some(listener),
         })
+    }
+
+    async fn post_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        state: &mut Self::State
+    ) -> Result<(), ActorProcessingErr> {
+
+        // If the used port differs from the user-specified port, inform the supervisor.
+        if let Some(listener) = &state.listener {
+            if let Ok(local_addr) = listener.local_addr() {
+                if local_addr.port() != self.port {
+                    if let Some(supervisor) = myself.try_get_supervisor() {
+                        supervisor.send_message(
+                            NodeServerMessage::PortChanged {
+                                port: local_addr.port()
+                            }
+                        )?;
+                    }
+                }
+            }
+        }
+
+        // startup the event processing loop by sending an initial msg
+        let _ = myself.cast(ListenerMessage);
+
+        Ok(())
     }
 
     async fn post_stop(

--- a/ractor_cluster/src/node/mod.rs
+++ b/ractor_cluster/src/node/mod.rs
@@ -354,7 +354,8 @@ impl Actor for NodeServer {
             self.encryption_mode.clone(),
         );
 
-        let (actor_ref, _) = Actor::spawn_linked(None, listener, (), myself.get_cell()).await?;
+        let (actor_ref, _) =
+            Actor::spawn_linked(None, listener, myself.clone(), myself.get_cell()).await?;
 
         Ok(Self::State {
             node_sessions: HashMap::new(),
@@ -476,7 +477,8 @@ impl Actor for NodeServer {
                     );
 
                     let (actor_ref, _) =
-                        Actor::spawn_linked(None, listener, (), myself.get_cell()).await?;
+                        Actor::spawn_linked(None, listener, myself.clone(), myself.get_cell())
+                            .await?;
                     state.listener = actor_ref;
                 } else {
                     match state.node_sessions.entry(actor.get_id()) {
@@ -514,7 +516,8 @@ impl Actor for NodeServer {
                     );
 
                     let (actor_ref, _) =
-                        Actor::spawn_linked(None, listener, (), myself.get_cell()).await?;
+                        Actor::spawn_linked(None, listener, myself.clone(), myself.get_cell())
+                            .await?;
                     state.listener = actor_ref;
                 } else {
                     match state.node_sessions.entry(actor.get_id()) {

--- a/ractor_cluster/src/node/mod.rs
+++ b/ractor_cluster/src/node/mod.rs
@@ -146,7 +146,7 @@ pub enum NodeServerMessage {
     /// free port.
     PortChanged {
         /// The new port number
-        port: u16
+        port: u16,
     },
 }
 
@@ -447,7 +447,7 @@ impl Actor for NodeServer {
             Self::Msg::UnsubscribeToEvents(id) => {
                 let _ = state.subscriptions.remove(&id);
             }
-            Self::Msg::PortChanged {port} => {
+            Self::Msg::PortChanged { port } => {
                 state.this_node_name.connection_string = format!("{}:{}", self.hostname, port);
             }
         }

--- a/ractor_cluster/src/node/mod.rs
+++ b/ractor_cluster/src/node/mod.rs
@@ -140,6 +140,14 @@ pub enum NodeServerMessage {
 
     /// Unsubscribe to node events for the given subscription id
     UnsubscribeToEvents(String),
+
+    /// Change the port used in the connection String for the [ crate::net::listener ].
+    /// This is used if the port specified in [ NodeServer ] is 0 and the OS chooses an arbitrary
+    /// free port.
+    PortChanged {
+        /// The new port number
+        port: u16
+    },
 }
 
 /// Message from the TCP `ractor_cluster::net::session::Session` actor and the
@@ -193,7 +201,7 @@ pub struct NodeServer {
 impl NodeServer {
     /// Create a new node server instance
     ///
-    /// * `port` - The port to run the [NodeServer] on for incoming requests
+    /// * `port` - The port to run the [NodeServer] on for incoming requests. 0 to auto-select a free port.
     /// * `cookie` - The magic cookie for authentication between [NodeServer]s
     /// * `node_name` - The name of this node
     /// * `hostname` - The hostname of the machine
@@ -438,6 +446,9 @@ impl Actor for NodeServer {
             }
             Self::Msg::UnsubscribeToEvents(id) => {
                 let _ = state.subscriptions.remove(&id);
+            }
+            Self::Msg::PortChanged {port} => {
+                state.this_node_name.connection_string = format!("{}:{}", self.hostname, port);
             }
         }
         Ok(())

--- a/ractor_cluster_integration_tests/Dockerfile
+++ b/ractor_cluster_integration_tests/Dockerfile
@@ -1,6 +1,6 @@
 # Build from root of repository with
 #
-# docker build -f ractor_cluster_integration_tests/Dockerfile . -t ractor_integration_tests:latest
+# docker build -f ractor_cluster_integration_tests/Dockerfile --build-arg FEATURES="list,of,features" . -t ractor_integration_tests:latest
 # docker run -it ractor_integration_tests:latest help
 
 FROM rust:latest

--- a/ractor_cluster_integration_tests/envs/dist-connect.env
+++ b/ractor_cluster_integration_tests/envs/dist-connect.env
@@ -1,3 +1,3 @@
 A_TEST="dist-connect node-a 8199"
 B_TEST="dist-connect node-b 8198 8199 node-a"
-C_TEST="dist-connect node-c 8197 8199 node-a"
+C_TEST="dist-connect node-c 0 8199 node-a"

--- a/ractor_cluster_integration_tests/src/tests/dist_connect.rs
+++ b/ractor_cluster_integration_tests/src/tests/dist_connect.rs
@@ -3,7 +3,7 @@
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree.
 
-//! The the transitive dist-connect functionality of the cluster. If B -> A and C -> A
+//! Test the transitive dist-connect functionality of the cluster. If B -> A and C -> A
 //! then C should auto-connect to B
 
 use clap::Args;


### PR DESCRIPTION
# Issue
See Issue #334.

**TLDR:**
Creating a NodeServer with port 0 lets the OS choose an available port. The port chosen by the OS is not reflected in the connection_string. Transitive connections to nodes that used port 0 will fail, since other nodes will try to connect to port 0.

# Changes
I fixed the issue with the following changes:
 - Add a new `NodeServerMessage::PortChanged` that tells the NodeServer to update its connection_string.
 - In `net::listener::Listener::post_start()` query the port that the listener is bound to. If it differs from the user-specified port, send the supervisor (the NodeServer) a `PortChanged` Message.

I also changed the input for the dist_connect integration test slightly to use port 0 so that both the basic functionality and this 'edge case' are tested.

---

I'm not entirely sure this approach is the most idiomatic, so I am very open to feedback.