### PR TITLE
Avoid disabled tracing spans in actor messages

### DIFF
--- a/ractor/src/actor.rs
+++ b/ractor/src/actor.rs
@@ -57,6 +57,7 @@ use std::panic::AssertUnwindSafe;
 
 use actor_properties::MuxedMessage;
 use futures::TryFutureExt;
+#[cfg(feature = "message_span_propogation")]
 use tracing::Instrument;
 
 use crate::concurrency::JoinHandle;
@@ -946,7 +947,7 @@ where
         myself: ActorRef<TActor::Msg>,
         state: &mut TActor::State,
         handler: &TActor,
-        mut msg: crate::message::BoxedMessage,
+        msg: crate::message::BoxedMessage,
     ) -> Result<(), ActorProcessingErr> {
         // panic in order to kill the actor
         #[cfg(feature = "cluster")]
@@ -970,20 +971,30 @@ where
             }
         }
 
-        // The current [tracing::Span] is retrieved, boxed, and included in every
-        // `BoxedMessage` during the conversion of this `TActor::Msg`. It is used
-        // to automatically continue tracing span nesting when sending messages to Actors.
+        // When span propagation is enabled, an active [tracing::Span] is included in
+        // `BoxedMessage` during the conversion of this `TActor::Msg`. It is used to
+        // automatically continue tracing span nesting when sending messages to actors.
+        #[cfg(feature = "message_span_propogation")]
+        let mut msg = msg;
+        #[cfg(feature = "message_span_propogation")]
         let current_span_when_message_was_sent = msg.span.take();
 
         // An error here will bubble up to terminate the actor
         let typed_msg = TActor::Msg::from_boxed(msg)?;
 
-        if let Some(span) = current_span_when_message_was_sent {
-            handler
-                .handle(myself, typed_msg, state)
-                .instrument(span)
-                .await
-        } else {
+        #[cfg(feature = "message_span_propogation")]
+        {
+            if let Some(span) = current_span_when_message_was_sent {
+                handler
+                    .handle(myself, typed_msg, state)
+                    .instrument(span)
+                    .await
+            } else {
+                handler.handle(myself, typed_msg, state).await
+            }
+        }
+        #[cfg(not(feature = "message_span_propogation"))]
+        {
             handler.handle(myself, typed_msg, state).await
         }
     }

--- a/ractor/src/actor/actor_properties.rs
+++ b/ractor/src/actor/actor_properties.rs
@@ -215,6 +215,7 @@ impl ActorProperties {
         let boxed = BoxedMessage {
             msg: None,
             serialized_msg: Some(message),
+            #[cfg(feature = "message_span_propogation")]
             span: None,
         };
         Ok(self

--- a/ractor/src/message.rs
+++ b/ractor/src/message.rs
@@ -64,6 +64,7 @@ pub struct BoxedMessage {
     /// A serialized message for a remote actor, accessed only by the `RemoteActorRuntime`
     #[cfg(feature = "cluster")]
     pub serialized_msg: Option<SerializedMessage>,
+    #[cfg(feature = "message_span_propogation")]
     pub(crate) span: Option<tracing::Span>,
 }
 
@@ -132,28 +133,20 @@ pub trait Message: Any + Send + Sized + 'static {
     /// Convert this message to a [BoxedMessage]
     #[cfg(feature = "cluster")]
     fn box_message(self, pid: &ActorId) -> Result<BoxedMessage, BoxedDowncastErr> {
-        let span = {
-            #[cfg(feature = "message_span_propogation")]
-            {
-                Some(tracing::Span::current())
-            }
-            #[cfg(not(feature = "message_span_propogation"))]
-            {
-                None
-            }
-        };
         if Self::serializable() && !pid.is_local() {
             // it's a message to a remote actor, serialize it and send it over the wire!
             Ok(BoxedMessage {
                 msg: None,
                 serialized_msg: Some(self.serialize()?),
+                #[cfg(feature = "message_span_propogation")]
                 span: None,
             })
         } else if pid.is_local() {
             Ok(BoxedMessage {
                 msg: Some(Box::new(self)),
                 serialized_msg: None,
-                span,
+                #[cfg(feature = "message_span_propogation")]
+                span: current_message_span(),
             })
         } else {
             Err(BoxedDowncastErr)
@@ -164,19 +157,10 @@ pub trait Message: Any + Send + Sized + 'static {
     #[cfg(not(feature = "cluster"))]
     #[allow(unused_variables)]
     fn box_message(self, pid: &ActorId) -> Result<BoxedMessage, BoxedDowncastErr> {
-        let span = {
-            #[cfg(feature = "message_span_propogation")]
-            {
-                Some(tracing::Span::current())
-            }
-            #[cfg(not(feature = "message_span_propogation"))]
-            {
-                None
-            }
-        };
         Ok(BoxedMessage {
             msg: Some(Box::new(self)),
-            span,
+            #[cfg(feature = "message_span_propogation")]
+            span: current_message_span(),
         })
     }
 
@@ -226,5 +210,36 @@ impl<T: Any + Send + Sized + 'static + crate::serialization::BytesConvertable> M
             SerializedMessage::Cast { args, .. } => Ok(T::from_bytes(args)),
             _ => Err(BoxedDowncastErr),
         }
+    }
+}
+
+#[cfg(feature = "message_span_propogation")]
+fn current_message_span() -> Option<tracing::Span> {
+    let span = tracing::Span::current();
+    if span.is_disabled() {
+        None
+    } else {
+        Some(span)
+    }
+}
+
+#[cfg(all(test, feature = "message_span_propogation"))]
+mod tests {
+    use super::Message;
+    use crate::ActorId;
+
+    #[test]
+    fn box_message_only_captures_enabled_spans() {
+        tracing::subscriber::with_default(tracing::subscriber::NoSubscriber::default(), || {
+            let message = 1_u8.box_message(&ActorId::Local(1)).unwrap();
+            assert!(message.span.is_none());
+        });
+
+        tracing::subscriber::with_default(tracing_subscriber::registry(), || {
+            let span = tracing::info_span!("message_parent");
+            let _entered = span.enter();
+            let message = 1_u8.box_message(&ActorId::Local(1)).unwrap();
+            assert!(message.span.is_some());
+        });
     }
 }

--- a/ractor/src/thread_local/inner.rs
+++ b/ractor/src/thread_local/inner.rs
@@ -13,6 +13,7 @@ use std::sync::Mutex;
 
 use futures::FutureExt;
 use futures::TryFutureExt;
+#[cfg(feature = "message_span_propogation")]
 use tracing::Instrument;
 
 use super::ThreadLocalActor;
@@ -532,7 +533,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
         myself: ActorRef<TActor::Msg>,
         state: &mut TActor::State,
         handler: &TActor,
-        mut msg: crate::message::BoxedMessage,
+        msg: crate::message::BoxedMessage,
     ) -> Result<(), ActorProcessingErr> {
         // panic in order to kill the actor
         #[cfg(feature = "cluster")]
@@ -556,20 +557,30 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
             }
         }
 
-        // The current [tracing::Span] is retrieved, boxed, and included in every
-        // `BoxedMessage` during the conversion of this `TActor::Msg`. It is used
-        // to automatically continue tracing span nesting when sending messages to Actors.
+        // When span propagation is enabled, an active [tracing::Span] is included in
+        // `BoxedMessage` during the conversion of this `TActor::Msg`. It is used to
+        // automatically continue tracing span nesting when sending messages to actors.
+        #[cfg(feature = "message_span_propogation")]
+        let mut msg = msg;
+        #[cfg(feature = "message_span_propogation")]
         let current_span_when_message_was_sent = msg.span.take();
 
         // An error here will bubble up to terminate the actor
         let typed_msg = TActor::Msg::from_boxed(msg)?;
 
-        if let Some(span) = current_span_when_message_was_sent {
-            handler
-                .handle(myself, typed_msg, state)
-                .instrument(span)
-                .await
-        } else {
+        #[cfg(feature = "message_span_propogation")]
+        {
+            if let Some(span) = current_span_when_message_was_sent {
+                handler
+                    .handle(myself, typed_msg, state)
+                    .instrument(span)
+                    .await
+            } else {
+                handler.handle(myself, typed_msg, state).await
+            }
+        }
+        #[cfg(not(feature = "message_span_propogation"))]
+        {
             handler.handle(myself, typed_msg, state).await
         }
     }


### PR DESCRIPTION
## Summary

- omit span storage and receive-side instrumentation when propagation is disabled
- avoid retaining disabled spans when propagation is enabled
- skip span lookup for serialized messages sent to remote actors
- apply the same behavior to send and thread-local actor runtimes

## Why

`message_span_propogation` is enabled by default. With no active span, every local message still carried `Some(Span::none())` and entered the instrumentation path.

On an arm64 local run of the 100,000-message actor benchmark, normalizing disabled spans to `None` reduced the median from 15.370 ms to 13.602 ms (11.5%).

## Validation

- full `ractor` unit and documentation tests
- Tokio, async-std, cluster, propagation, and no-propagation feature builds
- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`

## Review notes

Enabled spans retain the existing behavior. Disabled spans carry no tracing context, so dropping them only removes overhead. The `BoxedMessage` layout change is internal.
