### PR TITLE
Save allocations in registry functions

### DIFF
--- a/ractor/src/actor/actor_ref.rs
+++ b/ractor/src/actor/actor_ref.rs
@@ -8,7 +8,6 @@
 use std::marker::PhantomData;
 
 use super::ActorCell;
-use crate::ActorName;
 use crate::Message;
 use crate::MessagingErr;
 use crate::SupervisionEvent;
@@ -114,7 +113,10 @@ where
     /// Try and retrieve a strongly-typed actor from the registry.
     ///
     /// Alias of [crate::registry::where_is]
-    pub fn where_is(name: ActorName) -> Option<crate::actor::ActorRef<TMessage>> {
+    pub fn where_is<K>(name: K) -> Option<crate::actor::ActorRef<TMessage>>
+    where
+        K: AsRef<str>,
+    {
         if let Some(actor) = crate::registry::where_is(name) {
             // check the type id when pulling from the registry
             let check = actor.is_message_type_of::<TMessage>();

--- a/ractor/src/registry.rs
+++ b/ractor/src/registry.rs
@@ -82,6 +82,8 @@
 
 use std::sync::Arc;
 
+use dashmap::mapref::entry::Entry::Occupied;
+use dashmap::mapref::entry::Entry::Vacant;
 use dashmap::DashMap;
 use once_cell::sync::OnceCell;
 
@@ -118,13 +120,14 @@ fn get_actor_registry<'a>() -> &'a Arc<DashMap<ActorName, ActorCell>> {
 /// Put an actor into the registry
 pub(crate) fn register<K>(name: K, actor: ActorCell) -> Result<(), ActorRegistryErr>
 where
-    K: Into<String> + AsRef<str>,
+    K: Into<String>,
 {
-    if get_actor_registry().get(name.as_ref()).is_some() {
-        Err(ActorRegistryErr::AlreadyRegistered(name.into()))
-    } else {
-        get_actor_registry().insert(name.into(), actor);
-        Ok(())
+    match get_actor_registry().entry(name.into()) {
+        Occupied(occupied) => Err(ActorRegistryErr::AlreadyRegistered(occupied.key().clone())),
+        Vacant(vacancy) => {
+            vacancy.insert(actor);
+            Ok(())
+        }
     }
 }
 

--- a/ractor/src/registry.rs
+++ b/ractor/src/registry.rs
@@ -82,8 +82,6 @@
 
 use std::sync::Arc;
 
-use dashmap::mapref::entry::Entry::Occupied;
-use dashmap::mapref::entry::Entry::Vacant;
 use dashmap::DashMap;
 use once_cell::sync::OnceCell;
 
@@ -118,20 +116,25 @@ fn get_actor_registry<'a>() -> &'a Arc<DashMap<ActorName, ActorCell>> {
 }
 
 /// Put an actor into the registry
-pub(crate) fn register(name: ActorName, actor: ActorCell) -> Result<(), ActorRegistryErr> {
-    match get_actor_registry().entry(name.clone()) {
-        Occupied(_) => Err(ActorRegistryErr::AlreadyRegistered(name)),
-        Vacant(vacancy) => {
-            vacancy.insert(actor);
-            Ok(())
-        }
+pub(crate) fn register<K>(name: K, actor: ActorCell) -> Result<(), ActorRegistryErr>
+where
+    K: Into<String> + AsRef<str>,
+{
+    if get_actor_registry().get(name.as_ref()).is_some() {
+        Err(ActorRegistryErr::AlreadyRegistered(name.into()))
+    } else {
+        get_actor_registry().insert(name.into(), actor);
+        Ok(())
     }
 }
 
 /// Remove an actor from the registry given it's actor name
-pub(crate) fn unregister(name: ActorName) {
+pub(crate) fn unregister<K>(name: K)
+where
+    K: AsRef<str>,
+{
     if let Some(reg) = ACTOR_REGISTRY.get() {
-        let _ = reg.remove(&name);
+        let _ = reg.remove(name.as_ref());
     }
 }
 
@@ -141,9 +144,12 @@ pub(crate) fn unregister(name: ActorName) {
 ///
 /// Returns: Some(actor) on successful identification of an actor, None if
 /// actor not registered
-pub fn where_is(name: ActorName) -> Option<ActorCell> {
+pub fn where_is<K>(name: K) -> Option<ActorCell>
+where
+    K: AsRef<str>,
+{
     let reg = get_actor_registry();
-    reg.get(&name).map(|v| v.value().clone())
+    reg.get(name.as_ref()).map(|v| v.value().clone())
 }
 
 /// Returns a list of names that have been registered


### PR DESCRIPTION
## Summary

In researching the registry functions, I saw that they all take a `String`. This is not necessary in `unregister` and `where_is` because we just immediately take the reference of that `String`. This also forces the caller to allocate every time they want to look up an actor.

By modifying this to a `K: AsRef<str>`, we can take `String` or `&str` while still supporting all codepaths today that use the full String.

Second, the `register` function clones the input String for every lookup, which results in an extra `.clone()` on every insert despite it not being needed. 

We can instead move this `.clone()` inside of the error case exclusively *and* use similar generics to allow for any str-like type on `register`.

## Test Plan

`cargo check` and `cargo test`