### PR TITLE
enable wasm + `async-trait` feature

### DIFF
--- a/ractor/benches/actor.rs
+++ b/ractor/benches/actor.rs
@@ -20,7 +20,14 @@ struct BenchActorMessage;
 #[cfg(feature = "cluster")]
 impl Message for BenchActorMessage {}
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for BenchActor {
     type Msg = BenchActorMessage;
 
@@ -250,7 +257,14 @@ fn process_messages(c: &mut Criterion) {
         num_msgs: u64,
     }
 
-    #[cfg_attr(feature = "async-trait", ractor::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        ractor::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
     impl Actor for MessagingActor {
         type Msg = BenchActorMessage;
 

--- a/ractor/benches/async_traits.rs
+++ b/ractor/benches/async_traits.rs
@@ -40,7 +40,14 @@ fn big_stack_futures(c: &mut Criterion) {
     #[cfg(feature = "cluster")]
     impl Message for LargeFutureActorMessage {}
 
-    #[cfg_attr(feature = "async-trait", ractor::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        ractor::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
     impl Actor for LargeFutureActor {
         type Msg = LargeFutureActorMessage;
 

--- a/ractor/examples/a_whole_lotta.rs
+++ b/ractor/examples/a_whole_lotta.rs
@@ -21,7 +21,14 @@ use ractor::ActorRef;
 
 struct Counter;
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for Counter {
     type Msg = ();
     type State = ();

--- a/ractor/examples/a_whole_lotta_messages.rs
+++ b/ractor/examples/a_whole_lotta_messages.rs
@@ -22,7 +22,14 @@ use ractor::ActorRef;
 
 struct Counter;
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for Counter {
     type Msg = u32;
     type State = ();

--- a/ractor/examples/counter.rs
+++ b/ractor/examples/counter.rs
@@ -37,7 +37,14 @@ enum CounterMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for CounterMessage {}
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for Counter {
     type Msg = CounterMessage;
 

--- a/ractor/examples/monte_carlo.rs
+++ b/ractor/examples/monte_carlo.rs
@@ -69,7 +69,14 @@ struct GameMessage(ActorRef<GameManagerMessage>);
 #[cfg(feature = "cluster")]
 impl ractor::Message for GameMessage {}
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for Game {
     type Msg = GameMessage;
 
@@ -146,7 +153,14 @@ impl GameManagerState {
     }
 }
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for GameManager {
     type Msg = GameManagerMessage;
 

--- a/ractor/examples/output_port.rs
+++ b/ractor/examples/output_port.rs
@@ -37,7 +37,14 @@ impl ractor::Message for Output {}
 
 struct Publisher;
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for Publisher {
     type Msg = PublisherMessage;
 
@@ -76,7 +83,14 @@ enum SubscriberMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for SubscriberMessage {}
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for Subscriber {
     type Msg = SubscriberMessage;
 

--- a/ractor/examples/philosophers.rs
+++ b/ractor/examples/philosophers.rs
@@ -121,7 +121,14 @@ impl Fork {
     }
 }
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for Fork {
     type Msg = ForkMessage;
     type State = ForkState;
@@ -334,7 +341,14 @@ impl Philosopher {
     }
 }
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for Philosopher {
     type Msg = PhilosopherMessage;
     type State = PhilosopherState;

--- a/ractor/examples/ping_pong.rs
+++ b/ractor/examples/ping_pong.rs
@@ -47,7 +47,14 @@ impl Message {
     }
 }
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for PingPong {
     type Msg = Message;
 

--- a/ractor/examples/supervisor.rs
+++ b/ractor/examples/supervisor.rs
@@ -103,7 +103,14 @@ enum LeafActorMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for LeafActorMessage {}
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for LeafActor {
     type Msg = LeafActorMessage;
     type State = LeafActorState;
@@ -166,7 +173,14 @@ enum MidLevelActorMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for MidLevelActorMessage {}
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for MidLevelActor {
     type Msg = MidLevelActorMessage;
     type State = MidLevelActorState;
@@ -246,7 +260,14 @@ enum RootActorMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for RootActorMessage {}
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for RootActor {
     type Msg = RootActorMessage;
     type State = RootActorState;

--- a/ractor/src/actor.rs
+++ b/ractor/src/actor.rs
@@ -122,7 +122,14 @@ pub(crate) fn get_panic_string(e: Box<dyn std::any::Any + Send>) -> ActorProcess
 /// patterns. Panics are also captured from the inner functions and wrapped into an Error
 /// type, however should an [Err(_)] result from any of these functions the **actor will
 /// terminate** and cleanup.
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 pub trait Actor: Sized + Sync + Send + 'static {
     /// The message type for this actor
     type Msg: Message;

--- a/ractor/src/actor/supervision_tests.rs
+++ b/ractor/src/actor/supervision_tests.rs
@@ -32,7 +32,14 @@ async fn test_supervision_panic_in_post_startup() {
         flag: Arc<AtomicU64>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -53,7 +60,14 @@ async fn test_supervision_panic_in_post_startup() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -125,7 +139,14 @@ async fn test_supervision_error_in_post_startup() {
         flag: Arc<AtomicU64>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -146,7 +167,14 @@ async fn test_supervision_error_in_post_startup() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -216,7 +244,14 @@ async fn test_supervision_panic_in_handle() {
         flag: Arc<AtomicU64>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -238,7 +273,14 @@ async fn test_supervision_panic_in_handle() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -315,7 +357,14 @@ async fn test_supervision_error_in_handle() {
         flag: Arc<AtomicU64>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -337,7 +386,14 @@ async fn test_supervision_error_in_handle() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -415,7 +471,14 @@ async fn test_supervision_panic_in_post_stop() {
         flag: Arc<AtomicU64>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -438,7 +501,14 @@ async fn test_supervision_panic_in_post_stop() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -498,7 +568,14 @@ async fn test_supervision_error_in_post_stop() {
         flag: Arc<AtomicU64>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -521,7 +598,14 @@ async fn test_supervision_error_in_post_stop() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -585,7 +669,14 @@ async fn test_supervision_panic_in_supervisor_handle() {
         flag: Arc<AtomicU64>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -607,7 +698,14 @@ async fn test_supervision_panic_in_supervisor_handle() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Midpoint {
         type Msg = ();
         type State = ();
@@ -632,7 +730,14 @@ async fn test_supervision_panic_in_supervisor_handle() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -729,7 +834,14 @@ async fn test_supervision_error_in_supervisor_handle() {
         flag: Arc<AtomicU64>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type Arguments = ();
@@ -751,7 +863,14 @@ async fn test_supervision_error_in_supervisor_handle() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Midpoint {
         type Msg = ();
         type State = ();
@@ -776,7 +895,14 @@ async fn test_supervision_error_in_supervisor_handle() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -868,7 +994,14 @@ async fn test_killing_a_supervisor_terminates_children() {
     struct Child;
     struct Supervisor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -882,7 +1015,14 @@ async fn test_killing_a_supervisor_terminates_children() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -944,7 +1084,14 @@ async fn instant_supervised_spawns() {
     let counter = Arc::new(AtomicU8::new(0));
 
     struct EmptySupervisor;
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for EmptySupervisor {
         type Msg = ();
         type State = ();
@@ -969,7 +1116,14 @@ async fn instant_supervised_spawns() {
     }
 
     struct EmptyActor;
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for EmptyActor {
         type Msg = String;
         type State = Arc<AtomicU8>;
@@ -1051,7 +1205,14 @@ async fn test_supervisor_captures_dead_childs_state() {
         flag: Arc<AtomicU64>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = u64;
@@ -1073,7 +1234,14 @@ async fn test_supervisor_captures_dead_childs_state() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -1154,7 +1322,14 @@ async fn test_supervisor_captures_dead_childs_state() {
 async fn test_supervisor_double_link() {
     struct Who;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Who {
         type Msg = ();
         type State = ();
@@ -1204,7 +1379,14 @@ async fn test_supervisor_exit_doesnt_call_child_post_stop() {
     }
     struct Supervisor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -1226,7 +1408,14 @@ async fn test_supervisor_exit_doesnt_call_child_post_stop() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -1291,7 +1480,14 @@ async fn stopping_children_and_wait_during_parent_shutdown() {
     }
     struct Supervisor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -1313,7 +1509,14 @@ async fn stopping_children_and_wait_during_parent_shutdown() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -1376,7 +1579,14 @@ async fn stopping_children_will_shutdown_parent_too() {
     }
     struct Supervisor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -1398,7 +1608,14 @@ async fn stopping_children_will_shutdown_parent_too() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -1462,7 +1679,14 @@ async fn draining_children_and_wait_during_parent_shutdown() {
     }
     struct Supervisor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -1484,7 +1708,14 @@ async fn draining_children_and_wait_during_parent_shutdown() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -1547,7 +1778,14 @@ async fn draining_children_will_shutdown_parent_too() {
     }
     struct Supervisor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -1569,7 +1807,14 @@ async fn draining_children_will_shutdown_parent_too() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -1637,7 +1882,14 @@ async fn test_simple_monitor() {
         counter: Arc<AtomicU8>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Peer {
         type Msg = ();
         type State = ();
@@ -1662,7 +1914,14 @@ async fn test_simple_monitor() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Monitor {
         type Msg = ();
         type State = ();

--- a/ractor/src/actor/tests.rs
+++ b/ractor/src/actor/tests.rs
@@ -38,7 +38,14 @@ async fn test_panic_on_start_captured() {
     #[derive(Default)]
     struct TestActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -65,7 +72,14 @@ async fn test_panic_on_start_captured() {
 async fn test_error_on_start_captured() {
     struct TestActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -96,7 +110,14 @@ async fn test_stop_higher_priority_over_messages() {
         counter: Arc<AtomicU8>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -174,7 +195,14 @@ async fn test_stop_higher_priority_over_messages() {
 async fn test_kill_terminates_work() {
     struct TestActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -223,7 +251,14 @@ async fn test_kill_terminates_work() {
 async fn test_stop_does_not_terminate_async_work() {
     struct TestActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -281,7 +316,14 @@ async fn test_stop_does_not_terminate_async_work() {
 async fn test_kill_terminates_supervision_work() {
     struct TestActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -334,7 +376,14 @@ async fn test_sending_message_to_invalid_actor_type() {
     struct TestMessage1;
     #[cfg(feature = "cluster")]
     impl crate::Message for TestMessage1 {}
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor1 {
         type Msg = TestMessage1;
         type State = ();
@@ -351,7 +400,14 @@ async fn test_sending_message_to_invalid_actor_type() {
     struct TestMessage2;
     #[cfg(feature = "cluster")]
     impl crate::Message for TestMessage2 {}
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor2 {
         type Msg = TestMessage2;
         type State = ();
@@ -394,7 +450,14 @@ async fn test_sending_message_to_dead_actor() {
     #[derive(Default)]
     struct TestActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -458,7 +521,14 @@ async fn test_serialized_cast() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = TestMessage;
         type State = ();
@@ -593,7 +663,14 @@ async fn test_serialized_rpc() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = TestMessage;
         type State = ();
@@ -674,7 +751,14 @@ async fn test_remote_actor() {
     let counter = Arc::new(AtomicU8::new(0));
 
     struct DummySupervisor;
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for DummySupervisor {
         type Msg = ();
         type State = ();
@@ -709,7 +793,14 @@ async fn test_remote_actor() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestRemoteActor {
         type Msg = TestRemoteMessage;
         type State = ();
@@ -785,7 +876,14 @@ async fn spawning_local_actor_as_remote_fails() {
     struct RemoteActor;
     struct RemoteActorMessage;
     impl crate::Message for RemoteActorMessage {}
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for RemoteActor {
         type Msg = RemoteActorMessage;
         type State = ();
@@ -800,7 +898,14 @@ async fn spawning_local_actor_as_remote_fails() {
     }
 
     struct EmptyActor;
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for EmptyActor {
         type Msg = ();
         type State = ();
@@ -843,7 +948,14 @@ async fn instant_spawns() {
     let counter = Arc::new(AtomicU8::new(0));
 
     struct EmptyActor;
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for EmptyActor {
         type Msg = String;
         type State = Arc<AtomicU8>;
@@ -905,7 +1017,14 @@ async fn instant_spawns() {
 )]
 async fn stop_and_wait() {
     struct SlowActor;
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for SlowActor {
         type Msg = ();
         type State = ();
@@ -937,7 +1056,14 @@ async fn stop_and_wait() {
 )]
 async fn kill_and_wait() {
     struct SlowActor;
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for SlowActor {
         type Msg = ();
         type State = ();
@@ -981,7 +1107,14 @@ fn returns_actor_references() {
 
     struct TestActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -1034,7 +1167,14 @@ async fn actor_failing_in_spawn_err_doesnt_poison_registries() {
     #[derive(Default)]
     struct Test;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Test {
         type Msg = ();
         type State = ();
@@ -1048,7 +1188,14 @@ async fn actor_failing_in_spawn_err_doesnt_poison_registries() {
     #[derive(Default)]
     struct Test2;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Test2 {
         type Msg = ();
         type State = ();
@@ -1084,7 +1231,14 @@ async fn actor_post_stop_executed_before_stop_and_wait_returns() {
         signal: Arc<AtomicU8>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -1140,7 +1294,14 @@ async fn actor_drain_messages() {
         signal: Arc<AtomicU32>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -1204,7 +1365,14 @@ async fn actor_drain_messages() {
 async fn runtime_message_typing() {
     struct TestActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -1240,7 +1408,14 @@ async fn runtime_message_typing() {
 async fn wait_for_death() {
     struct TestActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = EmptyMessage;
         type Arguments = ();
@@ -1288,7 +1463,14 @@ async fn derived_actor_ref() {
         counter: Arc<AtomicU32>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = u32;
         type Arguments = ();

--- a/ractor/src/concurrency.rs
+++ b/ractor/src/concurrency.rs
@@ -89,9 +89,7 @@ pub use self::tokio_with_wasm_primitives::*;
 mod target_specific {
     /// A wrapper for [std::marker::Send] on non-`wasm32-unknown-unknown` targets, or an empty trait on `wasm32-unknown-unknown` targets.
     /// Introduced for compatibility between wasm32 and other targets
-    #[cfg(not(feature = "async-trait"))]
     pub trait MaybeSend {}
-    #[cfg(not(feature = "async-trait"))]
     impl<T> MaybeSend for T {}
     pub(crate) use web_time::SystemTime;
 }
@@ -99,13 +97,10 @@ mod target_specific {
 mod target_specific {
     /// A wrapper for [std::marker::Send] on non-`wasm32-unknown-unknown` targets, or an empty trait on `wasm32-unknown-unknown` targets.
     /// Introduced for compatibility between wasm32 and other targets
-    #[cfg(not(feature = "async-trait"))]
     pub trait MaybeSend: Send {}
-    #[cfg(not(feature = "async-trait"))]
     impl<T> MaybeSend for T where T: Send {}
     pub(crate) use std::time::SystemTime;
 }
 
-#[cfg(not(feature = "async-trait"))]
 pub use target_specific::MaybeSend;
 pub(crate) use target_specific::SystemTime;

--- a/ractor/src/factory/discard.rs
+++ b/ractor/src/factory/discard.rs
@@ -132,7 +132,14 @@ impl DiscardSettings {
 
 /// Controls the dynamic concurrency level by receiving periodic snapshots of job statistics
 /// and emitting a new concurrency limit
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 pub trait DynamicDiscardController: Send + Sync + 'static {
     /// Compute the new threshold for discarding
     ///

--- a/ractor/src/factory/factoryimpl.rs
+++ b/ractor/src/factory/factoryimpl.rs
@@ -783,7 +783,14 @@ where
     }
 }
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl<TKey, TMsg, TWorkerStart, TWorker, TRouter, TQueue> Actor
     for Factory<TKey, TMsg, TWorkerStart, TWorker, TRouter, TQueue>
 where

--- a/ractor/src/factory/lifecycle.rs
+++ b/ractor/src/factory/lifecycle.rs
@@ -21,7 +21,14 @@ use crate::State;
 
 /// Hooks for [crate::factory::Factory] lifecycle events based on the
 /// underlying actor's lifecycle.
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 pub trait FactoryLifecycleHooks<TKey, TMsg>: State + Sync
 where
     TKey: JobKey,

--- a/ractor/src/factory/tests/basic.rs
+++ b/ractor/src/factory/tests/basic.rs
@@ -53,7 +53,14 @@ struct TestWorker {
     slow: Option<u64>,
 }
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl Worker for TestWorker {
     type Key = TestKey;
     type Message = TestMessage;
@@ -631,7 +638,14 @@ struct StuckWorker {
     slow: Option<u64>,
 }
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl Actor for StuckWorker {
     type Msg = WorkerMessage<TestKey, TestMessage>;
     type State = Self::Arguments;

--- a/ractor/src/factory/tests/draining_requests.rs
+++ b/ractor/src/factory/tests/draining_requests.rs
@@ -48,7 +48,14 @@ struct TestWorker {
     counter: Arc<AtomicU16>,
 }
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl Actor for TestWorker {
     type Msg = WorkerMessage<TestKey, TestMessage>;
     type State = Self::Arguments;

--- a/ractor/src/factory/tests/dynamic_discarding.rs
+++ b/ractor/src/factory/tests/dynamic_discarding.rs
@@ -50,7 +50,14 @@ struct TestWorker {
     slow: Option<u64>,
 }
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl Actor for TestWorker {
     type Msg = WorkerMessage<TestKey, TestMessage>;
     type State = Self::Arguments;
@@ -123,7 +130,14 @@ impl DiscardHandler<TestKey, TestMessage> for TestDiscarder {
 
 struct DiscardController {}
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl DynamicDiscardController for DiscardController {
     #[cfg(feature = "async-trait")]
     async fn compute(&mut self, _current_threshold: usize) -> usize {

--- a/ractor/src/factory/tests/dynamic_pool.rs
+++ b/ractor/src/factory/tests/dynamic_pool.rs
@@ -48,7 +48,14 @@ struct TestWorker {
 #[cfg(feature = "cluster")]
 impl crate::Message for TestMessage {}
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl Worker for TestWorker {
     type Key = TestKey;
     type Message = TestMessage;
@@ -197,7 +204,14 @@ async fn test_worker_pool_adjustment_automatic() {
 
     struct DynamicWorkerController;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl WorkerCapacityController for DynamicWorkerController {
         #[cfg(feature = "async-trait")]
         async fn get_pool_size(&mut self, _current: usize) -> usize {

--- a/ractor/src/factory/tests/dynamic_settings.rs
+++ b/ractor/src/factory/tests/dynamic_settings.rs
@@ -17,7 +17,14 @@ use crate::ActorRef;
 
 struct TestWorker;
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl Worker for TestWorker {
     type State = ();
     type Key = ();

--- a/ractor/src/factory/tests/lifecycle.rs
+++ b/ractor/src/factory/tests/lifecycle.rs
@@ -27,7 +27,14 @@ struct AtomicHooks {
     state: Arc<AtomicU8>,
 }
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl FactoryLifecycleHooks<(), ()> for AtomicHooks {
     #[cfg(feature = "async-trait")]
     async fn on_factory_started(
@@ -89,7 +96,14 @@ impl FactoryLifecycleHooks<(), ()> for AtomicHooks {
 
 struct TestWorker;
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl Actor for TestWorker {
     type State = Self::Arguments;
     type Msg = WorkerMessage<(), ()>;

--- a/ractor/src/factory/tests/priority_queueing.rs
+++ b/ractor/src/factory/tests/priority_queueing.rs
@@ -44,7 +44,14 @@ impl PriorityManager<StandardPriority, StandardPriority> for TestPriorityManager
     }
 }
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl Actor for TestWorker {
     type Msg = WorkerMessage<TestKey, TestMessage>;
     type State = (Self::Arguments, u16);

--- a/ractor/src/factory/tests/ratelim.rs
+++ b/ractor/src/factory/tests/ratelim.rs
@@ -17,7 +17,14 @@ use crate::*;
 
 struct TestWorker;
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl Worker for TestWorker {
     type State = ();
     type Key = ();

--- a/ractor/src/factory/tests/worker_lifecycle.rs
+++ b/ractor/src/factory/tests/worker_lifecycle.rs
@@ -30,7 +30,14 @@ enum MyWorkerMessage {
 #[cfg(feature = "cluster")]
 impl crate::Message for MyWorkerMessage {}
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl Actor for MyWorker {
     type State = Self::Arguments;
     type Msg = WorkerMessage<(), MyWorkerMessage>;
@@ -211,7 +218,14 @@ where
         _m: PhantomData<fn() -> TMessage2>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl<F2, TKey2, TMessage2> Actor for MockFactory<F2, TKey2, TMessage2>
     where
         TKey2: JobKey,

--- a/ractor/src/factory/worker.rs
+++ b/ractor/src/factory/worker.rs
@@ -64,7 +64,14 @@ pub struct DeadMansSwitchConfiguration {
 /// without breaking the factory <-> worker API requirement. If you so wish
 /// you can fully specify the actor properties instead of using this
 /// assistance trait.
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 pub trait Worker: Send + Sync + 'static {
     /// The worker's job-key type
     type Key: JobKey;
@@ -310,7 +317,14 @@ impl<TWorker: Worker> std::fmt::Debug for WorkerState<TWorker> {
     }
 }
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl<T> Actor for T
 where
     T: Worker,
@@ -419,7 +433,14 @@ where
 
 /// Controls the size of the worker pool by dynamically growing/shrinking the pool
 /// to requested size
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 pub trait WorkerCapacityController: 'static + Send + Sync {
     /// Retrieve the new pool size
     ///

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -207,6 +207,7 @@ pub use actor::messages::SupervisionEvent;
 pub use actor::Actor;
 pub use actor::ActorRuntime;
 #[cfg(feature = "async-trait")]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub use async_trait::async_trait;
 #[cfg(test)]
 use criterion as _;

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -21,7 +21,14 @@ use crate::SupervisionEvent;
 
 struct TestActor;
 
-#[cfg_attr(feature = "async-trait", crate::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    crate::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
 impl Actor for TestActor {
     type Msg = ();
     type Arguments = ();
@@ -536,7 +543,14 @@ async fn test_pg_monitoring() {
         pg_group: GroupName,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for AutoJoinActor {
         type Msg = ();
         type Arguments = ();
@@ -557,7 +571,14 @@ async fn test_pg_monitoring() {
         counter: Arc<AtomicU8>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for NotificationMonitor {
         type Msg = ();
         type Arguments = ();
@@ -647,7 +668,14 @@ async fn test_scope_monitoring() {
         pg_group: GroupName,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for AutoJoinActor {
         type Msg = ();
         type Arguments = ();
@@ -672,7 +700,14 @@ async fn test_scope_monitoring() {
         counter: Arc<AtomicU8>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for NotificationMonitor {
         type Msg = ();
         type Arguments = ();
@@ -788,7 +823,14 @@ async fn local_vs_remote_pg_members() {
     struct TestRemoteActor;
     struct TestRemoteActorMessage;
     impl crate::Message for TestRemoteActorMessage {}
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestRemoteActor {
         type Msg = TestRemoteActorMessage;
         type State = ();
@@ -862,7 +904,14 @@ async fn local_vs_remote_pg_members_in_named_scopes() {
     struct TestRemoteActor;
     struct TestRemoteActorMessage;
     impl crate::Message for TestRemoteActorMessage {}
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestRemoteActor {
         type Msg = TestRemoteActorMessage;
         type State = ();

--- a/ractor/src/port/output/tests.rs
+++ b/ractor/src/port/output/tests.rs
@@ -27,7 +27,14 @@ async fn test_single_forward() {
     }
     #[cfg(feature = "cluster")]
     impl crate::Message for TestActorMessage {}
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = TestActorMessage;
         type Arguments = ();
@@ -94,7 +101,14 @@ async fn test_50_receivers() {
     }
     #[cfg(feature = "cluster")]
     impl crate::Message for TestActorMessage {}
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = TestActorMessage;
         type Arguments = ();
@@ -177,7 +191,14 @@ async fn test_delivery() {
     }
     #[cfg(feature = "cluster")]
     impl crate::Message for TestActorMessage {}
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = TestActorMessage;
         type Arguments = ();
@@ -270,7 +291,14 @@ mod output_port_subscriber_tests {
 
     struct NumberPublisher;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for NumberPublisher {
         type State = OutputPort<u8>;
         type Msg = NumberPublisherMessage;
@@ -321,7 +349,14 @@ mod output_port_subscriber_tests {
     }
 
     struct PlusSubscriber;
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for PlusSubscriber {
         type State = u8;
         type Msg = PlusSubscriberMessage;
@@ -374,7 +409,14 @@ mod output_port_subscriber_tests {
     }
 
     struct MulSubscriber;
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for MulSubscriber {
         type State = u8;
         type Msg = MulSubscriberMessage;

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -19,7 +19,14 @@ async fn test_basic_registation() {
     #[derive(Default)]
     struct EmptyActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for EmptyActor {
         type Msg = ();
         type Arguments = ();
@@ -57,7 +64,14 @@ async fn test_basic_registation() {
 async fn test_duplicate_registration() {
     struct EmptyActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for EmptyActor {
         type Msg = ();
         type Arguments = ();
@@ -108,7 +122,14 @@ async fn test_duplicate_registration() {
 async fn test_actor_registry_unenrollment() {
     struct EmptyActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for EmptyActor {
         type Msg = ();
         type Arguments = ();
@@ -160,7 +181,14 @@ mod pid_registry_tests {
     struct RemoteActor;
     struct RemoteActorMessage;
     impl crate::Message for RemoteActorMessage {}
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for RemoteActor {
         type Msg = RemoteActorMessage;
         type State = ();
@@ -181,7 +209,14 @@ mod pid_registry_tests {
     )]
     async fn try_enroll_remote_actor() {
         struct EmptyActor;
-        #[cfg_attr(feature = "async-trait", crate::async_trait)]
+        #[cfg_attr(
+            all(
+                feature = "async-trait",
+                not(all(target_arch = "wasm32", target_os = "unknown"))
+            ),
+            crate::async_trait
+        )]
+        #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
         impl Actor for EmptyActor {
             type Msg = ();
             type State = ();
@@ -231,7 +266,14 @@ mod pid_registry_tests {
     async fn test_basic_registation() {
         struct EmptyActor;
 
-        #[cfg_attr(feature = "async-trait", crate::async_trait)]
+        #[cfg_attr(
+            all(
+                feature = "async-trait",
+                not(all(target_arch = "wasm32", target_os = "unknown"))
+            ),
+            crate::async_trait
+        )]
+        #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
         impl Actor for EmptyActor {
             type Msg = ();
             type Arguments = ();
@@ -268,7 +310,14 @@ mod pid_registry_tests {
     async fn test_actor_registry_unenrollment() {
         struct EmptyActor;
 
-        #[cfg_attr(feature = "async-trait", crate::async_trait)]
+        #[cfg_attr(
+            all(
+                feature = "async-trait",
+                not(all(target_arch = "wasm32", target_os = "unknown"))
+            ),
+            crate::async_trait
+        )]
+        #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
         impl Actor for EmptyActor {
             type Msg = ();
             type Arguments = ();
@@ -315,7 +364,14 @@ mod pid_registry_tests {
 
         struct AutoJoinActor;
 
-        #[cfg_attr(feature = "async-trait", crate::async_trait)]
+        #[cfg_attr(
+            all(
+                feature = "async-trait",
+                not(all(target_arch = "wasm32", target_os = "unknown"))
+            ),
+            crate::async_trait
+        )]
+        #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
         impl Actor for AutoJoinActor {
             type Msg = ();
             type Arguments = ();
@@ -334,7 +390,14 @@ mod pid_registry_tests {
             counter: Arc<DashMap<ActorId, u8>>,
         }
 
-        #[cfg_attr(feature = "async-trait", crate::async_trait)]
+        #[cfg_attr(
+            all(
+                feature = "async-trait",
+                not(all(target_arch = "wasm32", target_os = "unknown"))
+            ),
+            crate::async_trait
+        )]
+        #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
         impl Actor for NotificationMonitor {
             type Msg = ();
             type Arguments = ();

--- a/ractor/src/rpc/tests.rs
+++ b/ractor/src/rpc/tests.rs
@@ -32,7 +32,14 @@ async fn test_rpc_cast() {
         counter: Arc<AtomicU8>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = ();
         type Arguments = ();
@@ -96,7 +103,14 @@ async fn test_rpc_call() {
     }
     #[cfg(feature = "cluster")]
     impl crate::Message for MessageFormat {}
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = MessageFormat;
         type Arguments = ();
@@ -192,7 +206,14 @@ async fn test_rpc_call_forwarding() {
     }
     #[cfg(feature = "cluster")]
     impl crate::Message for WorkerMessage {}
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Worker {
         type Msg = WorkerMessage;
         type Arguments = ();
@@ -235,7 +256,14 @@ async fn test_rpc_call_forwarding() {
     }
     #[cfg(feature = "cluster")]
     impl crate::Message for ForwarderMessage {}
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Forwarder {
         type Msg = ForwarderMessage;
         type Arguments = ();
@@ -352,7 +380,14 @@ async fn test_multi_call() {
     }
     #[cfg(feature = "cluster")]
     impl crate::Message for MessageFormat {}
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = MessageFormat;
         type Arguments = ();

--- a/ractor/src/tests.rs
+++ b/ractor/src/tests.rs
@@ -53,7 +53,14 @@ fn test_error_conversions() {
 async fn test_error_message_extraction() {
     struct TestActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = ();
         type State = ();

--- a/ractor/src/thread_local/supervision_tests.rs
+++ b/ractor/src/thread_local/supervision_tests.rs
@@ -60,7 +60,14 @@ async fn test_thread_local_child() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();
@@ -128,7 +135,14 @@ async fn test_thread_local_supervisor() {
     #[derive(Default)]
     struct Supervisor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Child {
         type Msg = ();
         type State = ();
@@ -236,7 +250,14 @@ async fn test_thread_local_child_panic_handle() {
         }
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for Supervisor {
         type Msg = ();
         type State = ();

--- a/ractor/src/time/tests.rs
+++ b/ractor/src/time/tests.rs
@@ -27,7 +27,14 @@ async fn test_intervals() {
         counter: Arc<AtomicU8>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = ();
         type State = Arc<AtomicU8>;
@@ -94,7 +101,14 @@ async fn test_send_after() {
         counter: Arc<AtomicU8>,
     }
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = ();
         type State = Arc<AtomicU8>;
@@ -157,7 +171,14 @@ async fn test_send_after() {
 async fn test_exit_after() {
     struct TestActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = ();
         type State = ();
@@ -192,7 +213,14 @@ async fn test_exit_after() {
 async fn test_kill_after() {
     struct TestActor;
 
-    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        crate::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), crate::async_trait(?Send))]
     impl Actor for TestActor {
         type Msg = ();
         type State = ();

--- a/ractor_cluster/src/net/listener.rs
+++ b/ractor_cluster/src/net/listener.rs
@@ -48,7 +48,14 @@ pub(crate) struct ListenerState {
 #[derive(crate::RactorMessage)]
 pub(crate) struct ListenerMessage;
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for Listener {
     type Msg = ListenerMessage;
     type Arguments = ActorRef<NodeServerMessage>;

--- a/ractor_cluster/src/net/session.rs
+++ b/ractor_cluster/src/net/session.rs
@@ -115,7 +115,14 @@ pub(crate) struct SessionState {
     reader: ActorRef<SessionReaderMessage>,
 }
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for Session {
     type Msg = SessionMessage;
     type Arguments = super::NetworkStream;
@@ -295,7 +302,14 @@ enum SessionWriterMessage {
     WriteObject(crate::protocol::NetworkMessage),
 }
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for SessionWriter {
     type Msg = SessionWriterMessage;
     type Arguments = ActorWriteHalf;
@@ -383,7 +397,14 @@ struct SessionReaderState {
     reader: Option<ActorReadHalf>,
 }
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for SessionReader {
     type Msg = SessionReaderMessage;
     type Arguments = ActorReadHalf;

--- a/ractor_cluster/src/node.rs
+++ b/ractor_cluster/src/node.rs
@@ -347,7 +347,14 @@ impl NodeServerState {
     }
 }
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for NodeServer {
     type Msg = NodeServerMessage;
     type State = NodeServerState;

--- a/ractor_cluster/src/node/node_session.rs
+++ b/ractor_cluster/src/node/node_session.rs
@@ -884,7 +884,14 @@ impl NodeSessionState {
     }
 }
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for NodeSession {
     type Msg = super::NodeSessionMessage;
     type Arguments = crate::net::NetworkStream;

--- a/ractor_cluster/src/node/node_session/tests.rs
+++ b/ractor_cluster/src/node/node_session/tests.rs
@@ -17,7 +17,14 @@ use crate::node::NodeConnectionMode;
 use crate::NodeSessionMessage;
 
 struct DummyNodeServer;
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for DummyNodeServer {
     type Msg = crate::node::NodeServerMessage;
     type State = ();
@@ -56,7 +63,14 @@ impl Actor for DummyNodeServer {
 }
 
 struct DummyNodeSession;
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for DummyNodeSession {
     type Msg = crate::node::NodeSessionMessage;
     type State = ();
@@ -547,7 +561,14 @@ async fn node_session_handle_node_msg() {
         call_replies: Arc<AtomicU8>,
     }
 
-    #[cfg_attr(feature = "async-trait", ractor::async_trait)]
+    #[cfg_attr(
+        all(
+            feature = "async-trait",
+            not(all(target_arch = "wasm32", target_os = "unknown"))
+        ),
+        ractor::async_trait
+    )]
+    #[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
     impl Actor for DummyRemoteActor {
         type Msg = crate::remote_actor::RemoteActorMessage;
         type State = ();

--- a/ractor_cluster/src/remote_actor.rs
+++ b/ractor_cluster/src/remote_actor.rs
@@ -85,7 +85,14 @@ impl RemoteActorState {
 #[derive(RactorMessage)]
 pub(crate) struct RemoteActorMessage;
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for RemoteActor {
     type Msg = RemoteActorMessage;
     type State = RemoteActorState;

--- a/ractor_cluster/src/remote_actor/tests.rs
+++ b/ractor_cluster/src/remote_actor/tests.rs
@@ -17,7 +17,14 @@ impl FakeNodeSession {
     }
 }
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for FakeNodeSession {
     type Msg = crate::node::NodeSessionMessage;
     type State = ();

--- a/ractor_cluster_integration_tests/src/tests/pg_groups.rs
+++ b/ractor_cluster_integration_tests/src/tests/pg_groups.rs
@@ -42,7 +42,14 @@ struct HelloActorState {
     done: bool,
 }
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+#[cfg_attr(
+    all(
+        feature = "async-trait",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ),
+    ractor::async_trait
+)]
+#[cfg_attr(all(feature = "async-trait", all(target_arch = "wasm32", target_os = "unknown")), ractor::async_trait(?Send))]
 impl Actor for HelloActor {
     type Msg = HelloActorMessage;
     type State = HelloActorState;


### PR DESCRIPTION
The crate ``async-trait`` allows configuring whether the futures are marked as ``Send + Sync`` by a parameter to the macro (
``#[async_trait(?Send)]``): https://docs.rs/async-trait/latest/async_trait/#non-threadsafe-futures

This PR always exports the ``MaybeSend`` type, and changes how async trait is used depending on the target.

If the target is non-wasm, it's used as ``#[async_trait]`` as before.
If the target IS wasm, it's used as ``#[async_trait(?Send)]``.

That correctly models wasm, as there are no threads yet.

If, in the future, WASM gains native threads, things become complicated.

--------

I've changed this in the code, but purposefully not yet in the doc comments. I have the hope that there's an easier solution that doesn't pollute user code as much, maybe a custom macro that wraps async-trait or something.

