### PR TITLE
Register named remote actors and avoid late PgLeave respawns

### DIFF
--- a/ractor/src/actor/actor_cell.rs
+++ b/ractor/src/actor/actor_cell.rs
@@ -285,7 +285,19 @@ impl ActorCell {
         };
 
         if let Some(r_name) = registered_name {
-            crate::registry::register(r_name, cell.clone())?;
+            if let Err(crate::registry::ActorRegistryErr::AlreadyRegistered(_)) =
+                crate::registry::register(r_name.clone(), cell.clone())
+            {
+                // A local actor (or a previous remote shim) already holds this name.
+                // Skip registration and log — do not fail the spawn. The actor is still
+                // reachable by pid; callers must use `registry::where_is` rather than
+                // `ActorRef::where_is` to avoid message-type mismatches anyway.
+                tracing::warn!(
+                    "Remote actor name '{}' is already taken in the local registry; \
+                     spawning shim without registering the name",
+                    r_name
+                );
+            }
         }
 
         Ok((

--- a/ractor/src/actor/actor_cell.rs
+++ b/ractor/src/actor/actor_cell.rs
@@ -278,14 +278,16 @@ impl ActorCell {
             return Err(SpawnErr::StartupFailed(From::from("Cannot create a new remote actor handler without the actor id being marked as a remote actor!")));
         }
 
+        let registered_name = name.clone();
         let (props, rx1, rx2, rx3, rx4) = ActorProperties::new_remote::<TActor>(name, id);
         let cell = Self {
             inner: Arc::new(props),
         };
-        // NOTE: remote actors don't appear in the name registry
-        // if let Some(r_name) = name {
-        //     crate::registry::register(r_name, cell.clone())?;
-        // }
+
+        if let Some(r_name) = registered_name {
+            crate::registry::register(r_name, cell.clone())?;
+        }
+
         Ok((
             cell,
             ActorPortSet {

--- a/ractor/src/actor/actor_ref.rs
+++ b/ractor/src/actor/actor_ref.rs
@@ -114,6 +114,13 @@ where
     /// Try and retrieve a strongly-typed actor from the registry.
     ///
     /// Alias of [crate::registry::where_is]
+    ///
+    /// **Note on remote actors:** when the `cluster` feature is enabled, named remote actors
+    /// are registered in the same global registry. However, remote actor shims are internally
+    /// typed as `RemoteActorMessage`, not the original actor's message type. This means calling
+    /// `ActorRef::<MyMsg>::where_is(name)` for a remote actor will return `None` even if the
+    /// name is registered. To look up a remote actor by name, use [`crate::registry::where_is`]
+    /// directly to obtain the untyped [`crate::ActorCell`].
     pub fn where_is(name: ActorName) -> Option<crate::actor::ActorRef<TMessage>> {
         if let Some(actor) = crate::registry::where_is(name) {
             // check the type id when pulling from the registry

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -245,7 +245,7 @@ mod pid_registry_tests {
         }
 
         let remote_pid = ActorId::Remote { node_id: 1, pid: 2 };
-        let remote_name = "remote_actor_with_name".to_string();
+        let remote_name = "pid_registry_remote_actor_with_name".to_string();
 
         let (actor, handle) = Actor::spawn(None, EmptyActor, ())
             .await

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -228,6 +228,55 @@ mod pid_registry_tests {
         not(all(target_arch = "wasm32", target_os = "unknown")),
         tracing_test::traced_test
     )]
+    async fn remote_actor_with_name_is_registered() {
+        struct EmptyActor;
+        #[cfg_attr(feature = "async-trait", crate::async_trait)]
+        impl Actor for EmptyActor {
+            type Msg = ();
+            type State = ();
+            type Arguments = ();
+            async fn pre_start(
+                &self,
+                _this_actor: crate::ActorRef<Self::Msg>,
+                _: (),
+            ) -> Result<Self::State, ActorProcessingErr> {
+                Ok(())
+            }
+        }
+
+        let remote_pid = ActorId::Remote { node_id: 1, pid: 2 };
+        let remote_name = "remote_actor_with_name".to_string();
+
+        let (actor, handle) = Actor::spawn(None, EmptyActor, ())
+            .await
+            .expect("Actor failed to start");
+
+        let (remote_actor, remote_handle) = crate::ActorRuntime::spawn_linked_remote(
+            Some(remote_name.clone()),
+            RemoteActor,
+            remote_pid,
+            (),
+            actor.get_cell(),
+        )
+        .await
+        .expect("Failed to start remote actor");
+
+        assert!(crate::registry::where_is(remote_name.clone()).is_some());
+        assert!(crate::registry::where_is_pid(remote_actor.get_id()).is_none());
+
+        remote_actor.stop(None);
+        remote_handle.await.expect("Failed to stop remote actor");
+        actor.stop(None);
+        handle.await.expect("Failed to clean stop the actor");
+
+        assert!(crate::registry::where_is(remote_name).is_none());
+    }
+
+    #[crate::concurrency::test]
+    #[cfg_attr(
+        not(all(target_arch = "wasm32", target_os = "unknown")),
+        tracing_test::traced_test
+    )]
     async fn test_basic_registation() {
         struct EmptyActor;
 

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -277,6 +277,68 @@ mod pid_registry_tests {
         not(all(target_arch = "wasm32", target_os = "unknown")),
         tracing_test::traced_test
     )]
+    async fn remote_actor_name_collision_with_local_does_not_fail_spawn() {
+        struct LocalActor;
+        #[cfg_attr(feature = "async-trait", crate::async_trait)]
+        impl Actor for LocalActor {
+            type Msg = ();
+            type State = ();
+            type Arguments = ();
+            async fn pre_start(
+                &self,
+                _: crate::ActorRef<Self::Msg>,
+                _: (),
+            ) -> Result<Self::State, ActorProcessingErr> {
+                Ok(())
+            }
+        }
+
+        let shared_name = "collision_test_actor".to_string();
+        let remote_pid = ActorId::Remote {
+            node_id: 1,
+            pid: 99,
+        };
+
+        let (local_actor, local_handle) = Actor::spawn(Some(shared_name.clone()), LocalActor, ())
+            .await
+            .expect("Failed to start local actor");
+
+        assert!(crate::registry::where_is(shared_name.clone()).is_some());
+
+        let (supervisor, sup_handle) = Actor::spawn(None, LocalActor, ())
+            .await
+            .expect("Failed to start supervisor");
+
+        // Spawning a remote actor whose name is already taken must not fail.
+        let (remote_actor, remote_handle) = crate::ActorRuntime::spawn_linked_remote(
+            Some(shared_name.clone()),
+            RemoteActor,
+            remote_pid,
+            (),
+            supervisor.get_cell(),
+        )
+        .await
+        .expect("Remote spawn must succeed even when the name is already registered");
+
+        // The local actor still owns the name — the remote shim did not evict it.
+        let registered =
+            crate::registry::where_is(shared_name.clone()).expect("Name must still be registered");
+        assert_eq!(
+            registered.get_id(),
+            local_actor.get_id(),
+            "Local actor must still own the name after remote spawn collision"
+        );
+
+        // The remote shim itself is still alive and functional.
+        assert_eq!(remote_actor.get_id(), remote_pid);
+
+        remote_actor.stop(None);
+        remote_handle.await.expect("Failed to stop remote actor");
+        local_actor.stop(None);
+        local_handle.await.expect("Failed to stop local actor");
+        supervisor.stop(None);
+        sup_handle.await.expect("Failed to stop supervisor");
+    }
     async fn test_basic_registation() {
         struct EmptyActor;
 

--- a/ractor_cluster/src/node/node_session.rs
+++ b/ractor_cluster/src/node/node_session.rs
@@ -1047,15 +1047,9 @@ impl Actor for NodeSession {
                         actor.get_id(),
                     );
                     actor.kill();
-
-                    // NOTE: This is a legitimate panic of the `RemoteActor`, not the actor on the remote machine panicking (which
-                    // is handled by the remote actor's supervisor). Therefore we should re-spawn the actor, and if we can't we
-                    // should ourself die. Something is seriously wrong...
-                    let pid = actor.get_id().pid();
-                    let name = actor.get_name();
-                    let _ = self
-                        .get_or_spawn_remote_actor(&myself, name, pid, state)
-                        .await?;
+                    // Do not immediately respawn the remote shim here. The actor may still have
+                    // late lifecycle / process-group messages in flight, and respawning with the
+                    // same pid reintroduces stale-message races and registry collisions.
                 } else {
                     tracing::error!("NodeSesion {:?} received an unknown child panic superivision message from {} - '{msg}'",
                         state.name,

--- a/ractor_cluster/src/node/node_session.rs
+++ b/ractor_cluster/src/node/node_session.rs
@@ -584,12 +584,20 @@ impl NodeSession {
                 }
                 control_protocol::control_message::Msg::PgLeave(leave) => {
                     let mut cells = vec![];
-                    for control_protocol::Actor { pid, .. } in leave.actors {
+                    for control_protocol::Actor { pid, name } in leave.actors {
                         if let Some(actor) = state.remote_actors.get(&pid) {
                             cells.push(actor.get_cell());
+                        } else {
+                            tracing::debug!(
+                                "Ignoring PG leave for unknown remote actor {:?} on node {}",
+                                name,
+                                self.node_id
+                            );
                         }
                     }
-                    // join the remote actors to the local PG group
+                    // Remove the remote actors from the local PG group if we still have a live shim.
+                    // If the actor already terminated locally, there is no shim left to update and
+                    // the group membership will already have been cleaned up by the actor shutdown path.
                     if !cells.is_empty() {
                         tracing::debug!(
                             "PG Leave scope '{}' and group '{}' for {} remote actors",

--- a/ractor_cluster/src/node/node_session/tests.rs
+++ b/ractor_cluster/src/node/node_session/tests.rs
@@ -874,6 +874,81 @@ async fn node_session_handle_control() {
 }
 
 #[ractor::concurrency::test]
+async fn actor_failed_does_not_respawn_remote_actor() {
+    let (dummy_server, dummy_shandle) = Actor::spawn(None, DummyNodeServer, ())
+        .await
+        .expect("Failed to start dummy node server");
+    let (dummy_session, dummy_chandle) = Actor::spawn(None, DummyNodeSession, ())
+        .await
+        .expect("Failed to start dummy node session");
+
+    let server_ref: ActorRef<super::NodeServerMessage> = dummy_server.get_cell().into();
+    let session_ref: ActorRef<NodeSessionMessage> = dummy_session.get_cell().into();
+
+    let session = NodeSession {
+        cookie: "cookie".to_string(),
+        is_server: true,
+        node_id: 1,
+        this_node_name: auth_protocol::NameMessage {
+            name: "myself".to_string(),
+            flags: Some(auth_protocol::NodeFlags { version: 1 }),
+            connection_string: "localhost:123".to_string(),
+        },
+        node_server: server_ref.clone(),
+        connection_mode: NodeConnectionMode::Isolated,
+    };
+
+    let mut state = NodeSessionState {
+        auth: AuthenticationState::AsClient(auth::ClientAuthenticationProcess::Ok),
+        ready: ReadyState::Open,
+        local_addr: SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0),
+        peer_addr: SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0),
+        name: None,
+        remote_actors: HashMap::new(),
+        tcp: None,
+        epoch: Instant::now(),
+    };
+
+    let remote_name = "node_session_actor_failed_remote_actor".to_string();
+
+    let (remote_actor, remote_handle) = ractor::ActorRuntime::spawn_linked_remote(
+        Some(remote_name.clone()),
+        crate::remote_actor::RemoteActor,
+        ractor::ActorId::Remote {
+            node_id: 1,
+            pid: 43,
+        },
+        session_ref.clone(),
+        dummy_session.get_cell(),
+    )
+    .await
+    .expect("Failed to start remote actor");
+
+    state.remote_actors.insert(43, remote_actor.clone());
+
+    assert!(ractor::registry::where_is(remote_name.clone()).is_some());
+
+    session
+        .handle_supervisor_evt(
+            session_ref.clone(),
+            SupervisionEvent::ActorFailed(remote_actor.get_cell(), "boom".to_string().into()),
+            &mut state,
+        )
+        .await
+        .expect("Failed to process supervisor event");
+
+    remote_handle.await.expect("Failed to stop remote actor");
+
+    assert!(state.remote_actors.is_empty());
+    assert!(ractor::registry::where_is(remote_name).is_none());
+
+    dummy_server.stop(None);
+    dummy_session.stop(None);
+    dummy_shandle.await.unwrap();
+    dummy_chandle.await.unwrap();
+}
+
+#[ractor::concurrency::test]
 async fn pg_leave_after_terminate_does_not_respawn_remote_actor() {
     let (dummy_server, dummy_shandle) = Actor::spawn(None, DummyNodeServer, ())
         .await

--- a/ractor_cluster/src/node/node_session/tests.rs
+++ b/ractor_cluster/src/node/node_session/tests.rs
@@ -872,3 +872,107 @@ async fn node_session_handle_control() {
     dummy_shandle.await.unwrap();
     dummy_chandle.await.unwrap();
 }
+
+#[ractor::concurrency::test]
+async fn pg_leave_after_terminate_does_not_respawn_remote_actor() {
+    let (dummy_server, dummy_shandle) = Actor::spawn(None, DummyNodeServer, ())
+        .await
+        .expect("Failed to start dummy node server");
+    let (dummy_session, dummy_chandle) = Actor::spawn(None, DummyNodeSession, ())
+        .await
+        .expect("Failed to start dummy node session");
+
+    let server_ref: ActorRef<super::NodeServerMessage> = dummy_server.get_cell().into();
+    let session_ref: ActorRef<NodeSessionMessage> = dummy_session.get_cell().into();
+
+    let session = NodeSession {
+        cookie: "cookie".to_string(),
+        is_server: true,
+        node_id: 1,
+        this_node_name: auth_protocol::NameMessage {
+            name: "myself".to_string(),
+            flags: Some(auth_protocol::NodeFlags { version: 1 }),
+            connection_string: "localhost:123".to_string(),
+        },
+        node_server: server_ref.clone(),
+        connection_mode: NodeConnectionMode::Isolated,
+    };
+
+    let mut state = NodeSessionState {
+        auth: AuthenticationState::AsClient(auth::ClientAuthenticationProcess::Ok),
+        ready: ReadyState::Open,
+        local_addr: SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0),
+        peer_addr: SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0),
+        name: None,
+        remote_actors: HashMap::new(),
+        tcp: None,
+        epoch: Instant::now(),
+    };
+
+    let remote_name = "node_session_pg_leave_remote_actor".to_string();
+
+    session
+        .handle_control(
+            &mut state,
+            control_protocol::ControlMessage {
+                msg: Some(control_protocol::control_message::Msg::Spawn(
+                    control_protocol::Spawn {
+                        actors: vec![control_protocol::Actor {
+                            name: Some(remote_name.clone()),
+                            pid: 43,
+                        }],
+                    },
+                )),
+            },
+            session_ref.clone(),
+        )
+        .await
+        .expect("Failed to process control message");
+
+    assert_eq!(1, state.remote_actors.len());
+    assert!(ractor::registry::where_is(remote_name.clone()).is_some());
+
+    session
+        .handle_control(
+            &mut state,
+            control_protocol::ControlMessage {
+                msg: Some(control_protocol::control_message::Msg::Terminate(
+                    control_protocol::Terminate { ids: vec![43] },
+                )),
+            },
+            session_ref.clone(),
+        )
+        .await
+        .expect("Failed to process control message");
+
+    assert!(state.remote_actors.is_empty());
+    assert!(ractor::registry::where_is(remote_name.clone()).is_none());
+
+    session
+        .handle_control(
+            &mut state,
+            control_protocol::ControlMessage {
+                msg: Some(control_protocol::control_message::Msg::PgLeave(
+                    control_protocol::PgLeave {
+                        scope: "node_session_test_scope".to_string(),
+                        group: "node_session_handle_control".to_string(),
+                        actors: vec![control_protocol::Actor {
+                            name: Some(remote_name.clone()),
+                            pid: 43,
+                        }],
+                    },
+                )),
+            },
+            session_ref,
+        )
+        .await
+        .expect("Failed to process control message");
+
+    assert!(state.remote_actors.is_empty());
+    assert!(ractor::registry::where_is(remote_name).is_none());
+
+    dummy_server.stop(None);
+    dummy_session.stop(None);
+    dummy_shandle.await.unwrap();
+    dummy_chandle.await.unwrap();
+}


### PR DESCRIPTION
### Summary
This PR makes named remote actors visible in the local named registry, matching the behavior of local actors. It also closes several lifecycle safety gaps that would have caused registry collisions and stale-message races.

### Motivation
Addresses #93: "Remote actors don't appear in the local registry".

Remote actors already behave like local actors in most ways, but their names were not exposed through `ractor::registry::where_is(...)`. That made name-based lookup inconsistent and reduced the usefulness of remote actors in cluster setups.

### What changed

**`ractor/src/actor/actor_cell.rs`**
- Re-enabled name registration for remote actors in `ActorCell::new_remote`
- Name collisions (remote name already taken by a local actor) now log a `warn!` and skip registration instead of returning a hard `SpawnErr`. The shim is still spawned and reachable by pid.

**`ractor/src/actor/actor_ref.rs`**
- Documented that `ActorRef::<T>::where_is` returns `None` for remote actors because remote shims are typed as `RemoteActorMessage` internally. Callers should use `registry::where_is` directly for untyped remote lookups.

**`ractor_cluster/src/node/node_session.rs`**
- `ActorFailed` for a remote shim: kill and remove without immediately respawning. Respawning with the same pid reintroduces stale-message races and registry collisions; the remote node controls re-announcement via a new `Spawn` control message.
- `PgLeave` for an unknown pid: log a debug message and skip instead of recreating the shim. If the actor already terminated locally, group membership was already cleaned up by the shutdown path.

**PID registry behavior unchanged:**
- Local actors still register in the PID registry
- Remote actors do not register in the PID registry

### Regression tests added
- Named remote actor appears in `registry::where_is(...)` and is removed on shutdown
- Remote spawn with a colliding local name succeeds without evicting the local actor
- `ActorFailed` on a remote shim does not respawn it
- Late `PgLeave` after remote actor termination does not respawn the shim

### Testing
- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`
- `cargo test -p ractor --features cluster remote_actor_with_name_is_registered -- --nocapture`
- `cargo test -p ractor --features cluster remote_actor_name_collision_with_local_does_not_fail_spawn -- --nocapture`
- `cargo test -p ractor_cluster node_session_handle_control -- --nocapture`
- `cargo test -p ractor_cluster actor_failed_does_not_respawn_remote_actor -- --nocapture`
- `cargo test -p ractor_cluster pg_leave_after_terminate_does_not_respawn_remote_actor -- --nocapture`
