### PR TITLE
fix: drop join handle in spawn utils

### DIFF
--- a/ractor/src/actor/tests/mod.rs
+++ b/ractor/src/actor/tests/mod.rs
@@ -383,7 +383,7 @@ async fn test_sending_message_to_dead_actor() {
         }
     }
 
-    let (actor, _) = crate::spawn::<TestActor>(())
+    let actor = crate::spawn::<TestActor>(())
         .await
         .expect("Actor failed to start");
 

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -239,10 +239,9 @@ impl<T: std::any::Any + Send + 'static> State for T {}
 /// * `args` - The arguments to start the actor
 ///
 /// Returns [Ok((ActorRef, JoinHandle<()>))] upon successful actor startup, [Err(SpawnErr)] otherwise
-pub async fn spawn<T: Actor + Default>(
-    args: T::Arguments,
-) -> Result<(ActorRef<T::Msg>, JoinHandle<()>), SpawnErr> {
-    T::spawn(None, T::default(), args).await
+pub async fn spawn<T: Actor + Default>(args: T::Arguments) -> Result<ActorRef<T::Msg>, SpawnErr> {
+    let (actor, _) = T::spawn(None, T::default(), args).await?;
+    Ok(actor)
 }
 
 /// Perform a background-spawn of an actor with the provided name. This is a utility wrapper
@@ -256,6 +255,7 @@ pub async fn spawn<T: Actor + Default>(
 pub async fn spawn_named<T: Actor + Default>(
     name: crate::ActorName,
     args: T::Arguments,
-) -> Result<(ActorRef<T::Msg>, JoinHandle<()>), SpawnErr> {
-    T::spawn(Some(name), T::default(), args).await
+) -> Result<ActorRef<T::Msg>, SpawnErr> {
+    let (actor, _) = T::spawn(Some(name), T::default(), args).await?;
+    Ok(actor)
 }

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -30,7 +30,7 @@ async fn test_basic_registation() {
         }
     }
 
-    let (actor, _) = crate::spawn_named::<EmptyActor>("my_actor".to_string(), ())
+    let actor = crate::spawn_named::<EmptyActor>("my_actor".to_string(), ())
         .await
         .expect("Actor failed to start");
 


### PR DESCRIPTION
This PR refactors `ractor::spawn` and `ractor::spawn_named` to drop the internal `JoinHandle` before returning the function’s output. Based on the current documentation and observed usage patterns, this change simplifies the API by removing unnecessary exposure of the `JoinHandle` to the caller.

**Note:** this is a breaking change.