### PR TITLE
Send call request without requiring await

### DIFF
--- a/ractor/src/concurrency/mod.rs
+++ b/ractor/src/concurrency/mod.rs
@@ -89,7 +89,9 @@ pub use self::tokio_with_wasm_primitives::*;
 mod target_specific {
     /// A wrapper for [std::marker::Send] on non-`wasm32-unknown-unknown` targets, or an empty trait on `wasm32-unknown-unknown` targets.
     /// Introduced for compatibility between wasm32 and other targets
+    #[cfg(not(feature = "async-trait"))]
     pub trait MaybeSend {}
+    #[cfg(not(feature = "async-trait"))]
     impl<T> MaybeSend for T {}
     pub(crate) use web_time::SystemTime;
 }
@@ -97,7 +99,9 @@ mod target_specific {
 mod target_specific {
     /// A wrapper for [std::marker::Send] on non-`wasm32-unknown-unknown` targets, or an empty trait on `wasm32-unknown-unknown` targets.
     /// Introduced for compatibility between wasm32 and other targets
+    #[cfg(not(feature = "async-trait"))]
     pub trait MaybeSend: Send {}
+    #[cfg(not(feature = "async-trait"))]
     impl<T> MaybeSend for T where T: Send {}
     pub(crate) use std::time::SystemTime;
 }

--- a/ractor_cluster/src/node/mod.rs
+++ b/ractor_cluster/src/node/mod.rs
@@ -141,7 +141,7 @@ pub enum NodeServerMessage {
     /// Unsubscribe to node events for the given subscription id
     UnsubscribeToEvents(String),
 
-    /// Change the port used in the connection String for the [ crate::net::listener ].
+    /// Change the port used in the connection String for the `ractor_cluster::net::listener`.
     /// This is used if the port specified in [ NodeServer ] is 0 and the OS chooses an arbitrary
     /// free port.
     PortChanged {


### PR DESCRIPTION
This change addresses #343 

Here we will immediately trigger the message send, deferring the receive future. In the previous version, even the send will wait for the caller to poll the future, which means the "send" may not occur right away, and this is somewhat counter intuitive.