### PR TITLE
Box actor processing loop once instead of per message

### DIFF
--- a/ractor/src/actor.rs
+++ b/ractor/src/actor.rs
@@ -808,7 +808,10 @@ where
 
         let myself_clone = myself.clone();
 
-        let future = async move {
+        // Box the processing loop once per actor. This indirection prevents deeply
+        // nested actor graphs from overflowing rustc's layout query depth without allocating
+        // a new box for every message handled by the loop.
+        let future = Box::pin(async move {
             // the message processing loop. If we get an exit flag, try and capture the exit reason if there
             // is one
             loop {
@@ -816,7 +819,7 @@ where
                     should_exit,
                     exit_reason,
                     was_killed,
-                } = Box::pin(Self::process_message(&myself, state, handler, &mut ports))
+                } = Self::process_message(&myself, state, handler, &mut ports)
                     .await
                     .map_err(ActorErr::Failed)?;
                 // processing loop exit
@@ -824,7 +827,7 @@ where
                     return Ok((state, exit_reason, was_killed));
                 }
             }
-        };
+        });
 
         // capture any panics in this future and convert to an ActorErr
         let loop_done = futures::FutureExt::catch_unwind(AssertUnwindSafe(future))


### PR DESCRIPTION
## Summary

- move the actor runtime's layout-indirection box from each message to the lifetime of the processing loop
- preserve the compiler-depth protection needed by deeply nested actor graphs
- leave panic capture, kill interruption, graceful stop, and thread-local actors unchanged

## Performance

On an arm64 local run of the 100,000-message actor benchmark without span propagation:

- before: 12.995 ms median
- after: 8.861 ms median
- improvement: 31.8%

The benchmark used the same dependency set and Criterion configuration for both runs.

## Validation

- `cargo test --package ractor`
- `cargo test --package ractor --no-default-features --features async-std`
- `cargo test --package ractor_cluster_integration_tests --no-run`
- native and `async-trait` cluster checks
- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`

## Review notes

Removing the indirection introduced in #410 reproduces rustc's layout-query overflow in `ractor_cluster_integration_tests`. Boxing the whole inner loop retains that regression guard while amortizing the allocation over the actor lifetime.
