### PR TITLE
Update rand to 0.10 and getrandom to 0.4

### DIFF
--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -70,7 +70,7 @@ backtrace = "0.3"
 function_name = "0.3"
 paste = "1"
 serial_test = "3.0.0"
-rand = "0.8"
+rand = "0.10"
 tracing-glog = "0.4"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
@@ -94,7 +94,7 @@ wasm-bindgen-test = "0.3.50"
 # 'getrandom' isn't used directly, but it's used by a dependency, and, for WASM, we need to enable the feature 'js'.
 #   https://docs.rs/getrandom/latest/getrandom/#webassembly-support
 #
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
 criterion = { version = "0.8", default-features = false }
 
 [[bench]]

--- a/ractor/examples/monte_carlo.rs
+++ b/ractor/examples/monte_carlo.rs
@@ -24,8 +24,8 @@ use ractor::Actor;
 use ractor::ActorId;
 use ractor::ActorProcessingErr;
 use ractor::ActorRef;
-use rand::thread_rng;
-use rand::Rng;
+use rand::rng;
+use rand::RngExt;
 
 // ================== Player Actor ================== //
 
@@ -59,8 +59,8 @@ impl GameState {
     /// On average, the player will win their roll 49 out of 100 times, resulting in a house edge
     /// of 2%
     fn roll_dice() -> bool {
-        let mut rng = thread_rng();
-        matches!(rng.gen_range(0..101), x if x > 51)
+        let mut rng = rng();
+        matches!(rng.random_range(0..101), x if x > 51)
     }
 }
 

--- a/ractor/src/serialization.rs
+++ b/ractor/src/serialization.rs
@@ -203,16 +203,16 @@ mod impls {
 
 #[cfg(test)]
 mod tests {
-    use rand::distributions::Alphanumeric;
-    use rand::thread_rng;
-    use rand::Rng;
+    use rand::distr::Alphanumeric;
+    use rand::rng;
+    use rand::RngExt;
 
     use super::BytesConvertable;
     use crate::message::BoxedDowncastErr;
     use crate::Message;
 
     fn random_string() -> String {
-        thread_rng()
+        rng()
             .sample_iter(&Alphanumeric)
             .take(30)
             .map(char::from)
@@ -224,7 +224,7 @@ mod tests {
             paste::item! {
                 #[test]
                 fn [< test_bytes_conversion_ $ty >] () {
-                    let test_data: $ty = rand::thread_rng().gen();
+                    let test_data: $ty = rand::rng().random();
                     let bytes = test_data.clone().into_bytes();
                     let back = <$ty as BytesConvertable>::from_bytes(bytes);
                     assert_eq!(test_data, back);
@@ -242,9 +242,9 @@ mod tests {
             paste::item! {
                 #[test]
                 fn [< test_bytes_conversion_vec_ $ty >] () {
-                    let mut rng = rand::thread_rng();
-                    let num_pts: usize = rng.gen_range(10..50);
-                    let test_data = (0..num_pts).into_iter().map(|_| rng.gen()).collect::<Vec<$ty>>();
+                    let mut rng = rand::rng();
+                    let num_pts: usize = rng.random_range(10..50);
+                    let test_data = (0..num_pts).into_iter().map(|_| rng.random()).collect::<Vec<$ty>>();
 
                     let bytes = test_data.clone().into_bytes();
                     let back = <Vec<$ty> as BytesConvertable>::from_bytes(bytes);

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -32,7 +32,7 @@ prost = { version = "0.14" }
 prost-types = { version = "0.14" }
 ractor = { version = "0.15.0", default-features = false, features = ["tokio_runtime", "message_span_propogation", "cluster"], path = "../ractor" }
 ractor_cluster_derive = { version = "0.15.0", path = "../ractor_cluster_derive" }
-rand = "0.8"
+rand = "0.10"
 socket2 = { version = "0.6", features = ["all"] }
 sha2 = "0.11"
 tokio = { version = "1", features = ["rt", "time", "sync", "macros", "net", "io-util", "tracing"]}

--- a/ractor_cluster/src/node/auth.rs
+++ b/ractor_cluster/src/node/auth.rs
@@ -6,7 +6,7 @@
 //! Define's a node's authentication process between peers. Definition
 //! can be found in [Erlang's handshake](https://www.erlang.org/doc/apps/erts/erl_dist_protocol.html)
 
-use rand::RngCore;
+use rand::Rng;
 
 use crate::hash::Digest;
 use crate::protocol::auth as proto;
@@ -50,7 +50,7 @@ impl ServerAuthenticationProcess {
 
     pub(crate) fn start_challenge(&self, cookie: &'_ str) -> Self {
         if matches!(self, Self::WaitingOnClientStatus | Self::HavePeerName(_)) {
-            let challenge = rand::thread_rng().next_u32();
+            let challenge = rand::rng().next_u32();
             let digest = crate::hash::challenge_digest(cookie, challenge);
             Self::WaitingOnClientChallengeReply(challenge, digest)
         } else {
@@ -142,7 +142,7 @@ impl ClientAuthenticationProcess {
                     if let Self::WaitingForServerChallenge(_) = &self {
                         let server_digest =
                             crate::hash::challenge_digest(cookie, challenge_msg.challenge);
-                        let challenge = rand::thread_rng().next_u32();
+                        let challenge = rand::rng().next_u32();
                         let expected_digest = crate::hash::challenge_digest(cookie, challenge);
                         return Self::WaitingForServerChallengeAck(
                             challenge_msg,

--- a/ractor_cluster/src/node/node_session.rs
+++ b/ractor_cluster/src/node/node_session.rs
@@ -26,7 +26,7 @@ use ractor::ActorProcessingErr;
 use ractor::ActorRef;
 use ractor::SpawnErr;
 use ractor::SupervisionEvent;
-use rand::Rng;
+use rand::RngExt;
 use tokio::time::Duration;
 
 use super::auth;
@@ -878,9 +878,7 @@ impl NodeSessionState {
     }
 
     fn get_send_delay() -> Duration {
-        Duration::from_millis(
-            rand::thread_rng().gen_range(MIN_PING_LATENCY_MS..MAX_PING_LATENCY_MS),
-        )
+        Duration::from_millis(rand::rng().random_range(MIN_PING_LATENCY_MS..MAX_PING_LATENCY_MS))
     }
 }
 

--- a/ractor_cluster_integration_tests/Cargo.toml
+++ b/ractor_cluster_integration_tests/Cargo.toml
@@ -23,7 +23,7 @@ async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
 ractor = { default-features = false, features = ["tokio_runtime", "message_span_propogation", "cluster"], path = "../ractor" }
 ractor_cluster = { path = "../ractor_cluster" }
-rand = "0.8"
+rand = "0.10"
 tokio-rustls = { version = "0.26" }
 rustls-pemfile = "2.1"
 rustyrepl = { version = "0.2", features = ["async"] }

--- a/ractor_cluster_integration_tests/src/tests/mod.rs
+++ b/ractor_cluster_integration_tests/src/tests/mod.rs
@@ -6,9 +6,9 @@
 //! Different test scenarios are defined here
 
 use clap::Parser;
-use rand::distributions::Alphanumeric;
-use rand::thread_rng;
-use rand::Rng;
+use rand::distr::Alphanumeric;
+use rand::rng;
+use rand::RngExt;
 
 pub mod auth_handshake;
 pub mod dist_connect;
@@ -19,7 +19,7 @@ pub mod external_unix;
 pub mod pg_groups;
 
 fn random_name() -> String {
-    thread_rng()
+    rng()
         .sample_iter(&Alphanumeric)
         .take(30)
         .map(char::from)


### PR DESCRIPTION
Combines and supersedes the dependabot PRs #430 (rand 0.8 → 0.10) and #432 (getrandom 0.2 → 0.4), which could not land independently because rand 0.10 transitively bumps the getrandom version pulled into WASM builds and ships breaking API changes.

## Bumps
- `rand`: 0.8 → 0.10 in `ractor`, `ractor_cluster`, `ractor_cluster_integration_tests`
- `getrandom` (WASM dev-dep in `ractor`): 0.2 → 0.4, with the renamed `wasm_js` feature (the `js` feature was renamed in getrandom 0.3)

## rand 0.10 API migration
- `thread_rng()` → `rng()`
- `distributions` → `distr` (e.g. `Alphanumeric`)
- `RngCore` trait → `Rng` (base trait was renamed)
- `Rng` extension trait → `RngExt`
- `gen()` / `gen_range(..)` → `random()` / `random_range(..)`

## Test plan
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D clippy::all -D warnings`
- Full CI feature-flag matrix from `CLAUDE.md`: default, `cluster`, `async-trait`, `blanket_serde`, `monitors`, `async-std`, `async-std,async-trait`, `async-std,message_span_propogation`, `tokio_runtime`-only, `tokio_runtime,message_span_propogation`, `output-port-v2`, `ractor_cluster`, `ractor_cluster -F async-trait` — all green locally
- `cargo bench --no-run`
- `cargo doc --lib -r` (only pre-existing unrelated rustdoc warnings)
- `cargo build --tests --target wasm32-unknown-unknown --package ractor` to confirm the `wasm_js` feature is correct

Closes #430
Closes #432