### PR TITLE
[WASM] remove MaybeSend, ensure 'timeout' is Send

### DIFF
--- a/.github/wasm-test-runner/index.js
+++ b/.github/wasm-test-runner/index.js
@@ -7,7 +7,13 @@ import { spawn } from "child_process";
         console.error("Set `WORKING_DIR` to the directory of ractor");
         return;
     }
-    const cargoRunner = spawn("wasm-pack test --chrome ./ractor", { cwd: workingDir, stdio: "pipe", shell: true });
+    var command;
+    if (process.env.FEATURES_ASYNC_TRAIT == true) {
+        command = "wasm-pack test --chrome ./ractor --features async-trait";
+    } else {
+        command = "wasm-pack test --chrome ./ractor";
+    }
+    const cargoRunner = spawn(command, { cwd: workingDir, stdio: "pipe", shell: true });
     cargoRunner.stdout.setEncoding("utf-8");
     cargoRunner.stderr.setEncoding("utf-8");
     const flagPromise = new Promise((resolve) => {
@@ -71,7 +77,7 @@ import { spawn } from "child_process";
         })(),
         new Promise((_, rej) => setTimeout(() => {
             rej(new Error("Timed out when running tests.."))
-        }, 5 * 60 * 1000))
+        }, 20 * 60 * 1000))
     ]);
 
     await page.close();

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -30,8 +30,42 @@ jobs:
         run: |
           cd ./.github/wasm-test-runner
           npm install
+          
       - name: Run tests
         run: |
           export WORKING_DIR=$(pwd)
           cd ./.github/wasm-test-runner
-          node ./index.js     
+          node ./index.js
+
+
+  unit-test-async-trait:
+    name: "Run unit tests in browser (features: async-trait)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+      
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      
+      - name: Setup test runner
+        run: |
+          cd ./.github/wasm-test-runner
+          npm install
+          
+      - name: "Run tests (features: async-trait)"
+        env:
+          FEATURES_ASYNC_TRAIT: "true"
+        run: |
+          export WORKING_DIR=$(pwd)
+          cd ./.github/wasm-test-runner
+          node ./index.js

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -40,7 +40,8 @@ strum = { version = "0.26", features = ["derive"] }
 
 ## Configurable dependencies
 # Tracing feature requires --cfg=tokio_unstable
-async-std = { version = "1", features = ["attributes"], optional = true }
+# async-std feature 'unstable' is required for spawn_local: https://docs.rs/async-std/latest/async_std/task/fn.spawn_local.html
+async-std = { version = "1", features = ["attributes", "unstable"], optional = true }
 async-trait = { version = "0.1", optional = true }
 tokio = { version = "1.30", features = ["sync"] }
 tracing = { version = "0.1", features = ["attributes"] }
@@ -51,12 +52,15 @@ pot = { version = "3.0", optional = true }
 
 
 [target.'cfg(all(target_arch = "wasm32",target_os = "unknown"))'.dependencies]
+js-sys = "0.3.77"
 tokio_with_wasm = { version = "0.8.2", features = [
     "macros",
     "sync",
     "rt",
     "time",
 ] }
+wasm-bindgen = "0.2.100"
+wasm-bindgen-futures = "0.4.50"
 web-time = "1.1.0"
 
 [dev-dependencies]
@@ -86,7 +90,10 @@ tracing-test = "0.2"
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 tokio = { version = "1.30", features = ["rt", "time", "sync", "macros"] }
 wasm-bindgen-test = "0.3.50"
-getrandom = { version = "0.2.15", features = ["js"] }
+# 'getrandom' isn't used directly, but it's used by a dependency, and, for WASM, we need to enable the feature 'js'.
+#   https://docs.rs/getrandom/latest/getrandom/#webassembly-support
+#
+getrandom = { version = "0.2", features = ["js"] }
 criterion = { version = "0.5", default-features = false }
 
 [[bench]]

--- a/ractor/src/actor.rs
+++ b/ractor/src/actor.rs
@@ -60,8 +60,6 @@ use futures::TryFutureExt;
 use tracing::Instrument;
 
 use crate::concurrency::JoinHandle;
-#[cfg(not(feature = "async-trait"))]
-use crate::concurrency::MaybeSend;
 use crate::ActorId;
 pub mod messages;
 use messages::*;
@@ -152,7 +150,7 @@ pub trait Actor: Sized + Sync + Send + 'static {
         &self,
         myself: ActorRef<Self::Msg>,
         args: Self::Arguments,
-    ) -> impl Future<Output = Result<Self::State, ActorProcessingErr>> + MaybeSend;
+    ) -> impl Future<Output = Result<Self::State, ActorProcessingErr>> + Send;
     /// Invoked when an actor is being started by the system.
     ///
     /// Any initialization inherent to the actor's role should be
@@ -189,7 +187,7 @@ pub trait Actor: Sized + Sync + Send + 'static {
         &self,
         myself: ActorRef<Self::Msg>,
         state: &mut Self::State,
-    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + MaybeSend {
+    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + Send {
         async { Ok(()) }
     }
 
@@ -226,7 +224,7 @@ pub trait Actor: Sized + Sync + Send + 'static {
         &self,
         myself: ActorRef<Self::Msg>,
         state: &mut Self::State,
-    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + MaybeSend {
+    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + Send {
         async { Ok(()) }
     }
     /// Invoked after an actor has been stopped to perform final cleanup. In the
@@ -260,7 +258,7 @@ pub trait Actor: Sized + Sync + Send + 'static {
         myself: ActorRef<Self::Msg>,
         message: Self::Msg,
         state: &mut Self::State,
-    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + MaybeSend {
+    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + Send {
         async { Ok(()) }
     }
     /// Handle the incoming message from the event processing loop. Unhandled panickes will be
@@ -293,7 +291,7 @@ pub trait Actor: Sized + Sync + Send + 'static {
         myself: ActorRef<Self::Msg>,
         message: crate::message::SerializedMessage,
         state: &mut Self::State,
-    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + MaybeSend {
+    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + Send {
         async { Ok(()) }
     }
     /// Handle the remote incoming message from the event processing loop. Unhandled panickes will be
@@ -327,7 +325,7 @@ pub trait Actor: Sized + Sync + Send + 'static {
         myself: ActorRef<Self::Msg>,
         message: SupervisionEvent,
         state: &mut Self::State,
-    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + MaybeSend {
+    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + Send {
         async move {
             match message {
                 SupervisionEvent::ActorTerminated(who, _, _)
@@ -379,8 +377,7 @@ pub trait Actor: Sized + Sync + Send + 'static {
         name: Option<ActorName>,
         handler: Self,
         startup_args: Self::Arguments,
-    ) -> impl Future<Output = Result<(ActorRef<Self::Msg>, JoinHandle<()>), SpawnErr>> + MaybeSend
-    {
+    ) -> impl Future<Output = Result<(ActorRef<Self::Msg>, JoinHandle<()>), SpawnErr>> + Send {
         ActorRuntime::<Self>::spawn(name, handler, startup_args)
     }
     /// Spawn an actor of this type, which is unsupervised, automatically starting
@@ -419,8 +416,7 @@ pub trait Actor: Sized + Sync + Send + 'static {
         handler: Self,
         startup_args: Self::Arguments,
         supervisor: ActorCell,
-    ) -> impl Future<Output = Result<(ActorRef<Self::Msg>, JoinHandle<()>), SpawnErr>> + MaybeSend
-    {
+    ) -> impl Future<Output = Result<(ActorRef<Self::Msg>, JoinHandle<()>), SpawnErr>> + Send {
         ActorRuntime::<Self>::spawn_linked(name, handler, startup_args, supervisor)
     }
     /// Spawn an actor of this type with a supervisor, automatically starting the actor

--- a/ractor/src/concurrency.rs
+++ b/ractor/src/concurrency.rs
@@ -81,31 +81,17 @@ pub mod async_std_primitives;
 pub use self::async_std_primitives::*;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub mod tokio_with_wasm_primitives;
+pub mod wasm_browser_primitives;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub use self::tokio_with_wasm_primitives::*;
+pub use self::wasm_browser_primitives::*;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod target_specific {
-    /// A wrapper for [std::marker::Send] on non-`wasm32-unknown-unknown` targets, or an empty trait on `wasm32-unknown-unknown` targets.
-    /// Introduced for compatibility between wasm32 and other targets
-    #[cfg(not(feature = "async-trait"))]
-    pub trait MaybeSend {}
-    #[cfg(not(feature = "async-trait"))]
-    impl<T> MaybeSend for T {}
     pub(crate) use web_time::SystemTime;
 }
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 mod target_specific {
-    /// A wrapper for [std::marker::Send] on non-`wasm32-unknown-unknown` targets, or an empty trait on `wasm32-unknown-unknown` targets.
-    /// Introduced for compatibility between wasm32 and other targets
-    #[cfg(not(feature = "async-trait"))]
-    pub trait MaybeSend: Send {}
-    #[cfg(not(feature = "async-trait"))]
-    impl<T> MaybeSend for T where T: Send {}
     pub(crate) use std::time::SystemTime;
 }
 
-#[cfg(not(feature = "async-trait"))]
-pub use target_specific::MaybeSend;
 pub(crate) use target_specific::SystemTime;

--- a/ractor/src/concurrency/tokio_primitives.rs
+++ b/ractor/src/concurrency/tokio_primitives.rs
@@ -45,6 +45,14 @@ where
     spawn_named(None, future)
 }
 
+/// Spawn a task on the executor runtime which will not be moved to other threads
+pub fn spawn_local<F>(future: F) -> JoinHandle<F::Output>
+where
+    F: Future + 'static,
+{
+    tokio::task::spawn_local(future)
+}
+
 /// Spawn a (possibly) named task on the executor runtime
 pub fn spawn_named<F>(name: Option<&str>, future: F) -> JoinHandle<F::Output>
 where

--- a/ractor/src/concurrency/wasm_browser_primitives.rs
+++ b/ractor/src/concurrency/wasm_browser_primitives.rs
@@ -3,7 +3,10 @@
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree.
 
-//! Concurrency primitives based on `tokio`
+//! Concurrency primitives for the browser based on `tokio-with-wasm` and `wasm-bindgen`.
+//! This implementation only works in a browser environment and is not suitable for server-side wasm use.
+
+mod time;
 
 use std::future::Future;
 
@@ -19,19 +22,19 @@ pub type Duration = std::time::Duration;
 pub type Instant = web_time::Instant;
 
 /// Sleep the task for a duration of time
-pub async fn sleep(dur: Duration) {
-    tokio::time::sleep(dur).await;
+pub fn sleep(dur: Duration) -> impl Future<Output = ()> + Send {
+    time::sleep(dur)
 }
 
 /// An asynchronous interval calculation which waits until
 /// a checkpoint time to tick
-pub type Interval = tokio::time::Interval;
+pub type Interval = time::Interval;
 
 /// Build a new interval at the given duration starting at now
 ///
 /// Ticks 1 time immediately
 pub fn interval(dur: Duration) -> Interval {
-    tokio::time::interval(dur)
+    time::interval(dur)
 }
 
 /// A set of futures to join on, in an unordered fashion
@@ -41,17 +44,27 @@ pub type JoinSet<T> = tokio::task::JoinSet<T>;
 /// Spawn a task on the executor runtime
 pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
 where
-    F: Future + 'static,
-    F::Output: 'static,
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
 {
     spawn_named(None, future)
+}
+
+/// Spawn a task on the executor runtime which will not be moved to other threads
+pub fn spawn_local<F>(future: F) -> JoinHandle<F::Output>
+where
+    F: Future + 'static,
+{
+    // note: 'tokio_with_wasm::spawn_local' has an incorrect signature and only works with Output=().
+
+    tokio_with_wasm::spawn(future)
 }
 
 /// Spawn a (possibly) named task on the executor runtime
 pub fn spawn_named<F>(name: Option<&str>, future: F) -> JoinHandle<F::Output>
 where
-    F: Future + 'static,
-    F::Output: 'static,
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
 {
     #[cfg(tokio_unstable)]
     {
@@ -77,11 +90,10 @@ where
 /// Returns [Ok(_)] if the future succeeded before the timeout, [Err(super::Timeout)] otherwise
 pub async fn timeout<F, T>(dur: super::Duration, future: F) -> Result<T, super::Timeout>
 where
-    F: Future<Output = T>,
+    F: Future<Output = T> + Send,
+    T: 'static,
 {
-    tokio::time::timeout(dur, future)
-        .await
-        .map_err(|_| super::Timeout)
+    time::timeout(dur, future).await.map_err(|_| super::Timeout)
 }
 
 macro_rules! select {

--- a/ractor/src/concurrency/wasm_browser_primitives/time.rs
+++ b/ractor/src/concurrency/wasm_browser_primitives/time.rs
@@ -1,0 +1,236 @@
+//! This source file is copied from 'tokio_with_wasm' 0.8.6 and modified to properly mark futures as `Send`.
+//! (https://github.com/cunarist/tokio-with-wasm/blob/b4171d75a899c02cea4afc3a3f523c3809959cae/package/src/glue/time/mod.rs)
+
+//! Utilities for tracking time.
+//!
+//! This module provides a number of types for executing code after a set period
+//! of time.
+
+/// from tokio_with_wasm-0.8.6\src\glue\common\mod.rs
+mod common {
+    use js_sys::Function;
+    use wasm_bindgen::{prelude::*, JsValue};
+
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(js_namespace = console, js_name = error)]
+        pub fn error(s: &str);
+        #[wasm_bindgen(js_namespace = Date, js_name = now)]
+        pub fn now() -> f64;
+        #[wasm_bindgen(js_namespace = globalThis, js_name = setTimeout)]
+        pub fn set_timeout(callback: &Function, milliseconds: f64);
+        #[wasm_bindgen(js_namespace = globalThis, js_name = setInterval)]
+        pub fn set_interval(callback: &Function, milliseconds: f64) -> i32;
+        #[wasm_bindgen(js_namespace = globalThis, js_name = clearInterval)]
+        pub fn clear_interval(id: i32);
+    }
+
+    pub(super) trait LogError {
+        fn log_error(&self, code: &str);
+    }
+
+    impl LogError for JsValue {
+        fn log_error(&self, code: &str) {
+            error(&format!("Error `{code}` in `tokio_with_wasm`:\n{self:?}"));
+        }
+    }
+
+    impl<T> LogError for Result<T, JsValue> {
+        fn log_error(&self, code: &str) {
+            if let Err(js_value) = self {
+                error(&format!(
+                    "Error `{code}` in `tokio_with_wasm`:\n{js_value:?}"
+                ));
+            }
+        }
+    }
+}
+
+mod util {
+    use std::future::Future;
+
+    use tokio::sync::oneshot::error::RecvError;
+
+    pub(super) fn wrap_future_as_send<F, T>(
+        f: F,
+    ) -> impl Future<Output = Result<T, RecvError>> + Send
+    where
+        F: Future<Output = T> + 'static,
+        T: Send + 'static,
+    {
+        let (tx, rx) = crate::concurrency::oneshot();
+        tokio_with_wasm::spawn_local(async move {
+            let result = f.await;
+            let _ = tx.send(result); // note: failures here are ignored, the most likely reason would be a dropped receiver
+        });
+        rx
+    }
+}
+
+use util::*;
+
+use common::*;
+
+use js_sys::Promise;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use wasm_bindgen::prelude::{Closure, JsCast};
+use wasm_bindgen_futures::JsFuture;
+
+async fn time_future(duration: Duration) {
+    let milliseconds = duration.as_millis() as f64;
+    let promise = Promise::new(&mut |resolve, _reject| {
+        set_timeout(&resolve, milliseconds);
+    });
+    JsFuture::from(promise).await.log_error("TIME_FUTURE");
+}
+
+/// Waits until `duration` has elapsed.
+pub(super) fn sleep(duration: Duration) -> Sleep {
+    let time_future = time_future(duration);
+    let send_safe_future = wrap_future_as_send(time_future);
+    Sleep {
+        time_future: Box::pin(async move {
+            let _ = send_safe_future.await;
+        }),
+    }
+}
+
+/// Future returned by `sleep`.
+pub(super) struct Sleep {
+    time_future: Pin<Box<dyn Future<Output = ()> + Send>>,
+}
+
+impl Future for Sleep {
+    type Output = ();
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.time_future.as_mut().poll(cx)
+    }
+}
+
+/// Poll a future with a timeout.
+/// If the future is ready, return the output.
+/// If the future is pending, poll the sleep future.
+pub(super) fn timeout<F>(duration: Duration, future: F) -> Timeout<F>
+where
+    F: Future,
+{
+    let time_future = time_future(duration);
+    let send_safe_future = wrap_future_as_send(time_future);
+    Timeout {
+        future: Box::pin(future),
+        time_future: Box::pin(async move {
+            let _ = send_safe_future.await;
+        }),
+    }
+}
+
+/// Future returned by `timeout`.
+pub(super) struct Timeout<F: Future> {
+    future: Pin<Box<F>>,
+    time_future: Pin<Box<dyn Future<Output = ()> + Send>>,
+}
+
+impl<F: Future> Future for Timeout<F> {
+    type Output = Result<F::Output, Elapsed>;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Poll the future first.
+        // If it's ready, return the output.
+        // If it's pending, poll the sleep future.
+        match self.future.as_mut().poll(cx) {
+            Poll::Ready(output) => Poll::Ready(Ok(output)),
+            Poll::Pending => match self.time_future.as_mut().poll(cx) {
+                Poll::Ready(()) => Poll::Ready(Err(Elapsed(()))),
+                Poll::Pending => Poll::Pending,
+            },
+        }
+    }
+}
+
+/// Errors returned by `Timeout`.
+///
+/// This error is returned when a timeout expires before the function was able
+/// to finish.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Elapsed(());
+
+impl Display for Elapsed {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+        "deadline has elapsed".fmt(fmt)
+    }
+}
+
+impl Error for Elapsed {}
+
+impl From<Elapsed> for io::Error {
+    fn from(_err: Elapsed) -> io::Error {
+        io::ErrorKind::TimedOut.into()
+    }
+}
+
+/// Creates a new interval that ticks every `period` duration.
+pub(super) fn interval(period: Duration) -> Interval {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let period_ms = period.as_millis() as f64;
+    // Create a closure that sends a tick via the channel.
+    let closure = Closure::wrap(Box::new(move || {
+        let _ = tx.send(());
+    }) as Box<dyn Fn()>);
+    // Register an interval with the closure.
+    let interval_id = set_interval(closure.as_ref().unchecked_ref(), period_ms);
+    // Release memory management of this closure from Rust to the JS GC.
+    closure.forget();
+    Interval {
+        period,
+        rx,
+        interval_id,
+    }
+}
+
+/// A structure that represents an interval that ticks at a specified period.
+/// It provides methods to wait for the next tick, reset the interval,
+/// and ensure the interval is cleaned up when it is dropped.
+#[derive(Debug)]
+pub struct Interval {
+    period: Duration,
+    rx: tokio::sync::mpsc::UnboundedReceiver<()>,
+    interval_id: i32,
+}
+
+impl Interval {
+    /// Waits until the next tick.
+    pub async fn tick(&mut self) {
+        self.rx.recv().await;
+    }
+
+    /// Resets the interval, making the next tick occur
+    /// after the original period.
+    /// This clears the existing interval and establishes a new one.
+    pub fn reset(&mut self) {
+        // Clear the existing interval.
+        clear_interval(self.interval_id);
+
+        // Create a new channel to receive ticks.
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        self.rx = rx;
+        let period_ms = self.period.as_millis() as f64;
+        // Set up a new interval.
+        let closure = Closure::wrap(Box::new(move || {
+            let _ = tx.send(());
+        }) as Box<dyn Fn()>);
+        self.interval_id = set_interval(closure.as_ref().unchecked_ref(), period_ms);
+        // Release memory management of this closure from Rust to the JS GC.
+        closure.forget();
+    }
+}
+
+impl Drop for Interval {
+    fn drop(&mut self) {
+        clear_interval(self.interval_id);
+    }
+}

--- a/ractor/src/factory/tests.rs
+++ b/ractor/src/factory/tests.rs
@@ -14,4 +14,5 @@ mod lifecycle;
 mod priority_queueing;
 mod ratelim;
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+/// these tests use panic and are not supported on wasm because wasm is panic=abort
 mod worker_lifecycle;

--- a/ractor/src/factory/worker.rs
+++ b/ractor/src/factory/worker.rs
@@ -28,8 +28,6 @@ use super::WorkerId;
 use crate::concurrency::Duration;
 use crate::concurrency::Instant;
 use crate::concurrency::JoinHandle;
-#[cfg(not(feature = "async-trait"))]
-use crate::concurrency::MaybeSend;
 use crate::Actor;
 use crate::ActorCell;
 use crate::ActorId;
@@ -96,7 +94,7 @@ pub trait Worker: Send + Sync + 'static {
         wid: WorkerId,
         factory: &ActorRef<FactoryMessage<Self::Key, Self::Message>>,
         args: Self::Arguments,
-    ) -> impl Future<Output = Result<Self::State, ActorProcessingErr>> + MaybeSend;
+    ) -> impl Future<Output = Result<Self::State, ActorProcessingErr>> + Send;
 
     /// Invoked when a worker is being started by the system.
     ///
@@ -138,7 +136,7 @@ pub trait Worker: Send + Sync + 'static {
         wid: WorkerId,
         factory: &ActorRef<FactoryMessage<Self::Key, Self::Message>>,
         state: &mut Self::State,
-    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + MaybeSend {
+    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + Send {
         async { Ok(()) }
     }
     /// Invoked after an actor has started.
@@ -178,7 +176,7 @@ pub trait Worker: Send + Sync + 'static {
         wid: WorkerId,
         factory: &ActorRef<FactoryMessage<Self::Key, Self::Message>>,
         state: &mut Self::State,
-    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + MaybeSend {
+    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + Send {
         async { Ok(()) }
     }
     /// Invoked after an actor has been stopped to perform final cleanup. In the
@@ -218,7 +216,7 @@ pub trait Worker: Send + Sync + 'static {
         factory: &ActorRef<FactoryMessage<Self::Key, Self::Message>>,
         job: Job<Self::Key, Self::Message>,
         state: &mut Self::State,
-    ) -> impl Future<Output = Result<Self::Key, ActorProcessingErr>> + MaybeSend {
+    ) -> impl Future<Output = Result<Self::Key, ActorProcessingErr>> + Send {
         async { Ok(job.key) }
     }
 
@@ -257,7 +255,7 @@ pub trait Worker: Send + Sync + 'static {
         myself: ActorCell,
         message: SupervisionEvent,
         state: &mut Self::State,
-    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + MaybeSend {
+    ) -> impl Future<Output = Result<(), ActorProcessingErr>> + Send {
         async move {
             match message {
                 SupervisionEvent::ActorTerminated(who, _, _)

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -181,10 +181,6 @@ pub mod registry;
 pub mod rpc;
 #[cfg(feature = "cluster")]
 pub mod serialization;
-#[cfg(all(
-    feature = "tokio_runtime",
-    not(all(target_arch = "wasm32", target_os = "unknown"))
-))]
 pub mod thread_local;
 pub mod time;
 
@@ -267,10 +263,6 @@ pub async fn spawn<T: Actor + Default>(
 /// * `spawner` - The thread-local spawner ([thread_local::ThreadLocalActorSpawner]) used to spawn thread-local actors
 ///
 /// Returns [Ok((ActorRef, JoinHandle<()>))] upon successful actor startup, [Err(SpawnErr)] otherwise
-#[cfg(all(
-    feature = "tokio_runtime",
-    not(all(target_arch = "wasm32", target_os = "unknown"))
-))]
 pub async fn spawn_local<T: thread_local::ThreadLocalActor>(
     args: T::Arguments,
     spawner: thread_local::ThreadLocalActorSpawner,

--- a/ractor/src/macros.rs
+++ b/ractor/src/macros.rs
@@ -237,3 +237,6 @@ macro_rules! forward {
         }
     }};
 }
+
+#[cfg(test)]
+mod tests;

--- a/ractor/src/macros/tests.rs
+++ b/ractor/src/macros/tests.rs
@@ -1,0 +1,125 @@
+use crate::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+
+#[derive(Debug)]
+enum TestMessage {
+    Add(i32, i32, RpcReplyPort<i32>),
+    Echo(String, RpcReplyPort<String>),
+    #[allow(dead_code)]
+    CastOnly(i32),
+}
+
+#[cfg(feature = "cluster")]
+impl crate::Message for TestMessage {}
+
+struct TestActor;
+
+#[cfg_attr(feature = "async-trait", crate::async_trait)]
+impl Actor for TestActor {
+    type Msg = TestMessage;
+    type Arguments = ();
+    type State = ();
+
+    async fn pre_start(
+        &self,
+        _this_actor: ActorRef<Self::Msg>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(())
+    }
+
+    async fn handle(
+        &self,
+        _: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        _: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            TestMessage::Add(a, b, reply) => {
+                let _ = reply.send(a + b);
+            }
+            TestMessage::Echo(s, reply) => {
+                let _ = reply.send(s);
+            }
+            TestMessage::CastOnly(_) => {}
+        }
+        Ok(())
+    }
+}
+
+async fn spawn_test_actor() -> (
+    ActorRef<TestMessage>,
+    impl std::future::Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>>,
+) {
+    let (actor, handle) = Actor::spawn(None, TestActor, ())
+        .await
+        .expect("Actor spawn failed");
+    let wrapped_handle = async move {
+        let result = handle.await;
+
+        #[cfg(not(feature = "async-std"))]
+        {
+            result.map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+        }
+
+        #[cfg(feature = "async-std")]
+        {
+            result.map_err(|()| {
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "async task error",
+                )) as Box<dyn std::error::Error + Send + Sync>
+            })
+        }
+    };
+    (actor, wrapped_handle)
+}
+
+#[crate::concurrency::test]
+async fn test_call_macro() {
+    let (actor, handle) = spawn_test_actor().await;
+
+    let result = call!(actor, TestMessage::Add, 2, 3);
+    assert!(result.is_ok(), "call! macro failed: {:?}", result.err());
+    assert_eq!(result.unwrap(), 5);
+
+    actor.stop(None);
+    assert!(handle.await.is_ok(), "Actor handle join failed");
+}
+
+#[crate::concurrency::test]
+async fn test_call_macro_echo() {
+    let (actor, handle) = spawn_test_actor().await;
+
+    let msg = "hello".to_string();
+    let result = call!(actor, TestMessage::Echo, msg.clone());
+    assert!(result.is_ok(), "call! macro failed: {:?}", result.err());
+    assert_eq!(result.unwrap(), msg);
+
+    actor.stop(None);
+    assert!(handle.await.is_ok(), "Actor handle join failed");
+}
+
+#[crate::concurrency::test]
+async fn test_call_t_macro_success() {
+    let (actor, handle) = spawn_test_actor().await;
+
+    let result = call_t!(actor, TestMessage::Add, 100, 4, 6);
+    assert!(result.is_ok(), "call_t! macro failed: {:?}", result.err());
+    assert_eq!(result.unwrap(), 10);
+
+    actor.stop(None);
+    assert!(handle.await.is_ok(), "Actor handle join failed");
+}
+
+#[crate::concurrency::test]
+async fn test_cast_macro() {
+    let (actor, handle) = spawn_test_actor().await;
+
+    let res = cast!(actor, TestMessage::CastOnly(42));
+    assert!(res.is_ok(), "cast! macro failed: {:?}", res.err());
+
+    actor.stop(None);
+    assert!(handle.await.is_ok(), "Actor handle join failed");
+}
+
+// TODO: forward! macro is not tested here due to its complexity and need for two actors.

--- a/ractor/src/rpc.rs
+++ b/ractor/src/rpc.rs
@@ -119,11 +119,12 @@ fn internal_call<F, TMessage, TReply, TMsgBuilder>(
     sender: F,
     msg_builder: TMsgBuilder,
     timeout_option: Option<Duration>,
-) -> impl std::future::Future<Output = Result<CallResult<TReply>, MessagingErr<TMessage>>>
+) -> impl std::future::Future<Output = Result<CallResult<TReply>, MessagingErr<TMessage>>> + Send
 where
     F: Fn(TMessage) -> Result<(), MessagingErr<TMessage>>,
     TMessage: Message,
     TMsgBuilder: FnOnce(RpcReplyPort<TReply>) -> TMessage,
+    TReply: Send + 'static,
 {
     let (tx, rx) = concurrency::oneshot();
     let port: RpcReplyPort<TReply> = match timeout_option {
@@ -182,6 +183,7 @@ pub async fn call<TMessage, TReply, TMsgBuilder>(
 where
     TMessage: Message,
     TMsgBuilder: FnOnce(RpcReplyPort<TReply>) -> TMessage,
+    TReply: Send + 'static,
 {
     internal_call(|m| actor.send_message(m), msg_builder, timeout_option).await
 }
@@ -331,6 +333,7 @@ where
     ) -> Result<CallResult<TReply>, MessagingErr<TMessage>>
     where
         TMsgBuilder: FnOnce(RpcReplyPort<TReply>) -> TMessage,
+        TReply: Send + 'static,
     {
         call::<TMessage, TReply, TMsgBuilder>(&self.inner, msg_builder, timeout_option).await
     }
@@ -380,6 +383,7 @@ where
     ) -> Result<CallResult<TReply>, MessagingErr<TMessage>>
     where
         TMsgBuilder: FnOnce(RpcReplyPort<TReply>) -> TMessage,
+        TReply: Send + 'static,
     {
         internal_call(|m| self.send_message(m), msg_builder, timeout_option).await
     }

--- a/ractor/src/tests.rs
+++ b/ractor/src/tests.rs
@@ -5,8 +5,6 @@
 
 //! Basic tests of errors, error conversions, etc
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-use getrandom as _;
 // It was used by examples
 use ractor_example_entry_proc as _;
 
@@ -16,6 +14,14 @@ use crate::ActorCell;
 use crate::ActorProcessingErr;
 use crate::ActorRef;
 use crate::RactorErr;
+
+// getrandom is an indirect dependency.
+// We reference it in cargo.toml in order to add the feature 'js',
+//   which is required for the `wasm32-unknown-unknown` target.
+// Without the following line, it would show an error:
+//   "warning: extern crate `getrandom` is unused in crate `ractor`"
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use getrandom as _;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);

--- a/ractor/src/thread_local/inner.rs
+++ b/ractor/src/thread_local/inner.rs
@@ -268,7 +268,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
                 }
 
                 // run the processing loop, backgrounding the work
-                let handle = tokio::task::spawn_local(async move {
+                let handle = crate::concurrency::spawn_local(async move {
                     let myself = actor_ref.clone();
                     let evt = match Self::processing_loop(
                         ports, &mut state, &handler, actor_ref, id, name,

--- a/ractor/src/thread_local/supervision_tests.rs
+++ b/ractor/src/thread_local/supervision_tests.rs
@@ -28,7 +28,10 @@ fn get_spawner() -> ThreadLocalActorSpawner {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 async fn test_thread_local_child() {
     use crate::thread_local::ThreadLocalActor;
@@ -122,7 +125,10 @@ async fn test_thread_local_child() {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 async fn test_thread_local_supervisor() {
     struct Child;
     #[derive(Default)]
@@ -207,7 +213,11 @@ async fn test_thread_local_supervisor() {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 async fn test_thread_local_child_panic_handle() {
     #[derive(Default)]
     struct Child;

--- a/ractor/src/thread_local/tests.rs
+++ b/ractor/src/thread_local/tests.rs
@@ -39,7 +39,10 @@ struct EmptyMessage;
 impl crate::Message for EmptyMessage {}
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 async fn test_panic_on_start_captured() {
     #[derive(Default)]
@@ -64,7 +67,10 @@ async fn test_panic_on_start_captured() {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 async fn test_error_on_start_captured() {
     #[derive(Default)]
     struct TestActor;
@@ -88,7 +94,10 @@ async fn test_error_on_start_captured() {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 async fn test_stop_higher_priority_over_messages() {
     let message_counter = Arc::new(AtomicU8::new(0u8));
 
@@ -159,7 +168,10 @@ async fn test_stop_higher_priority_over_messages() {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 async fn test_kill_terminates_work() {
     #[derive(Default)]
     struct TestActor;
@@ -205,7 +217,10 @@ async fn test_kill_terminates_work() {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 async fn test_stop_does_not_terminate_async_work() {
     #[derive(Default)]
     struct TestActor;
@@ -260,7 +275,10 @@ async fn test_stop_does_not_terminate_async_work() {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 async fn test_kill_terminates_supervision_work() {
     #[derive(Default)]
     struct TestActor;
@@ -308,7 +326,10 @@ async fn test_kill_terminates_supervision_work() {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 async fn test_sending_message_to_invalid_actor_type() {
     #[derive(Default)]
     struct TestActor1;
@@ -368,7 +389,10 @@ async fn test_sending_message_to_invalid_actor_type() {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 async fn test_sending_message_to_dead_actor() {
     #[derive(Default)]
     struct TestActor;
@@ -403,7 +427,10 @@ async fn test_sending_message_to_dead_actor() {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 async fn stop_and_wait() {
     #[derive(Default)]
     struct SlowActor;
@@ -433,7 +460,10 @@ async fn stop_and_wait() {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 async fn kill_and_wait() {
     #[derive(Default)]
     struct SlowActor;
@@ -464,7 +494,10 @@ async fn kill_and_wait() {
 
 /// https://github.com/slawlor/ractor/issues/254
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 async fn actor_post_stop_executed_before_stop_and_wait_returns() {
     #[derive(Default)]
     struct TestActor;
@@ -509,7 +542,10 @@ async fn actor_post_stop_executed_before_stop_and_wait_returns() {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 async fn actor_drain_messages() {
     #[derive(Default)]
     struct TestActor;
@@ -564,7 +600,10 @@ async fn actor_drain_messages() {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 async fn wait_for_death() {
     #[derive(Default)]
     struct TestActor;
@@ -605,7 +644,10 @@ async fn wait_for_death() {
 }
 
 #[crate::concurrency::test]
-#[tracing_test::traced_test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
 async fn derived_actor_ref() {
     let result_counter = Arc::new(AtomicU32::new(0));
 


### PR DESCRIPTION
I wanted to open this PR mainly to push additional fuel into the flames of the discussion in https://github.com/slawlor/ractor/issues/361.

Specifically, I believe this makes the whole MaybeSync machinery obsolete so that it will be easier to share code between WASM and non-WASM.


----------

I have changed the wasm tests to run twice - once without, and once with the feature ``async-trait``. This ensures that both configurations are valid in WASM.

I have added a unit test that demonstrates something that failed before, that is, invoking ``call!`` from inside an actor (see https://github.com/slawlor/ractor/issues/361#issuecomment-2974987143).

First I added the unit test, which failed in my CI (https://github.com/0x53A/ractor/actions/runs/15676933563/job/44159323493) with ``error: future cannot be sent between threads safely``.

Then I applied the changes, which made ``timeout`` Send, which fixed the failing test (https://github.com/0x53A/ractor/actions/runs/15679737485).

-----------

The implementation inside ``tokio_with_wasm_primitives.rs`` is way too complex - I just copy-pasted a bunch of code to make it work. I'll clean that up.

----

Next step would be to also reenable other code that's currently disabled for wasm and align it with non-wasm, for example the ``thread_local`` module with ``ThreadLocalActor``, I see no reason why this shouldn't be able to run on WASM.