### PR TITLE
Make process-group shutdown cleanup relationship-proportional

### DIFF
--- a/ractor/src/actor/actor_cell.rs
+++ b/ractor/src/actor/actor_cell.rs
@@ -322,19 +322,22 @@ impl ActorCell {
         self.inner.supports_remoting
     }
 
-    /// Set the status of the [super::Actor]. If the status is set to
+    /// Advance the status of the [super::Actor]. Requests to move backward in
+    /// the lifecycle are ignored. If the status advances to
     /// [ActorStatus::Stopping] or [ActorStatus::Stopped] the actor
     /// will also be unenrolled from both the named registry ([crate::registry])
     /// and the PG groups ([crate::pg]) if it's enrolled in any
     ///
     /// * `status` - The [ActorStatus] to set
-    pub(crate) fn set_status(&self, status: ActorStatus) {
+    ///
+    /// Returns the status observed immediately before the update.
+    pub(crate) fn set_status(&self, status: ActorStatus) -> ActorStatus {
+        let previous_status = self.inner.set_status(status);
+
         // The actor is shut down — only run cleanup once, on the first transition
-        // to Stopping. This avoids redundant full-DashMap iterations on the
-        // Stopping → Stopped transition.
-        if (status == ActorStatus::Stopped || status == ActorStatus::Stopping)
-            && self.get_status() < ActorStatus::Stopping
-        {
+        // to Stopping. Publish the new status before cleanup so concurrent PG
+        // registrations cannot be added after the reverse indexes are drained.
+        if status >= ActorStatus::Stopping && previous_status < ActorStatus::Stopping {
             #[cfg(feature = "cluster")]
             {
                 // stop monitoring for updates
@@ -353,12 +356,12 @@ impl ActorCell {
 
         // Fix for #254. We should only notify the stop listener AFTER post_stop
         // has executed, which is when the state gets set to `Stopped`.
-        if status == ActorStatus::Stopped {
+        if status == ActorStatus::Stopped && previous_status < ActorStatus::Stopped {
             // notify whoever might be waiting on the stop signal
             self.inner.notify_stop_listener();
         }
 
-        self.inner.set_status(status)
+        previous_status
     }
 
     /// Terminate this [super::Actor] and all it's children

--- a/ractor/src/actor/actor_properties.rs
+++ b/ractor/src/actor/actor_properties.rs
@@ -50,6 +50,18 @@ pub(crate) struct ActorProperties {
 }
 
 impl ActorProperties {
+    fn status_from_u8(status: u8) -> ActorStatus {
+        match status {
+            0u8 => ActorStatus::Unstarted,
+            1u8 => ActorStatus::Starting,
+            2u8 => ActorStatus::Running,
+            3u8 => ActorStatus::Upgrading,
+            4u8 => ActorStatus::Draining,
+            5u8 => ActorStatus::Stopping,
+            _ => ActorStatus::Stopped,
+        }
+    }
+
     pub(crate) fn new<TActor>(
         name: Option<ActorName>,
     ) -> (
@@ -105,19 +117,15 @@ impl ActorProperties {
     }
 
     pub(crate) fn get_status(&self) -> ActorStatus {
-        match self.status.load(Ordering::SeqCst) {
-            0u8 => ActorStatus::Unstarted,
-            1u8 => ActorStatus::Starting,
-            2u8 => ActorStatus::Running,
-            3u8 => ActorStatus::Upgrading,
-            4u8 => ActorStatus::Draining,
-            5u8 => ActorStatus::Stopping,
-            _ => ActorStatus::Stopped,
-        }
+        Self::status_from_u8(self.status.load(Ordering::SeqCst))
     }
 
-    pub(crate) fn set_status(&self, status: ActorStatus) {
-        self.status.store(status as u8, Ordering::SeqCst);
+    /// Advances the lifecycle status without allowing a concurrent or stale
+    /// transition to move it backwards.
+    ///
+    /// Returns the status observed immediately before this update.
+    pub(crate) fn set_status(&self, status: ActorStatus) -> ActorStatus {
+        Self::status_from_u8(self.status.fetch_max(status as u8, Ordering::SeqCst))
     }
 
     pub(crate) fn send_signal(&self, signal: Signal) -> Result<(), MessagingErr<()>> {

--- a/ractor/src/actor/tests.rs
+++ b/ractor/src/actor/tests.rs
@@ -28,6 +28,89 @@ struct EmptyMessage;
 #[cfg(feature = "cluster")]
 impl crate::Message for EmptyMessage {}
 
+struct StatusTestActor;
+
+#[cfg_attr(feature = "async-trait", crate::async_trait)]
+impl Actor for StatusTestActor {
+    type Msg = EmptyMessage;
+    type Arguments = ();
+    type State = ();
+
+    async fn pre_start(
+        &self,
+        _this_actor: ActorRef<Self::Msg>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(())
+    }
+}
+
+#[test]
+fn actor_status_transitions_are_monotonic() {
+    let actor = ActorCell::new::<StatusTestActor>(None).unwrap().0;
+
+    assert_eq!(
+        ActorStatus::Unstarted,
+        actor.set_status(ActorStatus::Starting)
+    );
+    assert_eq!(
+        ActorStatus::Starting,
+        actor.set_status(ActorStatus::Draining)
+    );
+    assert_eq!(
+        ActorStatus::Draining,
+        actor.set_status(ActorStatus::Running)
+    );
+    assert_eq!(ActorStatus::Draining, actor.get_status());
+    assert_eq!(
+        ActorStatus::Draining,
+        actor.set_status(ActorStatus::Stopped)
+    );
+    assert_eq!(
+        ActorStatus::Stopped,
+        actor.set_status(ActorStatus::Stopping)
+    );
+    assert_eq!(ActorStatus::Stopped, actor.get_status());
+}
+
+#[test]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+fn concurrent_shutdown_transitions_elect_cleanup_once() {
+    use std::sync::Barrier;
+
+    let actor = ActorCell::new::<StatusTestActor>(None).unwrap().0;
+    actor.set_status(ActorStatus::Running);
+    let barrier = Arc::new(Barrier::new(3));
+
+    let stopping_actor = actor.clone();
+    let stopping_barrier = barrier.clone();
+    let stopping = std::thread::spawn(move || {
+        stopping_barrier.wait();
+        stopping_actor.set_status(ActorStatus::Stopping)
+    });
+
+    let stopped_actor = actor.clone();
+    let stopped_barrier = barrier.clone();
+    let stopped = std::thread::spawn(move || {
+        stopped_barrier.wait();
+        stopped_actor.set_status(ActorStatus::Stopped)
+    });
+
+    barrier.wait();
+    let previous_statuses = [
+        stopping.join().expect("stopping thread panicked"),
+        stopped.join().expect("stopped thread panicked"),
+    ];
+    assert_eq!(
+        1,
+        previous_statuses
+            .iter()
+            .filter(|status| **status < ActorStatus::Stopping)
+            .count()
+    );
+    assert_eq!(ActorStatus::Stopped, actor.get_status());
+}
+
 #[crate::concurrency::test]
 #[cfg_attr(
     not(all(target_arch = "wasm32", target_os = "unknown")),

--- a/ractor/src/pg.rs
+++ b/ractor/src/pg.rs
@@ -72,6 +72,9 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::MutexGuard;
 
 use dashmap::mapref::entry::Entry::Occupied;
 use dashmap::DashMap;
@@ -154,6 +157,31 @@ struct GroupState {
     listeners: Vec<ActorCell>,
 }
 
+/// The process-group relationships owned by one actor.
+///
+/// Ordinary mutations hold the forward group entry while updating this reverse
+/// index. Shutdown first publishes `Stopping`, drains this index, and then
+/// removes the forward entries; registrations racing with that drain observe
+/// the new status and are rejected. The lock order is forward group/world
+/// entry, actor relations, then the scope index; shutdown releases the actor
+/// relations lock before acquiring any forward entry.
+#[derive(Default)]
+struct ActorRelations {
+    memberships: HashSet<ScopeGroupKey>,
+    group_monitors: HashSet<ScopeGroupKey>,
+    world_monitors: HashSet<ScopeGroupKey>,
+}
+
+impl ActorRelations {
+    fn is_empty(&self) -> bool {
+        self.memberships.is_empty()
+            && self.group_monitors.is_empty()
+            && self.world_monitors.is_empty()
+    }
+}
+
+type SharedActorRelations = Arc<Mutex<ActorRelations>>;
+
 struct PgState {
     /// Maps (scope, group) to the group's state (members + per-group listeners)
     map: DashMap<ScopeGroupKey, GroupState>,
@@ -161,6 +189,8 @@ struct PgState {
     index: DashMap<ScopeName, HashSet<GroupName>>,
     /// Scope-level and global monitors (sentinel keys only)
     world_listeners: DashMap<ScopeGroupKey, Vec<ActorCell>>,
+    /// Reverse index used to clean up only the relationships owned by an actor
+    actor_relations: DashMap<ActorId, SharedActorRelations>,
 }
 
 static PG_MONITOR: OnceCell<PgState> = OnceCell::new();
@@ -170,7 +200,65 @@ fn get_monitor<'a>() -> &'a PgState {
         map: DashMap::new(),
         index: DashMap::new(),
         world_listeners: DashMap::new(),
+        actor_relations: DashMap::new(),
     })
+}
+
+fn lock_relations(relations: &SharedActorRelations) -> MutexGuard<'_, ActorRelations> {
+    relations
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn get_or_create_actor_relations(monitor: &PgState, actor: ActorId) -> SharedActorRelations {
+    monitor.actor_relations.entry(actor).or_default().clone()
+}
+
+fn get_actor_relations(monitor: &PgState, actor: ActorId) -> Option<SharedActorRelations> {
+    monitor
+        .actor_relations
+        .get(&actor)
+        .map(|relations| relations.value().clone())
+}
+
+/// Removes the reverse-index entry once an actor owns no relationships.
+///
+/// A caller may already hold a clone of the same `Arc`, but it cannot add a new
+/// relationship once `Stopping` has been published. Callers must therefore use
+/// this only for stopping actors. Pointer comparison prevents removing a
+/// replacement entry created by a concurrent caller.
+fn remove_empty_actor_relations(
+    monitor: &PgState,
+    actor: ActorId,
+    relations: &SharedActorRelations,
+) {
+    let relations_guard = lock_relations(relations);
+    if !relations_guard.is_empty() {
+        return;
+    }
+
+    if let Occupied(entry) = monitor.actor_relations.entry(actor) {
+        if Arc::ptr_eq(entry.get(), relations) {
+            entry.remove();
+        }
+    }
+}
+
+fn add_group_to_index(monitor: &PgState, key: &ScopeGroupKey) {
+    monitor
+        .index
+        .entry(key.scope.clone())
+        .or_default()
+        .insert(key.group.clone());
+}
+
+fn remove_group_from_index(monitor: &PgState, key: &ScopeGroupKey) {
+    if let Occupied(mut entry) = monitor.index.entry(key.scope.clone()) {
+        entry.get_mut().remove(&key.group);
+        if entry.get().is_empty() {
+            entry.remove();
+        }
+    }
 }
 
 /// Sends notifications to scope-level and global world listeners.
@@ -229,42 +317,73 @@ pub fn join_scoped(scope: ScopeName, group: GroupName, actors: Vec<ActorCell>) {
     };
     let monitor = get_monitor();
 
-    // Filter out actors that are already stopping or stopped
-    let actors: Vec<ActorCell> = actors
+    // Preserve the existing notification contract: every caller-provided actor
+    // that is not already stopping remains in the event payload, including
+    // duplicate or already-joined actors.
+    let actors = actors
         .into_iter()
-        .filter(|a| (a.get_status() as u8) <= (ActorStatus::Draining as u8))
-        .collect();
-
+        .filter(|actor| actor.get_status() <= ActorStatus::Draining)
+        .collect::<Vec<_>>();
     if actors.is_empty() {
         return;
     }
 
-    // Lock map entry, insert members, clone per-group listeners, then drop the guard
-    let listeners = {
-        let mut entry = monitor.map.entry(key).or_default();
-        let gs = entry.value_mut();
-        for actor in actors.iter() {
-            gs.members.insert(actor.get_id(), actor.clone());
+    let mut stopped_relations = Vec::new();
+    let (joined, listeners) = {
+        let mut entry = monitor.map.entry(key.clone()).or_default();
+        let group_state = entry.value_mut();
+        let mut processed = HashSet::with_capacity(actors.len());
+        let mut accepted = HashSet::with_capacity(actors.len());
+
+        for actor in &actors {
+            if !processed.insert(actor.get_id()) {
+                continue;
+            }
+            let relations = get_or_create_actor_relations(monitor, actor.get_id());
+            let mut relations_guard = lock_relations(&relations);
+            if actor.get_status() <= ActorStatus::Draining {
+                relations_guard.memberships.insert(key.clone());
+                accepted.insert(actor.get_id());
+            } else if relations_guard.is_empty() {
+                stopped_relations.push((actor.get_id(), relations.clone()));
+            }
         }
-        gs.listeners.clone()
+
+        let joined = actors
+            .into_iter()
+            .filter(|actor| accepted.contains(&actor.get_id()))
+            .collect::<Vec<_>>();
+        for actor in &joined {
+            group_state.members.insert(actor.get_id(), actor.clone());
+        }
+
+        if !joined.is_empty() {
+            add_group_to_index(monitor, &key);
+        }
+
+        (joined, group_state.listeners.clone())
     };
 
-    // Update index
-    monitor
-        .index
-        .entry(scope.to_owned())
-        .or_default()
-        .insert(group.to_owned());
+    for (actor, relations) in stopped_relations {
+        remove_empty_actor_relations(monitor, actor, &relations);
+    }
 
-    // Notify per-group listeners (guard already dropped)
+    if joined.is_empty() {
+        if let Occupied(entry) = monitor.map.entry(key) {
+            if entry.get().members.is_empty() && entry.get().listeners.is_empty() {
+                entry.remove();
+            }
+        }
+        return;
+    }
+
     for listener in &listeners {
         let _ = listener.send_supervisor_evt(SupervisionEvent::ProcessGroupChanged(
-            GroupChangeMessage::Join(scope.to_owned(), group.clone(), actors.clone()),
+            GroupChangeMessage::Join(scope.to_owned(), group.clone(), joined.clone()),
         ));
     }
 
-    // Notify world listeners
-    notify_world_listeners(monitor, &scope, &group, &actors, true);
+    notify_world_listeners(monitor, &scope, &group, &joined, true);
 }
 
 /// Leaves the specified [crate::Actor]s from the PG group in the default scope
@@ -287,46 +406,38 @@ pub fn leave_scoped(scope: ScopeName, group: GroupName, actors: Vec<ActorCell>) 
     };
     let monitor = get_monitor();
 
-    // Lock map entry, remove members, clone listeners, check emptiness
-    let result = if let Occupied(mut occupied) = monitor.map.entry(key) {
-        let gs = occupied.get_mut();
-        for actor in actors.iter() {
-            gs.members.remove(&actor.get_id());
+    let result = if let Occupied(mut entry) = monitor.map.entry(key.clone()) {
+        let group_state = entry.get_mut();
+
+        for actor in &actors {
+            if let Some(relations) = get_actor_relations(monitor, actor.get_id()) {
+                lock_relations(&relations).memberships.remove(&key);
+            }
+            group_state.members.remove(&actor.get_id());
         }
-        let listeners = gs.listeners.clone();
-        let all_members_left = gs.members.is_empty();
-        let fully_empty = all_members_left && gs.listeners.is_empty();
-        if fully_empty {
-            occupied.remove();
+
+        let listeners = group_state.listeners.clone();
+        if group_state.members.is_empty() {
+            remove_group_from_index(monitor, &key);
+            if group_state.listeners.is_empty() {
+                entry.remove();
+            }
         }
-        Some((listeners, all_members_left))
+        Some(listeners)
     } else {
         None
     };
 
-    let Some((listeners, all_members_left)) = result else {
+    let Some(listeners) = result else {
         return;
     };
 
-    // Update index only if all members left
-    if all_members_left {
-        if let Some(mut groups) = monitor.index.get_mut(&scope) {
-            groups.remove(&group);
-            if groups.is_empty() {
-                drop(groups);
-                monitor.index.remove(&scope);
-            }
-        }
-    }
-
-    // Notify per-group listeners (guard already dropped)
     for listener in &listeners {
         let _ = listener.send_supervisor_evt(SupervisionEvent::ProcessGroupChanged(
             GroupChangeMessage::Leave(scope.to_owned(), group.clone(), actors.clone()),
         ));
     }
 
-    // Notify world listeners
     notify_world_listeners(monitor, &scope, &group, &actors, false);
 }
 
@@ -334,46 +445,33 @@ pub fn leave_scoped(scope: ScopeName, group: GroupName, actors: Vec<ActorCell>) 
 /// Used only during actor shutdown
 pub(crate) fn leave_all(actor: ActorId) {
     let monitor = get_monitor();
+    let Some(relations) = get_actor_relations(monitor, actor) else {
+        return;
+    };
+    let mut relations_guard = lock_relations(&relations);
+    let memberships = std::mem::take(&mut relations_guard.memberships);
+    drop(relations_guard);
+    let mut removal_events = Vec::with_capacity(memberships.len());
 
-    // Phase 1: iterate, remove actor from members, collect notification info
-    let mut removal_events: Vec<(ScopeGroupKey, ActorCell, Vec<ActorCell>)> = vec![];
-    let mut empty_member_keys: Vec<ScopeGroupKey> = vec![];
-
-    for mut kv in monitor.map.iter_mut() {
-        let key = kv.key().clone();
-        let gs = kv.value_mut();
-        if let Some(actor_cell) = gs.members.remove(&actor) {
-            let listeners = gs.listeners.clone();
-            removal_events.push((key.clone(), actor_cell, listeners));
-        }
-        if gs.members.is_empty() {
-            empty_member_keys.push(key);
-        }
-    }
-
-    // Phase 2: clean up empty entries (re-check under lock to handle concurrent joins)
-    for key in empty_member_keys {
-        if let Occupied(entry) = monitor.map.entry(key.clone()) {
-            if entry.get().members.is_empty() {
-                // Update index
-                if let Some(mut groups) = monitor.index.get_mut(&key.scope) {
-                    groups.remove(&key.group);
-                    if groups.is_empty() {
-                        drop(groups);
-                        monitor.index.remove(&key.scope);
+    for key in memberships {
+        if let Occupied(mut entry) = monitor.map.entry(key.clone()) {
+            let group_state = entry.get_mut();
+            if let Some(actor_cell) = group_state.members.remove(&actor) {
+                let listeners = group_state.listeners.clone();
+                if group_state.members.is_empty() {
+                    remove_group_from_index(monitor, &key);
+                    if group_state.listeners.is_empty() {
+                        entry.remove();
                     }
                 }
-                // Only remove map entry if listeners are also empty
-                if entry.get().listeners.is_empty() {
-                    entry.remove();
-                }
+                removal_events.push((key, actor_cell, listeners));
             }
         }
     }
 
-    // Phase 3: send notifications (outside all locks)
-    for (scope_and_group, cell, per_group_listeners) in removal_events.iter() {
-        // Notify per-group listeners
+    remove_empty_actor_relations(monitor, actor, &relations);
+
+    for (scope_and_group, cell, per_group_listeners) in &removal_events {
         for listener in per_group_listeners {
             let _ = listener.send_supervisor_evt(SupervisionEvent::ProcessGroupChanged(
                 GroupChangeMessage::Leave(
@@ -384,7 +482,6 @@ pub(crate) fn leave_all(actor: ActorId) {
             ));
         }
 
-        // Notify world listeners (scoped + global)
         notify_world_listeners(
             monitor,
             &scope_and_group.scope,
@@ -528,7 +625,25 @@ pub fn monitor(group: GroupName, actor: ActorCell) {
         group,
     };
     let monitor = get_monitor();
-    monitor.map.entry(key).or_default().listeners.push(actor);
+    let relations = get_or_create_actor_relations(monitor, actor.get_id());
+    let mut entry = monitor.map.entry(key.clone()).or_default();
+    let mut relations_guard = lock_relations(&relations);
+
+    if actor.get_status() <= ActorStatus::Draining {
+        entry.listeners.push(actor.clone());
+        relations_guard.group_monitors.insert(key.clone());
+    }
+
+    drop(relations_guard);
+    drop(entry);
+    if actor.get_status() >= ActorStatus::Stopping {
+        if let Occupied(entry) = monitor.map.entry(key) {
+            if entry.get().members.is_empty() && entry.get().listeners.is_empty() {
+                entry.remove();
+            }
+        }
+        remove_empty_actor_relations(monitor, actor.get_id(), &relations);
+    }
 }
 
 /// Subscribes the provided [crate::Actor] to the scope for updates
@@ -541,8 +656,26 @@ pub fn monitor_scope(scope: ScopeName, actor: ActorCell) {
         group: ALL_GROUPS_NOTIFICATION.to_owned(),
     };
     let monitor = get_monitor();
-    // Register ONLY in world_listeners (not per-group) to avoid duplicate notifications
-    monitor.world_listeners.entry(key).or_default().push(actor);
+    let relations = get_or_create_actor_relations(monitor, actor.get_id());
+    let mut entry = monitor.world_listeners.entry(key.clone()).or_default();
+    let mut relations_guard = lock_relations(&relations);
+
+    if actor.get_status() <= ActorStatus::Draining {
+        // Register ONLY in world_listeners (not per-group) to avoid duplicate notifications
+        entry.push(actor.clone());
+        relations_guard.world_monitors.insert(key.clone());
+    }
+
+    drop(relations_guard);
+    drop(entry);
+    if actor.get_status() >= ActorStatus::Stopping {
+        if let Occupied(entry) = monitor.world_listeners.entry(key) {
+            if entry.get().is_empty() {
+                entry.remove();
+            }
+        }
+        remove_empty_actor_relations(monitor, actor.get_id(), &relations);
+    }
 }
 
 /// Unsubscribes the provided [crate::Actor] for updates from the group
@@ -556,8 +689,22 @@ pub fn demonitor(group_name: GroupName, actor: ActorId) {
         group: group_name,
     };
     let monitor = get_monitor();
-    if let Some(mut gs) = monitor.map.get_mut(&key) {
-        gs.listeners.retain(|a| a.get_id() != actor);
+    let relations = get_actor_relations(monitor, actor);
+
+    if let Occupied(mut entry) = monitor.map.entry(key.clone()) {
+        let mut relations_guard = relations.as_ref().map(lock_relations);
+        let group_state = entry.get_mut();
+        group_state
+            .listeners
+            .retain(|listener| listener.get_id() != actor);
+        if let Some(relations_guard) = relations_guard.as_mut() {
+            relations_guard.group_monitors.remove(&key);
+        }
+        if group_state.members.is_empty() && group_state.listeners.is_empty() {
+            entry.remove();
+        }
+    } else if let Some(relations) = relations {
+        lock_relations(&relations).group_monitors.remove(&key);
     }
 }
 
@@ -571,12 +718,20 @@ pub fn demonitor_scope(scope: ScopeName, actor: ActorId) {
         group: ALL_GROUPS_NOTIFICATION.to_owned(),
     };
     let monitor = get_monitor();
-    if let Occupied(mut entry) = monitor.world_listeners.entry(key) {
+    let relations = get_actor_relations(monitor, actor);
+
+    if let Occupied(mut entry) = monitor.world_listeners.entry(key.clone()) {
+        let mut relations_guard = relations.as_ref().map(lock_relations);
         let listeners = entry.get_mut();
         listeners.retain(|a| a.get_id() != actor);
+        if let Some(relations_guard) = relations_guard.as_mut() {
+            relations_guard.world_monitors.remove(&key);
+        }
         if listeners.is_empty() {
             entry.remove();
         }
+    } else if let Some(relations) = relations {
+        lock_relations(&relations).world_monitors.remove(&key);
     }
 }
 
@@ -584,42 +739,34 @@ pub fn demonitor_scope(scope: ScopeName, actor: ActorId) {
 /// Used only during actor shutdown
 pub(crate) fn demonitor_all(actor: ActorId) {
     let monitor = get_monitor();
+    let Some(relations) = get_actor_relations(monitor, actor) else {
+        return;
+    };
+    let mut relations_guard = lock_relations(&relations);
+    let group_monitors = std::mem::take(&mut relations_guard.group_monitors);
+    let world_monitors = std::mem::take(&mut relations_guard.world_monitors);
+    drop(relations_guard);
 
-    // Remove from per-group listeners and track potentially empty entries
-    let mut maybe_empty = vec![];
-    for mut kv in monitor.map.iter_mut() {
-        let gs = kv.value_mut();
-        gs.listeners.retain(|a| a.get_id() != actor);
-        if gs.members.is_empty() && gs.listeners.is_empty() {
-            maybe_empty.push(kv.key().clone());
-        }
-    }
-
-    // Clean up fully empty entries
-    for key in maybe_empty {
-        if let Occupied(entry) = monitor.map.entry(key.clone()) {
-            if entry.get().members.is_empty() && entry.get().listeners.is_empty() {
+    for key in group_monitors {
+        if let Occupied(mut entry) = monitor.map.entry(key) {
+            let group_state = entry.get_mut();
+            group_state
+                .listeners
+                .retain(|listener| listener.get_id() != actor);
+            if group_state.members.is_empty() && group_state.listeners.is_empty() {
                 entry.remove();
-                if let Some(mut groups) = monitor.index.get_mut(&key.scope) {
-                    groups.remove(&key.group);
-                    if groups.is_empty() {
-                        drop(groups);
-                        monitor.index.remove(&key.scope);
-                    }
-                }
             }
         }
     }
 
-    // Remove from world listeners
-    let mut empty_world_keys = vec![];
-    for mut kv in monitor.world_listeners.iter_mut() {
-        kv.value_mut().retain(|a| a.get_id() != actor);
-        if kv.value().is_empty() {
-            empty_world_keys.push(kv.key().clone());
+    for key in world_monitors {
+        if let Occupied(mut entry) = monitor.world_listeners.entry(key) {
+            entry
+                .get_mut()
+                .retain(|listener| listener.get_id() != actor);
+            if entry.get().is_empty() {
+                entry.remove();
+            }
         }
-    }
-    for key in empty_world_keys {
-        monitor.world_listeners.remove(&key);
     }
 }

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -1120,3 +1120,280 @@ async fn test_stopped_actor_not_inserted() {
     let members = pg::get_members(&group);
     assert_eq!(0, members.len());
 }
+
+#[named]
+#[test]
+fn test_idempotent_membership_calls_preserve_notification_payloads() {
+    let group = function_name!().to_owned();
+    let (listener, mut listener_ports) =
+        crate::ActorCell::new::<TestActor>(None).expect("Failed to create listener");
+    let (member, _member_ports) =
+        crate::ActorCell::new::<TestActor>(None).expect("Failed to create member");
+
+    pg::monitor(group.clone(), listener.clone());
+    pg::join(group.clone(), vec![member.clone(), member.clone()]);
+    pg::join(group.clone(), vec![member.clone()]);
+
+    let first_join = listener_ports
+        .supervisor_rx
+        .try_recv()
+        .expect("join notification missing");
+    assert!(matches!(
+        first_join,
+        SupervisionEvent::ProcessGroupChanged(pg::GroupChangeMessage::Join(_, _, actors))
+            if actors.len() == 2 && actors.iter().all(|actor| actor.get_id() == member.get_id())
+    ));
+    let second_join = listener_ports
+        .supervisor_rx
+        .try_recv()
+        .expect("idempotent join notification missing");
+    assert!(matches!(
+        second_join,
+        SupervisionEvent::ProcessGroupChanged(pg::GroupChangeMessage::Join(_, _, actors))
+            if actors.len() == 1 && actors[0].get_id() == member.get_id()
+    ));
+
+    pg::leave(group.clone(), vec![member.clone(), member.clone()]);
+    pg::leave(group, vec![member.clone()]);
+
+    let first_leave = listener_ports
+        .supervisor_rx
+        .try_recv()
+        .expect("leave notification missing");
+    assert!(matches!(
+        first_leave,
+        SupervisionEvent::ProcessGroupChanged(pg::GroupChangeMessage::Leave(_, _, actors))
+            if actors.len() == 2 && actors.iter().all(|actor| actor.get_id() == member.get_id())
+    ));
+    let second_leave = listener_ports
+        .supervisor_rx
+        .try_recv()
+        .expect("idempotent leave notification missing");
+    assert!(matches!(
+        second_leave,
+        SupervisionEvent::ProcessGroupChanged(pg::GroupChangeMessage::Leave(_, _, actors))
+            if actors.len() == 1 && actors[0].get_id() == member.get_id()
+    ));
+    assert!(listener_ports.supervisor_rx.try_recv().is_err());
+
+    listener.set_status(crate::ActorStatus::Stopped);
+    member.set_status(crate::ActorStatus::Stopped);
+}
+
+#[named]
+#[crate::concurrency::test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
+async fn test_shutdown_cleans_only_the_actors_pg_relationships() {
+    let (departing, departing_handle) = Actor::spawn(None, TestActor, ())
+        .await
+        .expect("Failed to spawn departing actor");
+    let (remaining, remaining_handle) = Actor::spawn(None, TestActor, ())
+        .await
+        .expect("Failed to spawn remaining actor");
+
+    let scope = format!("{}_scope", function_name!());
+    let other_scope = format!("{}_other_scope", function_name!());
+    let default_group = format!("{}_default", function_name!());
+    let departing_group = format!("{}_departing", function_name!());
+    let shared_group = format!("{}_shared", function_name!());
+    let untouched_group = format!("{}_untouched", function_name!());
+    let monitored_group = format!("{}_monitored", function_name!());
+    let departing_monitored_group = format!("{}_departing_monitored", function_name!());
+
+    pg::join(
+        default_group.clone(),
+        vec![departing.clone().into(), remaining.clone().into()],
+    );
+    pg::join_scoped(
+        scope.clone(),
+        departing_group.clone(),
+        vec![departing.clone().into()],
+    );
+    pg::join_scoped(
+        scope.clone(),
+        shared_group.clone(),
+        vec![departing.clone().into(), remaining.clone().into()],
+    );
+    pg::join_scoped(
+        other_scope.clone(),
+        untouched_group.clone(),
+        vec![remaining.clone().into()],
+    );
+    pg::monitor(monitored_group.clone(), departing.clone().into());
+    pg::monitor(monitored_group.clone(), remaining.clone().into());
+    pg::monitor(departing_monitored_group.clone(), departing.clone().into());
+    pg::monitor_scope(scope.clone(), departing.clone().into());
+    pg::monitor_scope(scope.clone(), remaining.clone().into());
+    pg::monitor_scope(
+        pg::ALL_SCOPES_NOTIFICATION.to_owned(),
+        departing.clone().into(),
+    );
+    pg::monitor_scope(
+        pg::ALL_SCOPES_NOTIFICATION.to_owned(),
+        remaining.clone().into(),
+    );
+
+    departing.stop(None);
+    departing_handle.await.expect("Actor cleanup failed");
+
+    let default_members = pg::get_members(&default_group);
+    assert_eq!(1, default_members.len());
+    assert_eq!(remaining.get_id(), default_members[0].get_id());
+    assert!(pg::get_scoped_members(&scope, &departing_group).is_empty());
+
+    let shared_members = pg::get_scoped_members(&scope, &shared_group);
+    assert_eq!(1, shared_members.len());
+    assert_eq!(remaining.get_id(), shared_members[0].get_id());
+
+    let untouched_members = pg::get_scoped_members(&other_scope, &untouched_group);
+    assert_eq!(1, untouched_members.len());
+    assert_eq!(remaining.get_id(), untouched_members[0].get_id());
+    assert!(!pg::which_scoped_groups(&scope).contains(&departing_group));
+    let monitor = pg::get_monitor();
+    let group_key = pg::ScopeGroupKey {
+        scope: pg::DEFAULT_SCOPE.to_owned(),
+        group: monitored_group.clone(),
+    };
+    let group_state = monitor.map.get(&group_key).expect("group monitor missing");
+    assert!(group_state
+        .listeners
+        .iter()
+        .any(|listener| listener.get_id() == remaining.get_id()));
+    assert!(group_state
+        .listeners
+        .iter()
+        .all(|listener| listener.get_id() != departing.get_id()));
+    drop(group_state);
+
+    let departing_group_key = pg::ScopeGroupKey {
+        scope: pg::DEFAULT_SCOPE.to_owned(),
+        group: departing_monitored_group,
+    };
+    assert!(monitor.map.get(&departing_group_key).is_none());
+
+    for world_key in [
+        pg::ScopeGroupKey {
+            scope: scope.clone(),
+            group: pg::ALL_GROUPS_NOTIFICATION.to_owned(),
+        },
+        pg::ScopeGroupKey {
+            scope: pg::ALL_SCOPES_NOTIFICATION.to_owned(),
+            group: pg::ALL_GROUPS_NOTIFICATION.to_owned(),
+        },
+    ] {
+        let listeners = monitor
+            .world_listeners
+            .get(&world_key)
+            .expect("world monitor missing");
+        assert!(listeners
+            .iter()
+            .any(|listener| listener.get_id() == remaining.get_id()));
+        assert!(listeners
+            .iter()
+            .all(|listener| listener.get_id() != departing.get_id()));
+    }
+    assert!(monitor.actor_relations.get(&departing.get_id()).is_none());
+
+    {
+        let remaining_relations = pg::get_actor_relations(monitor, remaining.get_id())
+            .expect("remaining actor reverse index missing");
+        let remaining_relations = pg::lock_relations(&remaining_relations);
+        let expected_memberships = [
+            pg::ScopeGroupKey {
+                scope: pg::DEFAULT_SCOPE.to_owned(),
+                group: default_group,
+            },
+            pg::ScopeGroupKey {
+                scope: scope.clone(),
+                group: shared_group,
+            },
+            pg::ScopeGroupKey {
+                scope: other_scope,
+                group: untouched_group,
+            },
+        ];
+        assert_eq!(
+            expected_memberships.len(),
+            remaining_relations.memberships.len()
+        );
+        assert!(expected_memberships
+            .iter()
+            .all(|key| remaining_relations.memberships.contains(key)));
+        assert_eq!(1, remaining_relations.group_monitors.len());
+        assert!(remaining_relations
+            .group_monitors
+            .contains(&pg::ScopeGroupKey {
+                scope: pg::DEFAULT_SCOPE.to_owned(),
+                group: monitored_group,
+            }));
+        assert_eq!(2, remaining_relations.world_monitors.len());
+        assert!(remaining_relations
+            .world_monitors
+            .contains(&pg::ScopeGroupKey {
+                scope,
+                group: pg::ALL_GROUPS_NOTIFICATION.to_owned(),
+            }));
+        assert!(remaining_relations
+            .world_monitors
+            .contains(&pg::ScopeGroupKey {
+                scope: pg::ALL_SCOPES_NOTIFICATION.to_owned(),
+                group: pg::ALL_GROUPS_NOTIFICATION.to_owned(),
+            }));
+    }
+
+    remaining.stop(None);
+    remaining_handle.await.expect("Actor cleanup failed");
+}
+
+#[named]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+#[test]
+#[tracing_test::traced_test]
+fn test_stopping_actor_rejects_registration_blocked_on_relations() {
+    let group = format!("{}_group", function_name!());
+    let scope = format!("{}_scope", function_name!());
+    let world_key = pg::ScopeGroupKey {
+        scope: scope.clone(),
+        group: pg::ALL_GROUPS_NOTIFICATION.to_owned(),
+    };
+    let (actor, _ports) = crate::ActorCell::new::<TestActor>(None).expect("Failed to create actor");
+    pg::join(group.clone(), vec![actor.clone()]);
+
+    let monitor = pg::get_monitor();
+    let relations =
+        pg::get_actor_relations(monitor, actor.get_id()).expect("actor reverse index missing");
+    let relations_guard = pg::lock_relations(&relations);
+
+    let stopping_actor = actor.clone();
+    let stop_thread =
+        std::thread::spawn(move || stopping_actor.set_status(crate::ActorStatus::Stopping));
+    while actor.get_status() != crate::ActorStatus::Stopping {
+        std::thread::yield_now();
+    }
+
+    let registering_actor = actor.clone();
+    let registration = std::thread::spawn(move || {
+        pg::monitor_scope(scope, registering_actor);
+    });
+    while !monitor.world_listeners.try_get(&world_key).is_locked() {
+        std::thread::yield_now();
+    }
+
+    drop(relations_guard);
+    let previous_status = stop_thread.join().expect("stop thread panicked");
+    assert!(previous_status < crate::ActorStatus::Stopping);
+    registration.join().expect("registration thread panicked");
+
+    assert!(pg::get_members(&group).is_empty());
+    assert!(monitor
+        .world_listeners
+        .get(&world_key)
+        .map_or(true, |listeners| listeners
+            .iter()
+            .all(|listener| listener.get_id() != actor.get_id())));
+    assert!(monitor.actor_relations.get(&actor.get_id()).is_none());
+    actor.set_status(crate::ActorStatus::Stopped);
+}


### PR DESCRIPTION
## Summary

- add per-actor reverse indices for group memberships and group/scope monitors
- make shutdown cleanup proportional to that actor's relationships instead of all global PG state
- publish lifecycle transitions atomically and monotonically so one terminal transition owns cleanup
- preserve existing join/leave notification payload and idempotent-call semantics
- keep notifications outside locks and document the mutation lock order

## Performance

A local arm64 probe populated 20,000 groups, then stopped 500 actors that had no PG relationships:

- before: 190.432 ms median
- after: 0.979 ms median

This removes the global-state coupling that made unrelated actor churn contend on every PG shard.

## Regression coverage

- cleanup across multiple groups, scopes, group monitors, scope monitors, and global monitors
- unrelated actors and groups remain intact in both forward and reverse indices
- deterministic registration-versus-shutdown interleaving
- monotonic and concurrent lifecycle transitions
- preservation of duplicate/idempotent notification payloads

## Validation

- default, cluster, async-std, and async-trait test configurations
- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`

## Review notes

Actors that use PG allocate one small `Arc<Mutex<ActorRelations>>`, retained until shutdown. Operations for the same actor serialize; unrelated actors and groups remain concurrent. `Stopping` is visible before cleanup begins, while stop-wait notification remains after cleanup and `post_stop`.
