### PR TITLE
fix(cluster): correct authenticated callback spelling

### DIFF
--- a/ractor_cluster/src/node.rs
+++ b/ractor_cluster/src/node.rs
@@ -336,7 +336,7 @@ pub trait NodeEventSubscription: Send + 'static {
     ///
     /// * `ses`: The [NodeServerSessionInformation] representing the current state
     ///   of the node session
-    fn node_session_authenicated(&self, ses: NodeServerSessionInformation);
+    fn node_session_authenticated(&self, ses: NodeServerSessionInformation);
 
     /// A node session is ready
     ///
@@ -726,7 +726,7 @@ impl Actor for NodeServer {
                     }
                     let entry = &state.node_sessions[&actor_id];
                     for sub in state.subscriptions.values() {
-                        sub.node_session_authenicated(entry.clone());
+                        sub.node_session_authenticated(entry.clone());
                     }
                 }
             }
@@ -1025,7 +1025,7 @@ mod tests {
             ));
         }
 
-        fn node_session_authenicated(&self, _session: NodeServerSessionInformation) {}
+        fn node_session_authenticated(&self, _session: NodeServerSessionInformation) {}
 
         fn node_session_ready(&self, session: NodeServerSessionInformation) {
             let _ = self

--- a/ractor_cluster_integration_tests/src/tests/auth_handshake.rs
+++ b/ractor_cluster_integration_tests/src/tests/auth_handshake.rs
@@ -29,7 +29,7 @@ pub struct AuthHandshakeConfig {
 struct SubscriptionEventLogger;
 
 impl ractor_cluster::NodeEventSubscription for SubscriptionEventLogger {
-    fn node_session_authenicated(&self, ses: ractor_cluster::node::NodeServerSessionInformation) {
+    fn node_session_authenticated(&self, ses: ractor_cluster::node::NodeServerSessionInformation) {
         tracing::warn!(
             "[SubscriptionEventLogger] Node {} ({}) authenticated",
             ses.node_id,


### PR DESCRIPTION
## Summary

- rename `NodeEventSubscription::node_session_authenicated` to `node_session_authenticated`
- update `NodeServer` dispatch and all in-tree implementations
- preserve the original contributor authorship while refreshing this PR onto Ractor 0.16

## Breaking change

Downstream `NodeEventSubscription` implementations must rename this required method. There is no runtime, protocol, or wire-format change.

## Validation

- `cargo test -p ractor_cluster`
- `cargo test -p ractor_cluster -F async-trait`
- `cargo test -p ractor_cluster_integration_tests`
- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`

Closes #348