### PR TITLE
messages sent to actor are not boxed anymore

### DIFF
--- a/ractor/src/actor.rs
+++ b/ractor/src/actor.rs
@@ -966,7 +966,7 @@ where
             // to the remote system for decoding + handling by the real implementation. Therefore `RemoteActor`s
             // can be thought of as a "shim" to a real actor on a remote system
             if !myself.get_id().is_local() {
-                match msg.serialized_msg {
+                match msg.msg.into_serialized() {
                     Some(serialized_msg) => {
                         return handler
                             .handle_serialized(myself, serialized_msg, state)

--- a/ractor/src/actor.rs
+++ b/ractor/src/actor.rs
@@ -698,7 +698,10 @@ where
     /// * `handler` The [Actor] defining the logic for this actor
     ///
     /// Returns A tuple [(Actor, ActorPortSet)] to be passed to the `start` function of [Actor]
-    fn new(name: Option<ActorName>, handler: TActor) -> Result<(Self, ActorPortSet), SpawnErr> {
+    fn new(
+        name: Option<ActorName>,
+        handler: TActor,
+    ) -> Result<(Self, ActorPortSet<TActor::Msg>), SpawnErr> {
         let (actor_cell, ports) = actor_cell::ActorCell::new::<TActor>(name)?;
         let id = actor_cell.get_id();
         let name = actor_cell.get_name();
@@ -728,7 +731,7 @@ where
     #[tracing::instrument(name = "Actor", skip(self, ports, startup_args, supervisor), fields(id = self.id.to_string(), name = self.name))]
     async fn start(
         self,
-        ports: ActorPortSet,
+        ports: ActorPortSet<TActor::Msg>,
         startup_args: TActor::Arguments,
         supervisor: Option<ActorCell>,
     ) -> Result<(ActorRef<TActor::Msg>, JoinHandle<()>), SpawnErr> {
@@ -800,7 +803,7 @@ where
 
     #[tracing::instrument(name = "Actor", skip(ports, state, handler, myself, _id, _name), fields(id = _id.to_string(), name = _name))]
     async fn processing_loop(
-        mut ports: ActorPortSet,
+        mut ports: ActorPortSet<TActor::Msg>,
         state: &mut TActor::State,
         handler: &TActor,
         myself: ActorRef<TActor::Msg>,
@@ -869,7 +872,7 @@ where
         myself: ActorRef<TActor::Msg>,
         state: &mut TActor::State,
         handler: &TActor,
-        ports: &mut ActorPortSet,
+        ports: &mut ActorPortSet<TActor::Msg>,
     ) -> Result<ActorLoopResult, ActorProcessingErr> {
         match ports.listen_in_priority().await {
             Ok(actor_port_message) => match actor_port_message {
@@ -954,7 +957,7 @@ where
         myself: ActorRef<TActor::Msg>,
         state: &mut TActor::State,
         handler: &TActor,
-        mut msg: crate::message::BoxedMessage,
+        mut msg: crate::message::BoxedMessage<TActor::Msg>,
     ) -> Result<(), ActorProcessingErr> {
         // panic in order to kill the actor
         #[cfg(feature = "cluster")]

--- a/ractor/src/actor/actor_properties.rs
+++ b/ractor/src/actor/actor_properties.rs
@@ -57,12 +57,11 @@ impl<T: Any + Send> GenericInputPort for InputPort<MuxedMessage<T>> {
             msg: LocalOrSerialized::Serialized(message),
             span: None,
         };
-        Ok(self
-            .send(MuxedMessage::Message(boxed))
+        self.send(MuxedMessage::Message(boxed))
             .map_err(|e| match e.0 {
                 MuxedMessage::Message(m) => MessagingErr::SendErr(m.msg.into_serialized().unwrap()),
                 _ => panic!("Expected a boxed message but got a drain message"),
-            })?)
+            })
     }
 }
 
@@ -83,6 +82,7 @@ pub(crate) struct ActorProperties {
 }
 
 impl ActorProperties {
+    #[allow(clippy::type_complexity)]
     pub(crate) fn new<TActor: Actor>(
         name: Option<ActorName>,
     ) -> (
@@ -91,13 +91,11 @@ impl ActorProperties {
         OneshotReceiver<StopMessage>,
         InputPortReceiver<SupervisionEvent>,
         InputPortReceiver<MuxedMessage<TActor::Msg>>,
-    )
-    where
-        TActor: Actor,
-    {
+    ) {
         Self::new_remote::<TActor>(name, crate::actor::actor_id::get_new_local_id())
     }
 
+    #[allow(clippy::type_complexity)]
     pub(crate) fn new_remote<TActor: Actor>(
         name: Option<ActorName>,
         id: ActorId,
@@ -107,10 +105,7 @@ impl ActorProperties {
         OneshotReceiver<StopMessage>,
         InputPortReceiver<SupervisionEvent>,
         InputPortReceiver<MuxedMessage<TActor::Msg>>,
-    )
-    where
-        TActor: Actor,
-    {
+    ) {
         let (tx_signal, rx_signal) = mpsc::oneshot();
         let (tx_stop, rx_stop) = mpsc::oneshot();
         let (tx_supervision, rx_supervision) = mpsc::mpsc_unbounded();

--- a/ractor/src/actor/actor_properties.rs
+++ b/ractor/src/actor/actor_properties.rs
@@ -203,13 +203,13 @@ impl ActorProperties {
                 MessagingErr::ChannelClosed => MessagingErr::ChannelClosed,
                 MessagingErr::InvalidActorType => MessagingErr::InvalidActorType,
             }),
-            boxed => {
+            local => {
                 let sender: &InputPort<MuxedMessage<TMessage>> = {
                     let ptr: &dyn Any = &*self.message;
                     ptr.downcast_ref().ok_or(MessagingErr::InvalidActorType)?
                 };
                 sender
-                    .send(MuxedMessage::Message(boxed))
+                    .send(MuxedMessage::Message(local))
                     .map_err(|e| match e.0 {
                         MuxedMessage::Message(m) => {
                             MessagingErr::SendErr(TMessage::from_boxed(m).unwrap())

--- a/ractor/src/actor/actor_properties.rs
+++ b/ractor/src/actor/actor_properties.rs
@@ -187,17 +187,10 @@ impl ActorProperties {
             BoxedMessage {
                 span: _,
                 msg: LocalOrSerialized::Serialized(m),
-            } => self.message.send_serialized(m).map_err(|e| match e {
-                MessagingErr::SendErr(m) => MessagingErr::SendErr(
-                    TMessage::from_boxed(BoxedMessage {
-                        span: None,
-                        msg: LocalOrSerialized::Serialized(m),
-                    })
-                    .unwrap(),
-                ),
-                MessagingErr::ChannelClosed => MessagingErr::ChannelClosed,
-                MessagingErr::InvalidActorType => MessagingErr::InvalidActorType,
-            }),
+            } => self
+                .message
+                .send_serialized(m)
+                .map_err(convert_messaging_error),
             local => {
                 let sender: &InputPort<MuxedMessage<TMessage>> = {
                     let ptr: &dyn Any = &*self.message;
@@ -205,12 +198,7 @@ impl ActorProperties {
                 };
                 sender
                     .send(MuxedMessage::Message(local))
-                    .map_err(|e| match e.0 {
-                        MuxedMessage::Message(m) => {
-                            MessagingErr::SendErr(TMessage::from_boxed(m).unwrap())
-                        }
-                        _ => panic!("Expected a boxed message but got a drain message"),
-                    })
+                    .map_err(|e| convert_muxed_message_to_messaging_error(e.0))
             }
         }
     }
@@ -293,5 +281,116 @@ impl ActorProperties {
         // a notify permit (i.e. the actor stops, but you are only start waiting
         // after the actor has already notified it's dead.)
         self.wait_handler.notify_one();
+    }
+}
+
+#[cfg(feature = "cluster")]
+/// # Panic
+/// Panic if the `TMessage` cannot be deserialized from
+/// the serialized message passed as argument
+fn convert_messaging_error<TMessage: Message>(
+    e: MessagingErr<SerializedMessage>,
+) -> MessagingErr<TMessage> {
+    match e {
+        MessagingErr::SendErr(m) => MessagingErr::SendErr(
+            TMessage::from_boxed(BoxedMessage {
+                span: None,
+                msg: LocalOrSerialized::Serialized(m),
+            })
+            .unwrap(),
+        ),
+        MessagingErr::ChannelClosed => MessagingErr::ChannelClosed,
+        MessagingErr::InvalidActorType => MessagingErr::InvalidActorType,
+    }
+}
+/// # Panic
+/// Panic if the MuxedMessage is not MuxedMessage::Message
+fn convert_muxed_message_to_messaging_error<TMessage: Message>(
+    e: MuxedMessage<TMessage>,
+) -> MessagingErr<TMessage> {
+    match e {
+        MuxedMessage::Message(m) => MessagingErr::SendErr(TMessage::from_boxed(m).unwrap()),
+        _ => panic!("Expected a boxed message but got a drain message"),
+    }
+}
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "cluster")]
+    #[test]
+    fn test_convert_messaging_error() {
+        use crate::{
+            actor::actor_properties::convert_messaging_error,
+            message::{BoxedDowncastErr, SerializedMessage},
+            ActorId, Message, MessagingErr,
+        };
+
+        struct TestRemoteMessage;
+        // a serializable basic no-op message
+        impl Message for TestRemoteMessage {
+            fn serializable() -> bool {
+                true
+            }
+            fn deserialize(_bytes: SerializedMessage) -> Result<Self, BoxedDowncastErr> {
+                Ok(TestRemoteMessage)
+            }
+            fn serialize(self) -> Result<SerializedMessage, BoxedDowncastErr> {
+                Ok(crate::message::SerializedMessage::Cast {
+                    args: vec![],
+                    variant: "Cast".to_string(),
+                    metadata: None,
+                })
+            }
+        }
+        let id = ActorId::Remote { node_id: 1, pid: 1 };
+        let boxed = TestRemoteMessage.box_message(&id).unwrap();
+        assert!(matches!(
+            convert_messaging_error(MessagingErr::SendErr(boxed.msg.into_serialized().unwrap())),
+            MessagingErr::SendErr(TestRemoteMessage)
+        ));
+        assert!(matches!(
+            convert_messaging_error::<TestRemoteMessage>(
+                MessagingErr::<SerializedMessage>::ChannelClosed
+            ),
+            MessagingErr::<TestRemoteMessage>::ChannelClosed
+        ));
+        assert!(matches!(
+            convert_messaging_error::<TestRemoteMessage>(
+                MessagingErr::<SerializedMessage>::InvalidActorType
+            ),
+            MessagingErr::<TestRemoteMessage>::InvalidActorType
+        ));
+    }
+    #[test]
+    fn test_muxed_message_to_messaging_error() {
+        use crate::Message;
+        use crate::{
+            actor::actor_properties::{convert_muxed_message_to_messaging_error, MuxedMessage},
+            ActorId, MessagingErr,
+        };
+
+        struct TestRemoteMessage;
+        #[cfg(feature = "cluster")]
+        impl Message for TestRemoteMessage {}
+        let id = ActorId::Local(1);
+        let boxed = TestRemoteMessage.box_message(&id).unwrap();
+
+        assert!(matches!(
+            convert_muxed_message_to_messaging_error(MuxedMessage::Message(boxed)),
+            MessagingErr::SendErr(TestRemoteMessage)
+        ));
+    }
+    #[test]
+    #[should_panic]
+    fn test_muxed_message_to_messaging_error_panic() {
+        use crate::actor::actor_properties::{
+            convert_muxed_message_to_messaging_error, MuxedMessage,
+        };
+        #[cfg(feature = "cluster")]
+        use crate::Message;
+
+        struct TestRemoteMessage;
+        #[cfg(feature = "cluster")]
+        impl Message for TestRemoteMessage {}
+        convert_muxed_message_to_messaging_error(MuxedMessage::<TestRemoteMessage>::Drain);
     }
 }

--- a/ractor/src/actor/tests.rs
+++ b/ractor/src/actor/tests.rs
@@ -212,6 +212,9 @@ async fn test_kill_terminates_work() {
     crate::concurrency::sleep(Duration::from_millis(10)).await;
 
     assert_eq!(ActorStatus::Stopped, actor.get_status());
+
+    assert!(actor.send_message(EmptyMessage).is_err());
+
     assert!(handle.is_finished());
 }
 
@@ -508,6 +511,9 @@ async fn test_serialized_cast() {
     // cleanup
     actor.stop(None);
     handle.await.unwrap();
+
+    let serialized = (TestMessage).serialize().unwrap();
+    assert!(actor.send_serialized(serialized).is_err());
 }
 
 #[cfg(feature = "cluster")]

--- a/ractor/src/message.rs
+++ b/ractor/src/message.rs
@@ -70,7 +70,8 @@ pub(crate) enum LocalOrSerialized<T: Any + Send> {
     Serialized(SerializedMessage),
 }
 impl<T: Any + Send> LocalOrSerialized<T> {
-    pub fn into_local(self) -> Option<T> {
+    #[cfg(not(feature = "cluster"))]
+    pub(crate) fn into_local(self) -> Option<T> {
         match self {
             LocalOrSerialized::Local(msg) => Some(msg),
             #[cfg(feature = "cluster")]
@@ -78,18 +79,11 @@ impl<T: Any + Send> LocalOrSerialized<T> {
         }
     }
     #[cfg(feature = "cluster")]
-    pub fn into_serialized(self) -> Option<SerializedMessage> {
+    pub(crate) fn into_serialized(self) -> Option<SerializedMessage> {
         match self {
             LocalOrSerialized::Local(_) => None,
             LocalOrSerialized::Serialized(msg) => Some(msg),
         }
-    }
-    pub fn is_local(&self) -> bool {
-        matches!(self, LocalOrSerialized::Local(_))
-    }
-    #[cfg(feature = "cluster")]
-    pub fn is_serialized(&self) -> bool {
-        matches!(self, LocalOrSerialized::Serialized(_))
     }
 }
 

--- a/ractor/src/tests.rs
+++ b/ractor/src/tests.rs
@@ -83,8 +83,8 @@ async fn test_error_message_extraction() {
     let bad_message_actor: ActorRef<u32> = cell.into();
 
     let err = crate::cast!(bad_message_actor, 0u32).expect_err("Not an error!");
-    assert!(!err.has_message());
-    assert!(err.try_get_message().is_none());
+    assert!(err.has_message()); //actor status is checked before message type_id;
+    assert!(err.try_get_message().is_some());
 }
 
 #[crate::concurrency::test]

--- a/ractor/src/thread_local/inner.rs
+++ b/ractor/src/thread_local/inner.rs
@@ -78,6 +78,7 @@ impl ActorCell {
 }
 
 impl ActorProperties {
+    #[allow(clippy::type_complexity)]
     pub(crate) fn new_thread_local<TActor>(
         name: Option<ActorName>,
     ) -> (

--- a/ractor/src/thread_local/inner.rs
+++ b/ractor/src/thread_local/inner.rs
@@ -483,7 +483,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
             // to the remote system for decoding + handling by the real implementation. Therefore `RemoteActor`s
             // can be thought of as a "shim" to a real actor on a remote system
             if !myself.get_id().is_local() {
-                match msg.serialized_msg {
+                match msg.msg.into_serialized() {
                     Some(serialized_msg) => {
                         return handler
                             .handle_serialized(myself, serialized_msg, state)

--- a/ractor/src/thread_local/inner.rs
+++ b/ractor/src/thread_local/inner.rs
@@ -43,7 +43,7 @@ use crate::SupervisionEvent;
 impl ActorCell {
     pub(crate) fn new_thread_local<TActor>(
         name: Option<ActorName>,
-    ) -> Result<(Self, ActorPortSet), SpawnErr>
+    ) -> Result<(Self, ActorPortSet<TActor::Msg>), SpawnErr>
     where
         TActor: crate::thread_local::ThreadLocalActor,
     {
@@ -85,7 +85,7 @@ impl ActorProperties {
         OneshotReceiver<Signal>,
         OneshotReceiver<StopMessage>,
         mpsc::MpscUnboundedReceiver<SupervisionEvent>,
-        mpsc::MpscUnboundedReceiver<MuxedMessage>,
+        mpsc::MpscUnboundedReceiver<MuxedMessage<TActor::Msg>>,
     )
     where
         TActor: crate::thread_local::ThreadLocalActor,
@@ -104,7 +104,7 @@ impl ActorProperties {
                 wait_handler: mpsc::Notify::new(),
                 stop: Mutex::new(Some(tx_stop)),
                 supervision: tx_supervision,
-                message: tx_message,
+                message: Box::new(tx_message),
                 tree: Default::default(),
                 type_id: std::any::TypeId::of::<TActor::Msg>(),
                 #[cfg(feature = "cluster")]
@@ -147,7 +147,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
     /// Returns A tuple [(Actor, ActorPortSet)] to be passed to the `start` function of [Actor]
     fn new(
         name: Option<crate::ActorName>,
-    ) -> Result<(Self, crate::actor::actor_cell::ActorPortSet), crate::SpawnErr> {
+    ) -> Result<(Self, crate::actor::actor_cell::ActorPortSet<TActor::Msg>), crate::SpawnErr> {
         let (actor_cell, ports) =
             crate::actor::actor_cell::ActorCell::new_thread_local::<TActor>(name)?;
         let id = actor_cell.get_id();
@@ -231,7 +231,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
     #[tracing::instrument(name = "Actor", skip(self, ports, startup_args, supervisor), fields(id = self.id.to_string(), name = self.name))]
     async fn start(
         self,
-        ports: ActorPortSet,
+        ports: ActorPortSet<TActor::Msg>,
         startup_args: TActor::Arguments,
         spawner: ThreadLocalActorSpawner,
         supervisor: Option<ActorCell>,
@@ -320,7 +320,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
 
     #[tracing::instrument(name = "Actor", skip(ports, state, handler, myself, _id, _name), fields(id = _id.to_string(), name = _name))]
     async fn processing_loop(
-        mut ports: ActorPortSet,
+        mut ports: ActorPortSet<TActor::Msg>,
         state: &mut TActor::State,
         handler: &TActor,
         myself: ActorRef<TActor::Msg>,
@@ -389,7 +389,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
         myself: ActorRef<TActor::Msg>,
         state: &mut TActor::State,
         handler: &TActor,
-        ports: &mut ActorPortSet,
+        ports: &mut ActorPortSet<TActor::Msg>,
     ) -> Result<ActorLoopResult, ActorProcessingErr> {
         match ports.listen_in_priority().await {
             Ok(actor_port_message) => match actor_port_message {
@@ -474,7 +474,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
         myself: ActorRef<TActor::Msg>,
         state: &mut TActor::State,
         handler: &TActor,
-        mut msg: crate::message::BoxedMessage,
+        mut msg: crate::message::BoxedMessage<TActor::Msg>,
     ) -> Result<(), ActorProcessingErr> {
         // panic in order to kill the actor
         #[cfg(feature = "cluster")]

--- a/ractor_cluster_integration_tests/src/tests/encryption.rs
+++ b/ractor_cluster_integration_tests/src/tests/encryption.rs
@@ -40,12 +40,12 @@ pub struct EncryptionConfig {
     client_host: Option<String>,
 }
 
-#[allow(elided_named_lifetimes)]
+#[allow(mismatched_lifetime_syntaxes)]
 fn load_certs(path_str: &'static str) -> Result<Vec<CertificateDer>, ActorProcessingErr> {
     Ok(CertificateDer::pem_file_iter(path_str)?.collect::<Result<Vec<_>, _>>()?)
 }
 
-#[allow(elided_named_lifetimes)]
+#[allow(mismatched_lifetime_syntaxes)]
 fn load_key(path_str: &'static str) -> Result<PrivateKeyDer, ActorProcessingErr> {
     Ok(PrivateKeyDer::from_pem_file(path_str)?)
 }


### PR DESCRIPTION
While navigating inside the code I realized that every message sent to local actor are boxed.

So I made a set of simple changes so that message sent to actor are directly sent to the mpsc channel without being boxed.  This avoid one allocation per message.

The benchmarks show improvements. Moreover I think a more realistic benchmark would show much more improvement as avoiding the allocation should enhance cache locality during real code execution.

In this pull request I have used unsafe code, as it avoid to do a redundant type_id check, but it can implemented with 100% with safe code, at the cost of a call to Any::downcast_ref at each message sent.