### PR TITLE
Remove message boxing for performance improvement

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run benchmarks on main
-        run: CI=1 cargo bench -p ractor
+        run: cargo bench -p ractor
         env:
           CI: 1
 
@@ -32,7 +32,7 @@ jobs:
         run: cargo install critcmp --locked
 
       - name: Export main baseline
-        run: critcmp --export new > main.json
+        run: critcmp --export new | jq '.name = "main" | .benchmarks[].baseline = "main" | .benchmarks[].fullname |= sub("^new/"; "main/")' > main.json
 
       - name: Upload main baseline
         uses: actions/upload-artifact@v7

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -116,3 +116,9 @@ required-features = []
 name = "factory"
 harness = false
 required-features = []
+
+## Enable only for specific usage, very heavy in CI
+# [[bench]]
+# name = "output_ports"
+# harness = false
+# required-features = []

--- a/ractor/benches/actor.rs
+++ b/ractor/benches/actor.rs
@@ -13,17 +13,17 @@ use ractor::ActorProcessingErr;
 use ractor::ActorRef;
 #[cfg(feature = "cluster")]
 use ractor::Message;
-// use ractor::OutputPort;
 
+struct SpawnActor;
 struct BenchActor;
 
-struct BenchActorMessage;
+struct BenchMessage;
 #[cfg(feature = "cluster")]
-impl Message for BenchActorMessage {}
+impl Message for BenchMessage {}
 
 #[cfg_attr(feature = "async-trait", ractor::async_trait)]
-impl Actor for BenchActor {
-    type Msg = BenchActorMessage;
+impl Actor for SpawnActor {
+    type Msg = BenchMessage;
 
     type State = ();
 
@@ -34,7 +34,7 @@ impl Actor for BenchActor {
         myself: ActorRef<Self::Msg>,
         _: (),
     ) -> Result<Self::State, ActorProcessingErr> {
-        let _ = myself.cast(BenchActorMessage);
+        let _ = myself.cast(BenchMessage);
         Ok(())
     }
 
@@ -49,206 +49,146 @@ impl Actor for BenchActor {
     }
 }
 
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+impl Actor for BenchActor {
+    type Msg = BenchMessage;
+
+    type State = ();
+
+    type Arguments = ();
+
+    async fn pre_start(
+        &self,
+        _: ActorRef<Self::Msg>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(())
+    }
+
+    async fn handle(
+        &self,
+        _: ActorRef<Self::Msg>,
+        _message: Self::Msg,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+}
+
 fn create_actors(c: &mut Criterion) {
-    let small = 100;
+    #[cfg(not(feature = "async-std"))]
+    let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
+    #[cfg(feature = "async-std")]
+    {
+        async_std::task::block_on(async {})
+    }
     let large = if std::env::var("CI").is_ok() {
-        1_000
+        1_000usize
     } else {
         10_000
     };
-
-    let id = format!("Creation of {small} actors");
-    #[cfg(not(feature = "async-std"))]
-    let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
-    #[cfg(feature = "async-std")]
-    async_std::task::block_on(async {});
-    c.bench_function(&id, move |b| {
-        b.iter_batched(
-            || {},
-            |()| {
-                #[cfg(not(feature = "async-std"))]
-                {
-                    runtime.block_on(async move {
-                        let mut handles = vec![];
-                        for _ in 0..small {
-                            let (_, handler) = Actor::spawn(None, BenchActor, ())
-                                .await
-                                .expect("Failed to create test agent");
-                            handles.push(handler);
-                        }
-                        handles
-                    })
-                }
-                #[cfg(feature = "async-std")]
-                {
-                    async_std::task::block_on(async move {
-                        let mut handles = vec![];
-                        for _ in 0..small {
-                            let (_, handler) = Actor::spawn(None, BenchActor, ())
-                                .await
-                                .expect("Failed to create test agent");
-                            handles.push(handler);
-                        }
-                        handles
-                    })
-                }
-            },
-            BatchSize::PerIteration,
-        );
-    });
-
-    let id = format!("Creation of {large} actors");
-    #[cfg(not(feature = "async-std"))]
-    let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
-    #[cfg(feature = "async-std")]
-    async_std::task::block_on(async {});
-    c.bench_function(&id, move |b| {
-        b.iter_batched(
-            || {},
-            |()| {
-                #[cfg(not(feature = "async-std"))]
-                {
-                    runtime.block_on(async move {
-                        let mut handles = vec![];
-                        for _ in 0..large {
-                            let (_, handler) = Actor::spawn(None, BenchActor, ())
-                                .await
-                                .expect("Failed to create test agent");
-                            handles.push(handler);
-                        }
-                        handles
-                    })
-                }
-                #[cfg(feature = "async-std")]
-                {
-                    async_std::task::block_on(async move {
-                        let mut handles = vec![];
-                        for _ in 0..large {
-                            let (_, handler) = Actor::spawn(None, BenchActor, ())
-                                .await
-                                .expect("Failed to create test agent");
-                            handles.push(handler);
-                        }
-                        handles
-                    })
-                }
-            },
-            BatchSize::PerIteration,
-        );
-    });
+    for size in [100, large] {
+        let id = format!("Creation of {size} actors");
+        c.bench_function(&id, |b| {
+            b.iter_batched(
+                || {},
+                |()| {
+                    #[cfg(not(feature = "async-std"))]
+                    {
+                        runtime.block_on(async move {
+                            let mut handles = vec![];
+                            for _ in 0..size {
+                                let (_, handler) = Actor::spawn(None, SpawnActor, ())
+                                    .await
+                                    .expect("Failed to create test agent");
+                                handles.push(handler);
+                            }
+                            handles
+                        })
+                    }
+                    #[cfg(feature = "async-std")]
+                    {
+                        async_std::task::block_on(async move {
+                            let mut handles = vec![];
+                            for _ in 0..size {
+                                let (_, handler) = Actor::spawn(None, SpawnActor, ())
+                                    .await
+                                    .expect("Failed to create test agent");
+                                handles.push(handler);
+                            }
+                            handles
+                        })
+                    }
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
 }
 
 fn schedule_work(c: &mut Criterion) {
-    let small = 100;
+    #[cfg(not(feature = "async-std"))]
+    let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
+    #[cfg(feature = "async-std")]
+    {
+        async_std::task::block_on(async {})
+    }
     let large = if std::env::var("CI").is_ok() {
-        500
+        500usize
     } else {
-        1000
+        1_000
     };
+    for size in [100, large] {
+        let id = format!("Waiting on {size} actors to process first message");
+        c.bench_function(&id, |b| {
+            b.iter_batched(
+                || {
+                    #[cfg(not(feature = "async-std"))]
+                    {
+                        runtime.block_on(async move {
+                            let mut join_set = ractor::concurrency::JoinSet::new();
 
-    let id = format!("Waiting on {small} actors to process first message");
-    #[cfg(not(feature = "async-std"))]
-    let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
-    #[cfg(feature = "async-std")]
-    async_std::task::block_on(async {});
-    c.bench_function(&id, move |b| {
-        b.iter_batched(
-            || {
-                #[cfg(not(feature = "async-std"))]
-                {
-                    runtime.block_on(async move {
-                        let mut join_set = ractor::concurrency::JoinSet::new();
+                            for _ in 0..size {
+                                let (_, handler) = Actor::spawn(None, SpawnActor, ())
+                                    .await
+                                    .expect("Failed to create test agent");
+                                join_set.spawn(handler);
+                            }
+                            join_set
+                        })
+                    }
+                    #[cfg(feature = "async-std")]
+                    {
+                        async_std::task::block_on(async move {
+                            let mut join_set = ractor::concurrency::JoinSet::new();
 
-                        for _ in 0..small {
-                            let (_, handler) = Actor::spawn(None, BenchActor, ())
-                                .await
-                                .expect("Failed to create test agent");
-                            join_set.spawn(handler);
-                        }
-                        join_set
-                    })
-                }
-                #[cfg(feature = "async-std")]
-                {
-                    async_std::task::block_on(async move {
-                        let mut join_set = ractor::concurrency::JoinSet::new();
-
-                        for _ in 0..small {
-                            let (_, handler) = Actor::spawn(None, BenchActor, ())
-                                .await
-                                .expect("Failed to create test agent");
-                            join_set.spawn(handler);
-                        }
-                        join_set
-                    })
-                }
-            },
-            |mut handles| {
-                #[cfg(not(feature = "async-std"))]
-                {
-                    runtime.block_on(async move { while handles.join_next().await.is_some() {} })
-                }
-                #[cfg(feature = "async-std")]
-                {
-                    async_std::task::block_on(async move {
-                        while handles.join_next().await.is_some() {}
-                    })
-                }
-            },
-            BatchSize::PerIteration,
-        );
-    });
-
-    let id = format!("Waiting on {large} actors to process first message");
-    #[cfg(not(feature = "async-std"))]
-    let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
-    #[cfg(feature = "async-std")]
-    async_std::task::block_on(async {});
-    c.bench_function(&id, move |b| {
-        b.iter_batched(
-            || {
-                #[cfg(not(feature = "async-std"))]
-                {
-                    runtime.block_on(async move {
-                        let mut join_set = ractor::concurrency::JoinSet::new();
-                        for _ in 0..large {
-                            let (_, handler) = Actor::spawn(None, BenchActor, ())
-                                .await
-                                .expect("Failed to create test agent");
-                            join_set.spawn(handler);
-                        }
-                        join_set
-                    })
-                }
-                #[cfg(feature = "async-std")]
-                {
-                    async_std::task::block_on(async move {
-                        let mut join_set = ractor::concurrency::JoinSet::new();
-                        for _ in 0..large {
-                            let (_, handler) = Actor::spawn(None, BenchActor, ())
-                                .await
-                                .expect("Failed to create test agent");
-                            join_set.spawn(handler);
-                        }
-                        join_set
-                    })
-                }
-            },
-            |mut handles| {
-                #[cfg(not(feature = "async-std"))]
-                {
-                    runtime.block_on(async move { while handles.join_next().await.is_some() {} })
-                }
-                #[cfg(feature = "async-std")]
-                {
-                    async_std::task::block_on(async move {
-                        while handles.join_next().await.is_some() {}
-                    })
-                }
-            },
-            BatchSize::PerIteration,
-        );
-    });
+                            for _ in 0..size {
+                                let (_, handler) = Actor::spawn(None, SpawnActor, ())
+                                    .await
+                                    .expect("Failed to create test agent");
+                                join_set.spawn(handler);
+                            }
+                            join_set
+                        })
+                    }
+                },
+                |mut handles| {
+                    #[cfg(not(feature = "async-std"))]
+                    {
+                        runtime
+                            .block_on(async move { while handles.join_next().await.is_some() {} })
+                    }
+                    #[cfg(feature = "async-std")]
+                    {
+                        async_std::task::block_on(async move {
+                            while handles.join_next().await.is_some() {}
+                        })
+                    }
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
 }
 
 #[allow(clippy::async_yields_async)]
@@ -261,7 +201,7 @@ fn process_messages(c: &mut Criterion) {
 
     #[cfg_attr(feature = "async-trait", ractor::async_trait)]
     impl Actor for MessagingActor {
-        type Msg = BenchActorMessage;
+        type Msg = BenchMessage;
 
         type State = u64;
 
@@ -272,7 +212,7 @@ fn process_messages(c: &mut Criterion) {
             myself: ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
-            let _ = myself.cast(BenchActorMessage);
+            let _ = myself.cast(BenchMessage);
             Ok(0u64)
         }
 
@@ -286,7 +226,7 @@ fn process_messages(c: &mut Criterion) {
             if *state >= self.num_msgs {
                 myself.stop(None);
             } else {
-                let _ = myself.cast(BenchActorMessage);
+                let _ = myself.cast(BenchMessage);
             }
             Ok(())
         }
@@ -296,7 +236,9 @@ fn process_messages(c: &mut Criterion) {
     #[cfg(not(feature = "async-std"))]
     let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
     #[cfg(feature = "async-std")]
-    async_std::task::block_on(async {});
+    {
+        async_std::task::block_on(async {})
+    }
     c.bench_function(&id, move |b| {
         b.iter_batched(
             || {
@@ -340,162 +282,55 @@ fn process_messages(c: &mut Criterion) {
     });
 }
 
-// #[allow(clippy::async_yields_async)]
-// fn process_output_port_messages(c: &mut Criterion) {
-//     const NUM_MSGS: u64 = 1000;
-//     const NUM_RECEIVERS: u64 = 100;
-
-//     struct MessagingActor {
-//         num_msgs: u64,
-//     }
-
-//     #[cfg_attr(feature = "async-trait", ractor::async_trait)]
-//     impl Actor for MessagingActor {
-//         type Msg = BenchActorMessage;
-
-//         type State = (u64, OutputPort<u64>);
-
-//         type Arguments = OutputPort<u64>;
-
-//         async fn pre_start(
-//             &self,
-//             myself: ActorRef<Self::Msg>,
-//             arg: Self::Arguments,
-//         ) -> Result<Self::State, ActorProcessingErr> {
-//             let _ = myself.cast(BenchActorMessage);
-//             Ok((0u64, arg))
-//         }
-
-//         async fn handle(
-//             &self,
-//             myself: ActorRef<Self::Msg>,
-//             _message: Self::Msg,
-//             state: &mut Self::State,
-//         ) -> Result<(), ActorProcessingErr> {
-//             state.0 += 1;
-//             if state.0 > self.num_msgs {
-//                 myself.stop(None);
-//             } else {
-//                 state.1.send(state.0);
-//                 let _ = myself.cast(BenchActorMessage);
-//             }
-//             Ok(())
-//         }
-//     }
-//     struct ReceivingActor {
-//         num_msgs: u64,
-//     }
-
-//     #[cfg_attr(feature = "async-trait", ractor::async_trait)]
-//     impl Actor for ReceivingActor {
-//         type Msg = u64;
-
-//         type State = u64;
-
-//         type Arguments = ();
-
-//         async fn pre_start(
-//             &self,
-//             _myself: ActorRef<Self::Msg>,
-//             _: (),
-//         ) -> Result<Self::State, ActorProcessingErr> {
-//             Ok(0)
-//         }
-
-//         async fn handle(
-//             &self,
-//             myself: ActorRef<Self::Msg>,
-//             _message: Self::Msg,
-//             state: &mut Self::State,
-//         ) -> Result<(), ActorProcessingErr> {
-//             *state += 1u64;
-//             if *state >= self.num_msgs {
-//                 myself.stop(None);
-//             }
-//             Ok(())
-//         }
-//     }
-
-//     let id = format!(
-//         "Waiting on {NUM_MSGS} messages to be sent on output port to {NUM_RECEIVERS} actors"
-//     );
-//     #[cfg(not(feature = "async-std"))]
-//     let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
-//     #[cfg(feature = "async-std")]
-//     async_std::task::block_on(async {});
-//     c.bench_function(&id, move |b| {
-//         b.iter_batched(
-//             || {
-//                 #[cfg(not(feature = "async-std"))]
-//                 {
-//                     runtime.block_on(async move {
-//                         let output_port = OutputPort::default();
-//                         let mut handels = Vec::new();
-//                         for _ in 0..NUM_RECEIVERS {
-//                             let (r, h) =
-//                                 Actor::spawn(None, ReceivingActor { num_msgs: NUM_MSGS }, ())
-//                                     .await
-//                                     .expect("Failed to create test actor");
-//                             output_port.subscribe(r, Some);
-//                             handels.push(h);
-//                         }
-//                         let (_, handle) =
-//                             Actor::spawn(None, MessagingActor { num_msgs: NUM_MSGS }, output_port)
-//                                 .await
-//                                 .expect("Failed to create test actor");
-//                         handels.push(handle);
-//                         handels
-//                     })
-//                 }
-//                 #[cfg(feature = "async-std")]
-//                 {
-//                     async_std::task::block_on(async move {
-//                         let output_port = OutputPort::default();
-//                         let mut handels = Vec::new();
-//                         for _ in 0..16 {
-//                             let (r, h) =
-//                                 Actor::spawn(None, ReceivingActor { num_msgs: NUM_MSGS }, ())
-//                                     .await
-//                                     .expect("Failed to create test actor");
-//                             output_port.subscribe(r, Some);
-//                             handels.push(h);
-//                         }
-//                         let (_, handle) =
-//                             Actor::spawn(None, MessagingActor { num_msgs: NUM_MSGS }, output_port)
-//                                 .await
-//                                 .expect("Failed to create test actor");
-//                         handels.push(handle);
-//                         handels
-//                     })
-//                 }
-//             },
-//             |handles| {
-//                 #[cfg(not(feature = "async-std"))]
-//                 {
-//                     runtime.block_on(async move {
-//                         for handle in handles {
-//                             let _ = handle.await;
-//                         }
-//                     })
-//                 }
-//                 #[cfg(feature = "async-std")]
-//                 {
-//                     async_std::task::block_on(async move {
-//                         for handle in handles {
-//                             let _ = handle.await;
-//                         }
-//                     })
-//                 }
-//             },
-//             BatchSize::PerIteration,
-//         );
-//     });
-// }
+fn message_sending(c: &mut Criterion) {
+    #[cfg(not(feature = "async-std"))]
+    let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
+    #[cfg(feature = "async-std")]
+    {
+        async_std::task::block_on(async {})
+    }
+    for size in [1000, 100000] {
+        let id = format!("Sending of {size} messages to an actor");
+        c.bench_function(&id, |b| {
+            b.iter_batched(
+                || {
+                    #[cfg(not(feature = "async-std"))]
+                    {
+                        runtime.block_on(async move {
+                            let (a, h) = Actor::spawn(None, BenchActor, ())
+                                .await
+                                .expect("Failed to create test agent");
+                            (a, h)
+                        })
+                    }
+                    #[cfg(feature = "async-std")]
+                    {
+                        async_std::task::block_on(async move {
+                            let (a, h) = Actor::spawn(None, BenchActor, ())
+                                .await
+                                .expect("Failed to create test agent");
+                            (a, h)
+                        })
+                    }
+                },
+                |(actor, _handle)| {
+                    for _i in 0..size {
+                        actor
+                            .cast(BenchMessage)
+                            .expect("Failed to send message to actor");
+                    }
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
+}
 
 criterion_group!(
     actors,
     create_actors,
     schedule_work,
-    process_messages // process_output_port_messages
+    process_messages,
+    message_sending
 );
 criterion_main!(actors);

--- a/ractor/benches/output_ports.rs
+++ b/ractor/benches/output_ports.rs
@@ -1,0 +1,170 @@
+#[macro_use]
+extern crate criterion;
+
+use criterion::BatchSize;
+use criterion::Criterion;
+use ractor::Actor;
+use ractor::ActorProcessingErr;
+use ractor::ActorRef;
+#[cfg(feature = "cluster")]
+use ractor::Message;
+use ractor::OutputPort;
+
+struct BenchActorMessage;
+#[cfg(feature = "cluster")]
+impl Message for BenchActorMessage {}
+
+#[allow(clippy::async_yields_async)]
+fn process_output_port_messages(c: &mut Criterion) {
+    const NUM_MSGS: u64 = 1000;
+    const NUM_RECEIVERS: u64 = 100;
+
+    struct MessagingActor {
+        num_msgs: u64,
+    }
+
+    #[cfg_attr(feature = "async-trait", ractor::async_trait)]
+    impl Actor for MessagingActor {
+        type Msg = BenchActorMessage;
+
+        type State = (u64, OutputPort<u64>);
+
+        type Arguments = OutputPort<u64>;
+
+        async fn pre_start(
+            &self,
+            myself: ActorRef<Self::Msg>,
+            arg: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            let _ = myself.cast(BenchActorMessage);
+            Ok((0u64, arg))
+        }
+
+        async fn handle(
+            &self,
+            myself: ActorRef<Self::Msg>,
+            _message: Self::Msg,
+            state: &mut Self::State,
+        ) -> Result<(), ActorProcessingErr> {
+            state.0 += 1;
+            if state.0 > self.num_msgs {
+                myself.stop(None);
+            } else {
+                state.1.send(state.0);
+                let _ = myself.cast(BenchActorMessage);
+            }
+            Ok(())
+        }
+    }
+    struct ReceivingActor {
+        num_msgs: u64,
+    }
+
+    #[cfg_attr(feature = "async-trait", ractor::async_trait)]
+    impl Actor for ReceivingActor {
+        type Msg = u64;
+
+        type State = u64;
+
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _: (),
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(0)
+        }
+
+        async fn handle(
+            &self,
+            myself: ActorRef<Self::Msg>,
+            _message: Self::Msg,
+            state: &mut Self::State,
+        ) -> Result<(), ActorProcessingErr> {
+            *state += 1u64;
+            if *state >= self.num_msgs {
+                myself.stop(None);
+            }
+            Ok(())
+        }
+    }
+
+    let id = format!(
+        "Waiting on {NUM_MSGS} messages to be sent on output port to {NUM_RECEIVERS} actors"
+    );
+    #[cfg(not(feature = "async-std"))]
+    let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
+    #[cfg(feature = "async-std")]
+    let _ = async_std::task::block_on(async {});
+    c.bench_function(&id, move |b| {
+        b.iter_batched(
+            || {
+                #[cfg(not(feature = "async-std"))]
+                {
+                    runtime.block_on(async move {
+                        let output_port = OutputPort::default();
+                        let mut handels = Vec::new();
+                        for _ in 0..NUM_RECEIVERS {
+                            let (r, h) =
+                                Actor::spawn(None, ReceivingActor { num_msgs: NUM_MSGS }, ())
+                                    .await
+                                    .expect("Failed to create test actor");
+                            output_port.subscribe(r, |v| Some(v));
+                            handels.push(h);
+                        }
+                        let (_, handle) =
+                            Actor::spawn(None, MessagingActor { num_msgs: NUM_MSGS }, output_port)
+                                .await
+                                .expect("Failed to create test actor");
+                        handels.push(handle);
+                        handels
+                    })
+                }
+                #[cfg(feature = "async-std")]
+                {
+                    async_std::task::block_on(async move {
+                        let output_port = OutputPort::default();
+                        let mut handels = Vec::new();
+                        for _ in 0..16 {
+                            let (r, h) =
+                                Actor::spawn(None, ReceivingActor { num_msgs: NUM_MSGS }, ())
+                                    .await
+                                    .expect("Failed to create test actor");
+                            output_port.subscribe(r, |v| Some(v));
+                            handels.push(h);
+                        }
+                        let (_, handle) =
+                            Actor::spawn(None, MessagingActor { num_msgs: NUM_MSGS }, output_port)
+                                .await
+                                .expect("Failed to create test actor");
+                        handels.push(handle);
+                        handels
+                    })
+                }
+            },
+            |handles| {
+                #[cfg(not(feature = "async-std"))]
+                {
+                    runtime.block_on(async move {
+                        for handle in handles {
+                            let _ = handle.await;
+                        }
+                    })
+                }
+                #[cfg(feature = "async-std")]
+                {
+                    async_std::task::block_on(async move {
+                        for handle in handles {
+                            let _ = handle.await;
+                        }
+                    })
+                }
+            },
+            BatchSize::PerIteration,
+        );
+    });
+}
+
+criterion_group!(output_ports, process_output_port_messages);
+criterion_main!(output_ports);

--- a/ractor/src/actor.rs
+++ b/ractor/src/actor.rs
@@ -85,6 +85,7 @@ use crate::errors::ActorErr;
 use crate::errors::ActorProcessingErr;
 use crate::errors::MessagingErr;
 use crate::errors::SpawnErr;
+use crate::message::RactorMessage;
 use crate::ActorName;
 use crate::Message;
 use crate::State;
@@ -678,7 +679,10 @@ where
     /// * `handler` The [Actor] defining the logic for this actor
     ///
     /// Returns A tuple [(Actor, ActorPortSet)] to be passed to the `start` function of [Actor]
-    fn new(name: Option<ActorName>, handler: TActor) -> Result<(Self, ActorPortSet), SpawnErr> {
+    fn new(
+        name: Option<ActorName>,
+        handler: TActor,
+    ) -> Result<(Self, ActorPortSet<TActor::Msg>), SpawnErr> {
         let (actor_cell, ports) = actor_cell::ActorCell::new::<TActor>(name)?;
         let id = actor_cell.get_id();
         let name = actor_cell.get_name();
@@ -708,7 +712,7 @@ where
     #[tracing::instrument(name = "Actor", skip(self, ports, startup_args, supervisor), fields(id = self.id.to_string(), name = self.name))]
     async fn start(
         self,
-        ports: ActorPortSet,
+        ports: ActorPortSet<TActor::Msg>,
         startup_args: TActor::Arguments,
         supervisor: Option<ActorCell>,
     ) -> Result<(ActorRef<TActor::Msg>, JoinHandle<()>), SpawnErr> {
@@ -790,7 +794,7 @@ where
 
     #[tracing::instrument(name = "Actor", skip(ports, state, handler, myself, _id, _name), fields(id = _id.to_string(), name = _name))]
     async fn processing_loop(
-        mut ports: ActorPortSet,
+        mut ports: ActorPortSet<TActor::Msg>,
         state: &mut TActor::State,
         handler: &TActor,
         myself: ActorRef<TActor::Msg>,
@@ -859,7 +863,7 @@ where
         myself: &ActorRef<TActor::Msg>,
         state: &mut TActor::State,
         handler: &TActor,
-        ports: &mut ActorPortSet,
+        ports: &mut ActorPortSet<TActor::Msg>,
     ) -> Result<ActorLoopResult, ActorProcessingErr> {
         match ports.listen_in_priority().await {
             Ok(actor_port_message) => match actor_port_message {
@@ -946,7 +950,7 @@ where
         myself: ActorRef<TActor::Msg>,
         state: &mut TActor::State,
         handler: &TActor,
-        mut msg: crate::message::BoxedMessage,
+        mut msg: crate::message::LocalOrSerialized<TActor::Msg>,
     ) -> Result<(), ActorProcessingErr> {
         // panic in order to kill the actor
         #[cfg(feature = "cluster")]
@@ -955,7 +959,7 @@ where
             // to the remote system for decoding + handling by the real implementation. Therefore `RemoteActor`s
             // can be thought of as a "shim" to a real actor on a remote system
             if !myself.get_id().is_local() {
-                match msg.serialized_msg {
+                match msg.into_serialized() {
                     Some(serialized_msg) => {
                         return handler
                             .handle_serialized(myself, serialized_msg, state)
@@ -973,10 +977,10 @@ where
         // The current [tracing::Span] is retrieved, boxed, and included in every
         // `BoxedMessage` during the conversion of this `TActor::Msg`. It is used
         // to automatically continue tracing span nesting when sending messages to Actors.
-        let current_span_when_message_was_sent = msg.span.take();
+        let current_span_when_message_was_sent = msg.take_span();
 
         // An error here will bubble up to terminate the actor
-        let typed_msg = TActor::Msg::from_boxed(msg)?;
+        let typed_msg = TActor::Msg::decode(msg)?;
 
         if let Some(span) = current_span_when_message_was_sent {
             handler

--- a/ractor/src/actor/actor_properties.rs
+++ b/ractor/src/actor/actor_properties.rs
@@ -3,6 +3,7 @@
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree.
 
+use std::any::Any;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
 use std::sync::Mutex;
@@ -14,7 +15,8 @@ use crate::concurrency::MpscUnboundedReceiver as InputPortReceiver;
 use crate::concurrency::MpscUnboundedSender as InputPort;
 use crate::concurrency::OneshotReceiver;
 use crate::concurrency::OneshotSender as OneshotInputPort;
-use crate::message::BoxedMessage;
+use crate::message::LocalOrSerialized;
+use crate::message::RactorMessage;
 #[cfg(feature = "cluster")]
 use crate::message::SerializedMessage;
 use crate::Actor;
@@ -28,9 +30,37 @@ use crate::SupervisionEvent;
 
 /// A muxed-message wrapper which allows the message port to receive either a message or a drain
 /// request which is a point-in-time marker that the actor's input channel should be drained
-pub(crate) enum MuxedMessage {
+pub(crate) enum MuxedMessage<T: Any + Send> {
     Drain,
-    Message(BoxedMessage),
+    Message(LocalOrSerialized<T>),
+}
+
+pub(crate) trait GenericInputPort: Sync + Any + Send + 'static {
+    fn send_drain(&self) -> Result<(), MessagingErr<()>>;
+    #[cfg(feature = "cluster")]
+    fn send_serialized(
+        &self,
+        message: SerializedMessage,
+    ) -> Result<(), MessagingErr<SerializedMessage>>;
+}
+impl<T: Any + Send> GenericInputPort for InputPort<MuxedMessage<T>> {
+    fn send_drain(&self) -> Result<(), MessagingErr<()>> {
+        self.send(MuxedMessage::Drain)
+            .map_err(|_| MessagingErr::SendErr(()))
+    }
+
+    #[cfg(feature = "cluster")]
+    fn send_serialized(
+        &self,
+        message: SerializedMessage,
+    ) -> Result<(), MessagingErr<SerializedMessage>> {
+        let boxed = LocalOrSerialized::Serialized(message);
+        self.send(MuxedMessage::Message(boxed))
+            .map_err(|e| match e.0 {
+                MuxedMessage::Message(m) => MessagingErr::SendErr(m.into_serialized().unwrap()),
+                _ => panic!("Expected a boxed message but got a drain message"),
+            })
+    }
 }
 
 // The inner-properties of an Actor
@@ -42,7 +72,7 @@ pub(crate) struct ActorProperties {
     pub(crate) signal: Mutex<Option<OneshotInputPort<Signal>>>,
     pub(crate) stop: Mutex<Option<OneshotInputPort<StopMessage>>>,
     pub(crate) supervision: InputPort<SupervisionEvent>,
-    pub(crate) message: InputPort<MuxedMessage>,
+    pub(crate) message: Box<dyn GenericInputPort>,
     pub(crate) tree: SupervisionTree,
     pub(crate) type_id: std::any::TypeId,
     #[cfg(feature = "cluster")]
@@ -50,22 +80,21 @@ pub(crate) struct ActorProperties {
 }
 
 impl ActorProperties {
-    pub(crate) fn new<TActor>(
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn new<TActor: Actor>(
         name: Option<ActorName>,
     ) -> (
         Self,
         OneshotReceiver<Signal>,
         OneshotReceiver<StopMessage>,
         InputPortReceiver<SupervisionEvent>,
-        InputPortReceiver<MuxedMessage>,
-    )
-    where
-        TActor: Actor,
-    {
+        InputPortReceiver<MuxedMessage<TActor::Msg>>,
+    ) {
         Self::new_remote::<TActor>(name, crate::actor::actor_id::get_new_local_id())
     }
 
-    pub(crate) fn new_remote<TActor>(
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn new_remote<TActor: Actor>(
         name: Option<ActorName>,
         id: ActorId,
     ) -> (
@@ -73,11 +102,8 @@ impl ActorProperties {
         OneshotReceiver<Signal>,
         OneshotReceiver<StopMessage>,
         InputPortReceiver<SupervisionEvent>,
-        InputPortReceiver<MuxedMessage>,
-    )
-    where
-        TActor: Actor,
-    {
+        InputPortReceiver<MuxedMessage<TActor::Msg>>,
+    ) {
         let (tx_signal, rx_signal) = mpsc::oneshot();
         let (tx_stop, rx_stop) = mpsc::oneshot();
         let (tx_supervision, rx_supervision) = mpsc::mpsc_unbounded();
@@ -91,7 +117,7 @@ impl ActorProperties {
                 wait_handler: mpsc::Notify::new(),
                 stop: Mutex::new(Some(tx_stop)),
                 supervision: tx_supervision,
-                message: tx_message,
+                message: Box::new(tx_message),
                 tree: SupervisionTree::default(),
                 type_id: std::any::TypeId::of::<TActor::Msg>(),
                 #[cfg(feature = "cluster")]
@@ -144,29 +170,6 @@ impl ActorProperties {
     where
         TMessage: Message,
     {
-        // Only type-check messages of local actors, remote actors send serialized
-        // payloads
-        if self.id.is_local() && self.type_id != std::any::TypeId::of::<TMessage>() {
-            return Err(MessagingErr::InvalidActorType);
-        }
-
-        // Delegate to unchecked version after type check
-        self.send_message_unchecked(message)
-    }
-
-    /// Send a message without runtime type checking.
-    ///
-    /// This is an internal optimization for strongly-typed ActorRef which has compile-time
-    /// type safety guarantees, avoiding the redundant runtime TypeId comparison.
-    ///
-    /// SAFETY: Callers must ensure the message type matches the actor's expected type.
-    pub(crate) fn send_message_unchecked<TMessage>(
-        &self,
-        message: TMessage,
-    ) -> Result<(), MessagingErr<TMessage>>
-    where
-        TMessage: Message,
-    {
         let status = self.get_status();
         if status >= ActorStatus::Draining {
             // if currently draining, stopping or stopped: reject messages directly.
@@ -174,14 +177,30 @@ impl ActorProperties {
         }
 
         let boxed = message
-            .box_message(&self.id)
+            .encode(&self.id)
             .map_err(|_e| MessagingErr::InvalidActorType)?;
-        self.message
-            .send(MuxedMessage::Message(boxed))
-            .map_err(|e| match e.0 {
-                MuxedMessage::Message(m) => MessagingErr::SendErr(TMessage::from_boxed(m).unwrap()),
-                _ => panic!("Expected a boxed message but got a drain message"),
-            })
+
+        match boxed {
+            #[cfg(feature = "cluster")]
+            LocalOrSerialized::Serialized(m) => self
+                .message
+                .send_serialized(m)
+                .map_err(convert_messaging_error),
+            local => {
+                let channel: &InputPort<MuxedMessage<TMessage>> = {
+                    let ptr: &dyn Any = &*self.message;
+                    ptr.downcast_ref().ok_or(MessagingErr::InvalidActorType)?
+                };
+
+                channel.send(MuxedMessage::Message(local)).map_err(|ret| {
+                    let inner = match ret.0 {
+                        MuxedMessage::Message(LocalOrSerialized::Local { msg, .. }) => msg,
+                        _ => panic!("Impossible message received at send error point"),
+                    };
+                    MessagingErr::SendErr(inner)
+                })
+            }
+        }
     }
 
     pub(crate) fn drain(&self) -> Result<(), MessagingErr<()>> {
@@ -194,9 +213,7 @@ impl ActorProperties {
                     None
                 }
             });
-        self.message
-            .send(MuxedMessage::Drain)
-            .map_err(|_| MessagingErr::SendErr(()))
+        self.message.send_drain()
     }
 
     /// Start draining, and wait for the actor to exit
@@ -212,18 +229,7 @@ impl ActorProperties {
         &self,
         message: SerializedMessage,
     ) -> Result<(), Box<MessagingErr<SerializedMessage>>> {
-        let boxed = BoxedMessage {
-            msg: None,
-            serialized_msg: Some(message),
-            span: None,
-        };
-        Ok(self
-            .message
-            .send(MuxedMessage::Message(boxed))
-            .map_err(|e| match e.0 {
-                MuxedMessage::Message(m) => MessagingErr::SendErr(m.serialized_msg.unwrap()),
-                _ => panic!("Expected a boxed message but got a drain message"),
-            })?)
+        self.message.send_serialized(message).map_err(Box::new)
     }
 
     pub(crate) fn send_stop(
@@ -275,5 +281,65 @@ impl ActorProperties {
         // a notify permit (i.e. the actor stops, but you are only start waiting
         // after the actor has already notified it's dead.)
         self.wait_handler.notify_one();
+    }
+}
+
+/// # Panic
+/// Panic if the `TMessage` cannot be deserialized from
+/// the serialized message passed as argument
+#[cfg(feature = "cluster")]
+fn convert_messaging_error<TMessage: Message>(
+    e: MessagingErr<SerializedMessage>,
+) -> MessagingErr<TMessage> {
+    match e {
+        MessagingErr::SendErr(m) => MessagingErr::SendErr(
+            TMessage::decode(LocalOrSerialized::Serialized(m))
+                .expect("Failed to decode a serialized message to the provided concrete type"),
+        ),
+        MessagingErr::ChannelClosed => MessagingErr::ChannelClosed,
+        MessagingErr::InvalidActorType => MessagingErr::InvalidActorType,
+    }
+}
+#[cfg(all(test, feature = "cluster"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_messaging_error() {
+        struct TestRemoteMessage;
+        // a serializable basic no-op message
+        impl Message for TestRemoteMessage {
+            fn serializable() -> bool {
+                true
+            }
+            fn deserialize(_bytes: SerializedMessage) -> Result<Self, crate::message::DowncastErr> {
+                Ok(TestRemoteMessage)
+            }
+            fn serialize(self) -> Result<SerializedMessage, crate::message::DowncastErr> {
+                Ok(crate::message::SerializedMessage::Cast {
+                    args: vec![],
+                    variant: "Cast".to_string(),
+                    metadata: None,
+                })
+            }
+        }
+        let id = ActorId::Remote { node_id: 1, pid: 1 };
+        let boxed = TestRemoteMessage.encode(&id).unwrap();
+        assert!(matches!(
+            convert_messaging_error(MessagingErr::SendErr(boxed.into_serialized().unwrap())),
+            MessagingErr::SendErr(TestRemoteMessage)
+        ));
+        assert!(matches!(
+            convert_messaging_error::<TestRemoteMessage>(
+                MessagingErr::<SerializedMessage>::ChannelClosed
+            ),
+            MessagingErr::<TestRemoteMessage>::ChannelClosed
+        ));
+        assert!(matches!(
+            convert_messaging_error::<TestRemoteMessage>(
+                MessagingErr::<SerializedMessage>::InvalidActorType
+            ),
+            MessagingErr::<TestRemoteMessage>::InvalidActorType
+        ));
     }
 }

--- a/ractor/src/actor/actor_ref.rs
+++ b/ractor/src/actor/actor_ref.rs
@@ -103,8 +103,9 @@ where
     ///
     /// Returns [Ok(())] on successful message send, [Err(MessagingErr)] otherwise
     pub fn send_message(&self, message: TMessage) -> Result<(), MessagingErr<TMessage>> {
-        // Use unchecked version - ActorRef<TMessage> provides compile-time type safety
-        self.inner.inner.send_message_unchecked::<TMessage>(message)
+        // ActorRef<TMessage> provides compile-time type safety, so we can call
+        // the safe method directly on ActorProperties.
+        self.inner.inner.send_message::<TMessage>(message)
     }
 
     // ========================== General Actor Operation Aliases ========================== //

--- a/ractor/src/actor/messages.rs
+++ b/ractor/src/actor/messages.rs
@@ -12,7 +12,7 @@
 use std::any::Any;
 use std::fmt::Debug;
 
-use crate::message::BoxedDowncastErr;
+use crate::message::DowncastErr;
 use crate::ActorProcessingErr;
 use crate::State;
 
@@ -43,7 +43,7 @@ impl BoxedState {
 
     /// Try and take the resulting message as a specific type, consumes
     /// the boxed message
-    pub fn take<T>(&mut self) -> Result<T, BoxedDowncastErr>
+    pub fn take<T>(&mut self) -> Result<T, DowncastErr>
     where
         T: State,
     {
@@ -52,10 +52,10 @@ impl BoxedState {
                 if m.is::<T>() {
                     Ok(*m.downcast::<T>().unwrap())
                 } else {
-                    Err(BoxedDowncastErr)
+                    Err(DowncastErr)
                 }
             }
-            None => Err(BoxedDowncastErr),
+            None => Err(DowncastErr),
         }
     }
 }

--- a/ractor/src/actor/supervision_tests.rs
+++ b/ractor/src/actor/supervision_tests.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use crate::concurrency::Duration;
-use crate::message::BoxedDowncastErr;
+use crate::message::DowncastErr;
 use crate::periodic_check;
 use crate::Actor;
 use crate::ActorCell;
@@ -1119,10 +1119,10 @@ async fn test_supervisor_captures_dead_childs_state() {
     }
 
     let mut temp_state = super::messages::BoxedState::new(123u64);
-    assert_eq!(Err(BoxedDowncastErr), temp_state.take::<u32>());
+    assert_eq!(Err(DowncastErr), temp_state.take::<u32>());
     let mut temp_state = super::messages::BoxedState::new(123u64);
     assert_eq!(Ok(123u64), temp_state.take::<u64>());
-    assert_eq!(Err(BoxedDowncastErr), temp_state.take::<u64>());
+    assert_eq!(Err(DowncastErr), temp_state.take::<u64>());
 
     let flag = Arc::new(AtomicU64::new(0));
 

--- a/ractor/src/factory.rs
+++ b/ractor/src/factory.rs
@@ -166,7 +166,7 @@ use std::sync::Arc;
 use crate::concurrency::Duration;
 use crate::concurrency::Instant;
 #[cfg(feature = "cluster")]
-use crate::message::BoxedDowncastErr;
+use crate::message::DowncastErr;
 use crate::Message;
 use crate::RpcReplyPort;
 
@@ -342,15 +342,13 @@ where
     fn serializable() -> bool {
         TMsg::serializable()
     }
-    fn serialize(
-        self,
-    ) -> Result<crate::message::SerializedMessage, crate::message::BoxedDowncastErr> {
+    fn serialize(self) -> Result<crate::message::SerializedMessage, crate::message::DowncastErr> {
         match self {
             Self::Dispatch(job) => job.serialize(),
-            _ => Err(BoxedDowncastErr),
+            _ => Err(DowncastErr),
         }
     }
-    fn deserialize(bytes: crate::message::SerializedMessage) -> Result<Self, BoxedDowncastErr> {
+    fn deserialize(bytes: crate::message::SerializedMessage) -> Result<Self, DowncastErr> {
         Ok(Self::Dispatch(Job::<TKey, TMsg>::deserialize(bytes)?))
     }
 }

--- a/ractor/src/message.rs
+++ b/ractor/src/message.rs
@@ -15,14 +15,14 @@ use crate::RpcReplyPort;
 
 /// An error downcasting a boxed item to a strong type
 #[derive(Debug, Eq, PartialEq)]
-pub struct BoxedDowncastErr;
-impl std::fmt::Display for BoxedDowncastErr {
+pub struct DowncastErr;
+impl std::fmt::Display for DowncastErr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "An error occurred handling a boxed message")
+        write!(f, "An error occurred handling a message downcasting")
     }
 }
 
-impl std::error::Error for BoxedDowncastErr {}
+impl std::error::Error for DowncastErr {}
 
 /// Represents a serialized call or cast message
 #[cfg(feature = "cluster")]
@@ -56,23 +56,75 @@ pub enum SerializedMessage {
     CallReply(u64, Vec<u8>),
 }
 
-/// A "boxed" message denoting a strong-type message
-/// but generic so it can be passed around without type
-/// constraints
-pub struct BoxedMessage {
-    pub(crate) msg: Option<Box<dyn Any + Send>>,
-    /// A serialized message for a remote actor, accessed only by the `RemoteActorRuntime`
-    #[cfg(feature = "cluster")]
-    pub serialized_msg: Option<SerializedMessage>,
-    pub(crate) span: Option<tracing::Span>,
+pub(crate) trait RactorMessage: Any + Send + Sized {
+    fn decode(m: LocalOrSerialized<Self>) -> Result<Self, DowncastErr>;
+
+    fn encode(self, pid: &ActorId) -> Result<LocalOrSerialized<Self>, DowncastErr>;
 }
 
-impl std::fmt::Debug for BoxedMessage {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.msg.is_some() {
-            write!(f, "BoxedMessage(Local)")
-        } else {
-            write!(f, "BoxedMessage(Serialized)")
+impl<M: Message> RactorMessage for M {
+    /// Convert a [RactorMessage] to this concrete type
+    fn decode(m: LocalOrSerialized<Self>) -> Result<Self, DowncastErr> {
+        match m {
+            LocalOrSerialized::Local { msg, .. } => Ok(msg),
+            #[cfg(feature = "cluster")]
+            LocalOrSerialized::Serialized(serialized_message) => {
+                Self::deserialize(serialized_message)
+            }
+        }
+    }
+
+    /// Convert this message to a [RactorMessage]
+    fn encode(self, _pid: &ActorId) -> Result<LocalOrSerialized<Self>, DowncastErr> {
+        let span = {
+            #[cfg(feature = "message_span_propogation")]
+            {
+                Some(tracing::Span::current())
+            }
+            #[cfg(not(feature = "message_span_propogation"))]
+            {
+                None
+            }
+        };
+        #[cfg(feature = "cluster")]
+        {
+            if Self::serializable() && !_pid.is_local() {
+                // it's a message to a remote actor, serialize it and send it over the wire!
+                Ok(LocalOrSerialized::Serialized(self.serialize()?))
+            } else {
+                Ok(LocalOrSerialized::Local { msg: self, span })
+            }
+        }
+        #[cfg(not(feature = "cluster"))]
+        {
+            Ok(LocalOrSerialized::Local { msg: self, span })
+        }
+    }
+}
+
+pub(crate) enum LocalOrSerialized<T: Any + Send> {
+    Local {
+        msg: T,
+        span: Option<tracing::Span>,
+    },
+    #[cfg(feature = "cluster")]
+    /// A serialized message for a remote actor, accessed only by the `RemoteActorRuntime`
+    Serialized(SerializedMessage),
+}
+impl<T: Any + Send> LocalOrSerialized<T> {
+    #[cfg(feature = "cluster")]
+    pub(crate) fn into_serialized(self) -> Option<SerializedMessage> {
+        match self {
+            LocalOrSerialized::Local { .. } => None,
+            LocalOrSerialized::Serialized(msg) => Some(msg),
+        }
+    }
+
+    pub(crate) fn take_span(&mut self) -> Option<tracing::Span> {
+        match self {
+            LocalOrSerialized::Local { span, .. } => span.take(),
+            #[cfg(feature = "cluster")]
+            LocalOrSerialized::Serialized(_) => None,
         }
     }
 }
@@ -92,94 +144,6 @@ impl std::fmt::Debug for BoxedMessage {
 /// }
 /// ```
 pub trait Message: Any + Send + Sized + 'static {
-    /// Convert a [BoxedMessage] to this concrete type
-    #[cfg(feature = "cluster")]
-    fn from_boxed(mut m: BoxedMessage) -> Result<Self, BoxedDowncastErr> {
-        if m.msg.is_some() {
-            match m.msg.take() {
-                Some(m) => {
-                    // downcast already checks the type, no need for redundant is::<Self>() check
-                    m.downcast::<Self>()
-                        .map(|boxed| *boxed)
-                        .map_err(|_| BoxedDowncastErr)
-                }
-                _ => Err(BoxedDowncastErr),
-            }
-        } else if m.serialized_msg.is_some() {
-            match m.serialized_msg.take() {
-                Some(m) => Self::deserialize(m),
-                _ => Err(BoxedDowncastErr),
-            }
-        } else {
-            Err(BoxedDowncastErr)
-        }
-    }
-
-    /// Convert a [BoxedMessage] to this concrete type
-    #[cfg(not(feature = "cluster"))]
-    fn from_boxed(mut m: BoxedMessage) -> Result<Self, BoxedDowncastErr> {
-        match m.msg.take() {
-            Some(m) => {
-                // downcast already checks the type, no need for redundant is::<Self>() check
-                m.downcast::<Self>()
-                    .map(|boxed| *boxed)
-                    .map_err(|_| BoxedDowncastErr)
-            }
-            _ => Err(BoxedDowncastErr),
-        }
-    }
-
-    /// Convert this message to a [BoxedMessage]
-    #[cfg(feature = "cluster")]
-    fn box_message(self, pid: &ActorId) -> Result<BoxedMessage, BoxedDowncastErr> {
-        let span = {
-            #[cfg(feature = "message_span_propogation")]
-            {
-                Some(tracing::Span::current())
-            }
-            #[cfg(not(feature = "message_span_propogation"))]
-            {
-                None
-            }
-        };
-        if Self::serializable() && !pid.is_local() {
-            // it's a message to a remote actor, serialize it and send it over the wire!
-            Ok(BoxedMessage {
-                msg: None,
-                serialized_msg: Some(self.serialize()?),
-                span: None,
-            })
-        } else if pid.is_local() {
-            Ok(BoxedMessage {
-                msg: Some(Box::new(self)),
-                serialized_msg: None,
-                span,
-            })
-        } else {
-            Err(BoxedDowncastErr)
-        }
-    }
-
-    /// Convert this message to a [BoxedMessage]
-    #[cfg(not(feature = "cluster"))]
-    #[allow(unused_variables)]
-    fn box_message(self, pid: &ActorId) -> Result<BoxedMessage, BoxedDowncastErr> {
-        let span = {
-            #[cfg(feature = "message_span_propogation")]
-            {
-                Some(tracing::Span::current())
-            }
-            #[cfg(not(feature = "message_span_propogation"))]
-            {
-                None
-            }
-        };
-        Ok(BoxedMessage {
-            msg: Some(Box::new(self)),
-            span,
-        })
-    }
-
     /// Determines if this type is serializable
     #[cfg(feature = "cluster")]
     fn serializable() -> bool {
@@ -188,15 +152,15 @@ pub trait Message: Any + Send + Sized + 'static {
 
     /// Serializes this message (if supported)
     #[cfg(feature = "cluster")]
-    fn serialize(self) -> Result<SerializedMessage, BoxedDowncastErr> {
-        Err(BoxedDowncastErr)
+    fn serialize(self) -> Result<SerializedMessage, DowncastErr> {
+        Err(DowncastErr)
     }
 
     /// Deserialize binary data to this message type
     #[cfg(feature = "cluster")]
     #[allow(unused_variables)]
-    fn deserialize(bytes: SerializedMessage) -> Result<Self, BoxedDowncastErr> {
-        Err(BoxedDowncastErr)
+    fn deserialize(bytes: SerializedMessage) -> Result<Self, DowncastErr> {
+        Err(DowncastErr)
     }
 }
 
@@ -213,7 +177,7 @@ impl<T: Any + Send + Sized + 'static + crate::serialization::BytesConvertable> M
         true
     }
 
-    fn serialize(self) -> Result<SerializedMessage, BoxedDowncastErr> {
+    fn serialize(self) -> Result<SerializedMessage, DowncastErr> {
         Ok(SerializedMessage::Cast {
             variant: String::new(),
             args: self.into_bytes(),
@@ -221,10 +185,10 @@ impl<T: Any + Send + Sized + 'static + crate::serialization::BytesConvertable> M
         })
     }
 
-    fn deserialize(bytes: SerializedMessage) -> Result<Self, BoxedDowncastErr> {
+    fn deserialize(bytes: SerializedMessage) -> Result<Self, DowncastErr> {
         match bytes {
             SerializedMessage::Cast { args, .. } => Ok(T::from_bytes(args)),
-            _ => Err(BoxedDowncastErr),
+            _ => Err(DowncastErr),
         }
     }
 }

--- a/ractor/src/serialization.rs
+++ b/ractor/src/serialization.rs
@@ -208,7 +208,7 @@ mod tests {
     use rand::Rng;
 
     use super::BytesConvertable;
-    use crate::message::BoxedDowncastErr;
+    use crate::message::DowncastErr;
     use crate::Message;
 
     fn random_string() -> String {
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn test_boxed_downcast_error() {
-        let err = BoxedDowncastErr;
+        let err = DowncastErr;
         println!("{err}");
         println!("{err:?}");
     }

--- a/ractor/src/tests.rs
+++ b/ractor/src/tests.rs
@@ -89,8 +89,8 @@ async fn test_error_message_extraction() {
     let bad_message_actor: ActorRef<u32> = cell.into();
 
     let err = crate::cast!(bad_message_actor, 0u32).expect_err("Not an error!");
-    assert!(!err.has_message());
-    assert!(err.try_get_message().is_none());
+    assert!(err.has_message()); //actor status is checked before message type_id;
+    assert!(err.try_get_message().is_some());
 }
 
 #[crate::concurrency::test]

--- a/ractor/src/thread_local/inner.rs
+++ b/ractor/src/thread_local/inner.rs
@@ -27,7 +27,9 @@ use crate::actor::ActorLoopResult;
 use crate::concurrency as mpsc;
 use crate::concurrency::JoinHandle;
 use crate::concurrency::OneshotReceiver;
+#[cfg(feature = "cluster")]
 use crate::message::Message;
+use crate::message::RactorMessage;
 use crate::ActorCell;
 use crate::ActorErr;
 use crate::ActorId;
@@ -43,7 +45,7 @@ use crate::SupervisionEvent;
 impl ActorCell {
     pub(crate) fn new_thread_local<TActor>(
         name: Option<ActorName>,
-    ) -> Result<(Self, ActorPortSet), SpawnErr>
+    ) -> Result<(Self, ActorPortSet<TActor::Msg>), SpawnErr>
     where
         TActor: crate::thread_local::ThreadLocalActor,
     {
@@ -78,6 +80,7 @@ impl ActorCell {
 }
 
 impl ActorProperties {
+    #[allow(clippy::type_complexity)]
     pub(crate) fn new_thread_local<TActor>(
         name: Option<ActorName>,
     ) -> (
@@ -85,7 +88,7 @@ impl ActorProperties {
         OneshotReceiver<Signal>,
         OneshotReceiver<StopMessage>,
         mpsc::MpscUnboundedReceiver<SupervisionEvent>,
-        mpsc::MpscUnboundedReceiver<MuxedMessage>,
+        mpsc::MpscUnboundedReceiver<MuxedMessage<TActor::Msg>>,
     )
     where
         TActor: crate::thread_local::ThreadLocalActor,
@@ -104,7 +107,7 @@ impl ActorProperties {
                 wait_handler: mpsc::Notify::new(),
                 stop: Mutex::new(Some(tx_stop)),
                 supervision: tx_supervision,
-                message: tx_message,
+                message: Box::new(tx_message),
                 tree: Default::default(),
                 type_id: std::any::TypeId::of::<TActor::Msg>(),
                 #[cfg(feature = "cluster")]
@@ -147,7 +150,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
     /// Returns A tuple [(Actor, ActorPortSet)] to be passed to the `start` function of [Actor]
     fn new(
         name: Option<crate::ActorName>,
-    ) -> Result<(Self, crate::actor::actor_cell::ActorPortSet), crate::SpawnErr> {
+    ) -> Result<(Self, crate::actor::actor_cell::ActorPortSet<TActor::Msg>), crate::SpawnErr> {
         let (actor_cell, ports) =
             crate::actor::actor_cell::ActorCell::new_thread_local::<TActor>(name)?;
         let id = actor_cell.get_id();
@@ -272,7 +275,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
     #[tracing::instrument(name = "Actor", skip(self, ports, startup_args, supervisor), fields(id = self.id.to_string(), name = self.name))]
     async fn start(
         self,
-        ports: ActorPortSet,
+        ports: ActorPortSet<TActor::Msg>,
         startup_args: TActor::Arguments,
         spawner: ThreadLocalActorSpawner,
         supervisor: Option<ActorCell>,
@@ -376,7 +379,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
 
     #[tracing::instrument(name = "Actor", skip(ports, state, handler, myself, _id, _name), fields(id = _id.to_string(), name = _name))]
     async fn processing_loop(
-        mut ports: ActorPortSet,
+        mut ports: ActorPortSet<TActor::Msg>,
         state: &mut TActor::State,
         handler: &TActor,
         myself: ActorRef<TActor::Msg>,
@@ -445,7 +448,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
         myself: &ActorRef<TActor::Msg>,
         state: &mut TActor::State,
         handler: &TActor,
-        ports: &mut ActorPortSet,
+        ports: &mut ActorPortSet<TActor::Msg>,
     ) -> Result<ActorLoopResult, ActorProcessingErr> {
         match ports.listen_in_priority().await {
             Ok(actor_port_message) => match actor_port_message {
@@ -532,7 +535,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
         myself: ActorRef<TActor::Msg>,
         state: &mut TActor::State,
         handler: &TActor,
-        mut msg: crate::message::BoxedMessage,
+        mut msg: crate::message::LocalOrSerialized<TActor::Msg>,
     ) -> Result<(), ActorProcessingErr> {
         // panic in order to kill the actor
         #[cfg(feature = "cluster")]
@@ -541,7 +544,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
             // to the remote system for decoding + handling by the real implementation. Therefore `RemoteActor`s
             // can be thought of as a "shim" to a real actor on a remote system
             if !myself.get_id().is_local() {
-                match msg.serialized_msg {
+                match msg.into_serialized() {
                     Some(serialized_msg) => {
                         return handler
                             .handle_serialized(myself, serialized_msg, state)
@@ -559,10 +562,10 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
         // The current [tracing::Span] is retrieved, boxed, and included in every
         // `BoxedMessage` during the conversion of this `TActor::Msg`. It is used
         // to automatically continue tracing span nesting when sending messages to Actors.
-        let current_span_when_message_was_sent = msg.span.take();
+        let current_span_when_message_was_sent = msg.take_span();
 
         // An error here will bubble up to terminate the actor
-        let typed_msg = TActor::Msg::from_boxed(msg)?;
+        let typed_msg = TActor::Msg::decode(msg)?;
 
         if let Some(span) = current_span_when_message_was_sent {
             handler

--- a/ractor_cluster_derive/src/lib.rs
+++ b/ractor_cluster_derive/src/lib.rs
@@ -17,32 +17,34 @@
 //! 1. Non-serializable macros are simply getting `impl ractor::Message for MyStructOrEnum` added onto their struct
 //! 2. Serializable messages have to have a few formatting requirements.
 //!    a. All variants of the enum will be numbered based on their lexicographical ordering, which is sent over-the-wire in order to decode which
-//!    variant was called. This is the `index` field on any variant of `ractor::message::SerializedMessage`
+//!    variant was called. This is the `variant` field on any variant of `ractor::message::SerializedMessage`
 //!    b. All properties of the message **MUST** implement the `ractor::BytesConvertable` trait which means they supply a `to_bytes` and `from_bytes` method. Many
 //!    types are pre-done for you in `ractor`'s definition of the trait
 //!    c. For RPCs, exactly one field must be an `RpcReplyPort<T>` (at any position). Additionally the type of message the channel is expecting back must also implement `ractor::BytesConvertable`
 //!    d. Lastly, for RPCs, they should additionally be decorated with `#[rpc]` on each variant's definition. This helps the macro identify that it
 //!    is an RPC and will need port handler
 //!    e. Both tuple-style (`Variant(A, B)`) and struct-style (`Variant { a: A, b: B }`) fields are supported
+//!    f. Generic types are supported and should include proper where bounds for `BytesConvertable`
 
 extern crate proc_macro;
-
-mod codegen;
-mod ir;
-mod parse;
-
 use proc_macro::TokenStream;
+use quote::format_ident;
 use quote::quote;
+use quote::ToTokens;
+use syn::AngleBracketedGenericArguments;
 use syn::DeriveInput;
+use syn::Fields;
+use syn::Ident;
+use syn::TypePath;
+use syn::Variant;
+use syn::{self};
 
 /// Derive `ractor::Message` for messages that are local-only
 #[proc_macro_derive(RactorMessage)]
 pub fn ractor_message_derive_macro(input: TokenStream) -> TokenStream {
-    let ast: DeriveInput = match syn::parse(input) {
-        Ok(ast) => ast,
-        Err(err) => return err.to_compile_error().into(),
-    };
-
+    // Construct a representation of Rust code as a syntax tree
+    // that we can manipulate
+    let ast: DeriveInput = syn::parse(input).unwrap();
     let name = &ast.ident;
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let gen = quote! {
@@ -62,16 +64,554 @@ pub fn ractor_message_derive_macro(input: TokenStream) -> TokenStream {
 /// 4. Lastly, for RPCs, they should additionally be decorated with `#[rpc]` on each variant's definition. This helps the macro identify that it
 ///    is an RPC and will need port handler
 /// 5. Both tuple-style (`Variant(A, B)`) and struct-style (`Variant { a: A, b: B }`) fields are supported
-/// 6. For backwards compatibility, you can add new variants as long as you don't rename variants until all nodes in the cluster are upgraded.
+/// 6. Generic types are supported and should include proper where bounds for `BytesConvertable`
+/// 7. For backwards compatibility, you can add new variants as long as you don't rename variants until all nodes in the cluster are upgraded.
 #[proc_macro_derive(RactorClusterMessage, attributes(rpc))]
 pub fn ractor_cluster_message_derive_macro(input: TokenStream) -> TokenStream {
-    let ast: DeriveInput = match syn::parse(input) {
-        Ok(ast) => ast,
-        Err(err) => return err.to_compile_error().into(),
-    };
+    // Construct a representation of Rust code as a syntax tree
+    // that we can manipulate
+    let ast: DeriveInput = syn::parse(input).unwrap();
 
-    match parse::parse_cluster_message(&ast) {
-        Ok(parsed) => codegen::expand_cluster_message(&parsed).into(),
-        Err(err) => err.to_compile_error().into(),
+    // Build the trait implementation
+    impl_message_macro(&ast)
+}
+
+fn impl_message_macro(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    // we don't support the derive macro on structs or unions
+    if let syn::Data::Enum(enum_data) = &ast.data {
+        // Build the "serialize()" handler for each variant
+        let serialized_variants = enum_data
+            .variants
+            .iter()
+            .map(impl_variant_serialize)
+            .collect::<Vec<_>>();
+        // Build the deserialize handlers for both casts and calls
+        let casts = enum_data.variants.iter().filter_map(|variant| {
+            let is_call = variant.attrs.iter().any(|attr| attr.path().is_ident("rpc"));
+            if !is_call {
+                Some(impl_cast_variant_deserialize(variant))
+            } else {
+                None
+            }
+        });
+        let calls = enum_data.variants.iter().filter_map(|variant| {
+            let is_call = variant.attrs.iter().any(|attr| attr.path().is_ident("rpc"));
+            if is_call {
+                Some(impl_call_variant_deserialize(variant))
+            } else {
+                None
+            }
+        });
+
+        (quote! {
+            impl #impl_generics ractor::Message for #name #ty_generics #where_clause {
+                fn serializable() -> bool {
+                    // Network serializable message
+                    true
+                }
+
+                fn serialize(self) -> Result<ractor::message::SerializedMessage, ractor::message::DowncastErr> {
+                    use ::ractor::BytesConvertable;
+                    match self {
+                        #( #serialized_variants ),*
+                    }
+                }
+
+                fn deserialize(bytes: ractor::message::SerializedMessage) -> Result<Self, ractor::message::DowncastErr> {
+                    use ::ractor::BytesConvertable;
+                    match bytes {
+                        ractor::message::SerializedMessage::Cast {variant, args, metadata} => {
+                            match variant.as_str() {
+                                #(#casts,)*
+                                _ => {
+                                    // unknown CAST type
+                                    Err(ractor::message::DowncastErr)
+                                }
+                            }
+                        }
+                        ractor::message::SerializedMessage::Call {variant, args, reply, metadata} => {
+                            match variant.as_str() {
+                                #(#calls,)*
+                                _ => {
+                                    // unknown CALL type
+                                    Err(ractor::message::DowncastErr)
+                                }
+                            }
+                        }
+                        _ => {
+                            // call-reply isn't supported here
+                            Err(ractor::message::DowncastErr)
+                        }
+                    }
+                }
+            }
+        }).into()
+    } else {
+        TokenStream::new()
+    }
+}
+
+fn impl_variant_serialize(variant: &Variant) -> impl ToTokens {
+    let name = &variant.ident;
+    let variant_name = name.to_string();
+    let is_call = variant.attrs.iter().any(|attr| attr.path().is_ident("rpc"));
+    if is_call {
+        match &variant.fields {
+            Fields::Unit => panic!("RPC Calls must have a `RpcReplyPort<T>`"),
+            Fields::Unnamed(unnamed_fields) => {
+                // Find the RpcReplyPort field (could be at any position)
+                let fields: Vec<_> = unnamed_fields
+                    .unnamed
+                    .iter()
+                    .enumerate()
+                    .map(|(i, arg)| (format_ident!("field{}", i), &arg.ty))
+                    .collect();
+
+                let port_idx = fields
+                    .iter()
+                    .position(|(_, ty)| {
+                        if let syn::Type::Path(p) = ty {
+                            p.path
+                                .segments
+                                .iter()
+                                .any(|seg| seg.ident == "RpcReplyPort")
+                        } else {
+                            false
+                        }
+                    })
+                    .expect("RPC variant must have exactly one RpcReplyPort field");
+
+                let port_field = &fields[port_idx].0;
+                let port_type = if let syn::Type::Path(path_data) = &fields[port_idx].1 {
+                    get_generic_reply_port_type(path_data)
+                } else {
+                    panic!("No generic arguments on RpcReplyPort!");
+                };
+
+                let target_port = convert_serialize_port(port_field, &port_type);
+
+                let non_port_fields: Vec<_> = fields
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| *i != port_idx)
+                    .map(|(_, f)| f)
+                    .collect();
+
+                let field_names = fields.iter().map(|(a, _)| a);
+                let packed = non_port_fields
+                    .iter()
+                    .map(|(field, arg)| pack_args(field, arg));
+
+                quote! {
+                    Self::#name(#(#field_names),*) => {
+                        let mut __data = vec![];
+                        #(#packed;)*
+                        let __target_port = #target_port;
+                        Ok(ractor::message::SerializedMessage::Call {
+                            variant: #variant_name.to_string(),
+                            args: __data,
+                            reply: __target_port,
+                            metadata: None,
+                        })
+                    }
+                }
+            }
+            Fields::Named(named_fields) => {
+                // Find the RpcReplyPort field
+                let fields: Vec<_> = named_fields
+                    .named
+                    .iter()
+                    .map(|f| {
+                        let field_name = f.ident.as_ref().unwrap();
+                        (field_name.clone(), &f.ty)
+                    })
+                    .collect();
+
+                let port_idx = fields
+                    .iter()
+                    .position(|(_, ty)| {
+                        if let syn::Type::Path(p) = ty {
+                            p.path
+                                .segments
+                                .iter()
+                                .any(|seg| seg.ident == "RpcReplyPort")
+                        } else {
+                            false
+                        }
+                    })
+                    .expect("RPC variant must have exactly one RpcReplyPort field");
+
+                let port_field = &fields[port_idx].0;
+                let port_type = if let syn::Type::Path(path_data) = &fields[port_idx].1 {
+                    get_generic_reply_port_type(path_data)
+                } else {
+                    panic!("No generic arguments on RpcReplyPort!");
+                };
+
+                let target_port = convert_serialize_port(port_field, &port_type);
+
+                let non_port_fields: Vec<_> = fields
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| *i != port_idx)
+                    .collect();
+
+                let field_names = fields.iter().map(|(n, _)| n);
+                let packed = non_port_fields.iter().map(|(_, (field, arg))| {
+                    let field_ident = field;
+                    pack_args(field_ident, arg)
+                });
+
+                quote! {
+                    Self::#name { #(#field_names),* } => {
+                        let mut __data = vec![];
+                        #(#packed;)*
+                        let __target_port = #target_port;
+                        Ok(ractor::message::SerializedMessage::Call {
+                            variant: #variant_name.to_string(),
+                            args: __data,
+                            reply: __target_port,
+                            metadata: None,
+                        })
+                    }
+                }
+            }
+        }
+    } else {
+        match &variant.fields {
+            Fields::Unit => {
+                quote! {
+                    Self::#name => {
+                        Ok(ractor::message::SerializedMessage::Cast {
+                            variant: #variant_name.to_string(),
+                            args: vec![],
+                            metadata: None,
+                        })
+                    }
+                }
+            }
+            Fields::Unnamed(unnamed_fields) => {
+                let fields = unnamed_fields
+                    .unnamed
+                    .iter()
+                    .enumerate()
+                    .map(|(i, arg)| (format_ident!("field{}", i), &arg.ty))
+                    .collect::<Vec<_>>();
+
+                let field_names = fields.iter().map(|(a, _)| a);
+                let packed = fields.iter().map(|(field, arg)| pack_args(field, arg));
+                quote! {
+                    Self::#name(#(#field_names),*) => {
+                        let mut __data = vec![];
+                        #(#packed ;)*
+                        Ok(ractor::message::SerializedMessage::Cast {
+                            variant: #variant_name.to_string(),
+                            args: __data,
+                            metadata: None,
+                        })
+                    }
+                }
+            }
+            Fields::Named(named_fields) => {
+                let fields: Vec<_> = named_fields
+                    .named
+                    .iter()
+                    .map(|f| f.ident.as_ref().unwrap().clone())
+                    .collect();
+
+                let packed = named_fields.named.iter().map(|f| {
+                    let field_name = f.ident.as_ref().unwrap();
+                    pack_args(field_name, &f.ty)
+                });
+
+                quote! {
+                    Self::#name { #(#fields),* } => {
+                        let mut __data = vec![];
+                        #(#packed ;)*
+                        Ok(ractor::message::SerializedMessage::Cast {
+                            variant: #variant_name.to_string(),
+                            args: __data,
+                            metadata: None,
+                        })
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn impl_cast_variant_deserialize(variant: &Variant) -> impl ToTokens {
+    let name = &variant.ident;
+    let variant_name = name.to_string();
+    match &variant.fields {
+        Fields::Unit => {
+            quote! {
+                #variant_name => {
+                    Ok(Self::#name)
+                }
+            }
+        }
+        Fields::Unnamed(unnamed_fields) => {
+            let fields = unnamed_fields
+                .unnamed
+                .iter()
+                .enumerate()
+                .map(|(i, arg)| (format_ident!("field{}", i), &arg.ty))
+                .collect::<Vec<_>>();
+            let field_names: Vec<_> = fields.iter().map(|(a, _)| a.clone()).collect();
+            let unpacked = fields.iter().map(|(field, arg)| unpack_arg(field, arg));
+            quote! {
+                #variant_name => {
+                    let mut ptr = 0usize;
+                    #(#unpacked;)*
+                    Ok(Self::#name(#(#field_names),*))
+                }
+            }
+        }
+        Fields::Named(named_fields) => {
+            let field_idents: Vec<_> = named_fields
+                .named
+                .iter()
+                .map(|f| f.ident.as_ref().unwrap().clone())
+                .collect();
+
+            let unpacked = named_fields.named.iter().map(|f| {
+                let field_name = f.ident.as_ref().unwrap();
+                unpack_arg(field_name, &f.ty)
+            });
+
+            quote! {
+                #variant_name => {
+                    let mut ptr = 0usize;
+                    #(#unpacked;)*
+                    Ok(Self::#name { #(#field_idents),* })
+                }
+            }
+        }
+    }
+}
+
+fn impl_call_variant_deserialize(variant: &Variant) -> impl ToTokens {
+    let name = &variant.ident;
+    let variant_name = name.to_string();
+    match &variant.fields {
+        Fields::Unit => panic!("RPC Calls must have a `RpcReplyPort<T>`"),
+        Fields::Unnamed(unnamed_fields) => {
+            let fields: Vec<_> = unnamed_fields
+                .unnamed
+                .iter()
+                .enumerate()
+                .map(|(i, arg)| (format_ident!("field{}", i), &arg.ty))
+                .collect();
+
+            let port_idx = fields
+                .iter()
+                .position(|(_, ty)| {
+                    if let syn::Type::Path(p) = ty {
+                        p.path
+                            .segments
+                            .iter()
+                            .any(|seg| seg.ident == "RpcReplyPort")
+                    } else {
+                        false
+                    }
+                })
+                .expect("RPC variant must have exactly one RpcReplyPort field");
+
+            let port_field_name = fields[port_idx].0.clone();
+            let port_type = if let syn::Type::Path(path_data) = &fields[port_idx].1 {
+                get_generic_reply_port_type(path_data)
+            } else {
+                panic!("No generic arguments on RpcReplyPort!");
+            };
+
+            // Generate unpacking for non-port fields in the order they appear
+            let unpacked = fields
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| *i != port_idx)
+                .map(|(_, (field, arg))| unpack_arg(field, arg));
+
+            // Collect field names as owned Idents (not iterator) for quote! compatibility
+            let field_names: Vec<_> = fields.iter().map(|(f, _)| f.clone()).collect();
+
+            // Use `reply` from the SerializedMessage::Call { reply, .. } match arm
+            let reply_ident = format_ident!("reply");
+            let target_port = convert_deserialize_port(&reply_ident, &port_type);
+
+            quote! {
+                #variant_name => {
+                    let mut ptr = 0usize;
+                    #(#unpacked;)*
+                    let #port_field_name = #target_port;
+                    Ok(Self::#name(#(#field_names),*))
+                }
+            }
+        }
+        Fields::Named(named_fields) => {
+            let fields: Vec<_> = named_fields
+                .named
+                .iter()
+                .map(|f| {
+                    let field_name = f.ident.as_ref().unwrap();
+                    (field_name.clone(), &f.ty)
+                })
+                .collect();
+
+            let port_idx = fields
+                .iter()
+                .position(|(_, ty)| {
+                    if let syn::Type::Path(p) = ty {
+                        p.path
+                            .segments
+                            .iter()
+                            .any(|seg| seg.ident == "RpcReplyPort")
+                    } else {
+                        false
+                    }
+                })
+                .expect("RPC variant must have exactly one RpcReplyPort field");
+
+            let port_field_name = fields[port_idx].0.clone();
+            let port_type = if let syn::Type::Path(path_data) = &fields[port_idx].1 {
+                get_generic_reply_port_type(path_data)
+            } else {
+                panic!("No generic arguments on RpcReplyPort!");
+            };
+
+            // Generate unpacking for non-port fields in the order they appear
+            let unpacked = fields
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| *i != port_idx)
+                .map(|(_, (field, _arg))| {
+                    unpack_arg(
+                        field,
+                        &named_fields
+                            .named
+                            .iter()
+                            .find(|f| f.ident.as_ref().unwrap() == field)
+                            .unwrap()
+                            .ty,
+                    )
+                });
+
+            // Collect field names as owned Idents (not iterator) for quote! compatibility
+            let field_list: Vec<_> = fields.iter().map(|(f, _)| f.clone()).collect();
+            // Use `reply` from the SerializedMessage::Call { reply, .. } match arm
+            let reply_ident = format_ident!("reply");
+            let target_port = convert_deserialize_port(&reply_ident, &port_type);
+
+            quote! {
+                #variant_name => {
+                    let mut ptr = 0usize;
+                    #(#unpacked;)*
+                    let #port_field_name = #target_port;
+                    Ok(Self::#name { #(#field_list),* })
+                }
+            }
+        }
+    }
+}
+
+fn pack_args(field: &Ident, target_type: &syn::Type) -> impl ToTokens {
+    quote! {
+        {
+            let __arg_data = <#target_type as ractor::BytesConvertable>::into_bytes(#field);
+            let __arg_len = (__arg_data.len() as u64).to_be_bytes();
+            __data.extend(__arg_len);
+            __data.extend(__arg_data);
+        }
+    }
+}
+
+fn unpack_arg(field: &Ident, target_type: &syn::Type) -> impl ToTokens {
+    quote! {
+        let #field = {
+            let mut len_bytes = [0u8; 8];
+            len_bytes.copy_from_slice(&args[ptr..ptr+8]);
+            let len = u64::from_be_bytes(len_bytes) as usize;
+
+            ptr += 8;
+            let data_bytes = args[ptr..ptr+len].to_vec();
+            let t_result = <#target_type as ractor::BytesConvertable>::from_bytes(data_bytes);
+            ptr += len;
+            t_result
+        };
+    }
+}
+
+fn convert_deserialize_port(
+    the_port: &Ident,
+    port_type: &AngleBracketedGenericArguments,
+) -> impl ToTokens {
+    let generic_args = &port_type.args;
+    // TODO: catch unwind for the conversion? returning Err(DowncastErr)
+    quote! {
+        {
+            let (tx, rx) = ractor::concurrency::oneshot::#port_type();
+            let o_timeout = #the_port.get_timeout();
+            ractor::concurrency::spawn(async move {
+                if let Some(timeout) = o_timeout {
+                    if let Ok(Ok(result)) = ractor::concurrency::timeout(timeout, rx).await {
+                        let _ = #the_port.send(<#generic_args as BytesConvertable>::into_bytes(result));
+                    }
+                } else {
+                    if let Ok(result) = rx.await {
+                        let _ = #the_port.send(<#generic_args as BytesConvertable>::into_bytes(result));
+                    }
+                }
+            });
+            if let Some(timeout) = o_timeout {
+                ractor::RpcReplyPort::<_>::from((tx, timeout))
+            } else {
+                ractor::RpcReplyPort::<_>::from(tx)
+            }
+        }
+    }
+}
+
+fn convert_serialize_port(
+    the_port: &Ident,
+    target_type: &AngleBracketedGenericArguments,
+) -> impl ToTokens {
+    // TODO: catch unwind for the conversion? returning Err(DowncastErr)
+    let generic_args = &target_type.args;
+    quote! {
+        {
+            let (tx, rx) = ractor::concurrency::oneshot();
+            let o_timeout = #the_port.get_timeout();
+            ractor::concurrency::spawn(async move {
+                if let Some(timeout) = o_timeout {
+                    if let Ok(Ok(result)) = ractor::concurrency::timeout(timeout, rx).await {
+                        let typed_result = <#generic_args as ractor::BytesConvertable>::from_bytes(result);
+                        let _ = #the_port.send(typed_result);
+                    }
+                } else {
+                    if let Ok(result) = rx.await {
+                        let typed_result = <#generic_args as ractor::BytesConvertable>::from_bytes(result);
+                        let _ = #the_port.send(typed_result);
+                    }
+                }
+            });
+            if let Some(timeout) = o_timeout {
+                ractor::RpcReplyPort::<_>::from((tx, timeout))
+            } else {
+                ractor::RpcReplyPort::<_>::from(tx)
+            }
+        }
+    }
+}
+
+fn get_generic_reply_port_type(path_data: &TypePath) -> AngleBracketedGenericArguments {
+    if let syn::PathArguments::AngleBracketed(generic_args) =
+        &path_data.path.segments.first().unwrap().arguments
+    {
+        generic_args.clone()
+    } else {
+        panic!("RpcReplyPort failed to get generic args");
     }
 }


### PR DESCRIPTION
This is an extension of the message boxing approach proposed in PR #370. This however continues the improvements to remove additional type information that isn't necessary.

This diff includes the removal of the BoxedMessage struct in favor of a crate-private RactorMessage trait which adds the necessary extension methods, only within the `ractor`
context so as the privatize that functionality, as it was an unintentional leak anyways. This of course is a semver break as a public type is going away, but it should have been unused
anyways in all contexts. Additionally `BoxedDowncastErr` is renamed to `DowncastErr` as we are no longer boxing the message, but again this error variant shouldn't really be used publicly.

Will re-run the performance benchmarks present in #370 and past as a PR comment once ready