### PR TITLE
Reclaim cancelled remote RPC reply ports

### DIFF
--- a/ractor_cluster/src/remote_actor.rs
+++ b/ractor_cluster/src/remote_actor.rs
@@ -7,7 +7,8 @@
 //! running on a remote `node()` server. See [crate::node::NodeServer] for more on inter-node
 //! protocols
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
+use std::ops::Bound::{Excluded, Unbounded};
 
 use ractor::cast;
 use ractor::concurrency::JoinHandle;
@@ -27,6 +28,13 @@ use crate::NodeId;
 
 #[cfg(test)]
 mod tests;
+
+/// Maximum number of pending requests inspected when handling a message.
+///
+/// A fixed budget keeps cleanup work bounded while sustained traffic advances a
+/// round-robin cursor through all pending requests. This avoids a task or timer
+/// per RPC while still reclaiming reply ports whose receivers have gone away.
+const PENDING_REQUEST_CLEANUP_BUDGET: usize = 16;
 
 /// A [RemoteActor] is an actor which represents an actor on another node
 ///
@@ -66,17 +74,88 @@ pub(crate) struct RemoteActorState {
     message_tag: u64,
     /// The map of <message_tag, serialized_rpc_reply> port for network
     /// handling of [SerializedMessage::CallReply]s
-    pending_requests: HashMap<u64, RpcReplyPort<Vec<u8>>>,
+    pending_requests: BTreeMap<u64, RpcReplyPort<Vec<u8>>>,
+    /// Last request inspected for cancellation. The ordered map lets cleanup
+    /// resume without scanning every live request for every message.
+    pending_request_cleanup_cursor: Option<u64>,
 
     /// Owning session
     session: ActorRef<crate::node::NodeSessionMessage>,
 }
 
 impl RemoteActorState {
+    fn new(session: ActorRef<crate::node::NodeSessionMessage>) -> Self {
+        Self {
+            session,
+            message_tag: 0,
+            pending_requests: BTreeMap::new(),
+            pending_request_cleanup_cursor: None,
+        }
+    }
+
     /// Increment the message tag and return the "next" value
     fn get_and_increment_mtag(&mut self) -> u64 {
         self.message_tag += 1;
         self.message_tag
+    }
+
+    /// Remove reply ports whose receivers were cancelled or timed out.
+    ///
+    /// Each invocation inspects at most [`PENDING_REQUEST_CLEANUP_BUDGET`]
+    /// entries and resumes from the previous cursor, wrapping at the end. The
+    /// fixed-size tag buffer avoids allocating as part of message processing.
+    fn cleanup_closed_pending_requests(&mut self) {
+        let cleanup_count = self
+            .pending_requests
+            .len()
+            .min(PENDING_REQUEST_CLEANUP_BUDGET);
+        if cleanup_count == 0 {
+            self.pending_request_cleanup_cursor = None;
+            return;
+        }
+
+        let mut tags = [0; PENDING_REQUEST_CLEANUP_BUDGET];
+        let mut tag_count = 0;
+
+        if let Some(cursor) = self.pending_request_cleanup_cursor {
+            for (&tag, _) in self
+                .pending_requests
+                .range((Excluded(cursor), Unbounded))
+                .take(cleanup_count)
+            {
+                tags[tag_count] = tag;
+                tag_count += 1;
+            }
+        }
+
+        for (&tag, _) in self.pending_requests.iter().take(cleanup_count - tag_count) {
+            tags[tag_count] = tag;
+            tag_count += 1;
+        }
+
+        for tag in &tags[..tag_count] {
+            if self
+                .pending_requests
+                .get(tag)
+                .map_or(false, RpcReplyPort::is_closed)
+            {
+                self.pending_requests.remove(tag);
+            }
+        }
+
+        self.pending_request_cleanup_cursor = if self.pending_requests.is_empty() {
+            None
+        } else {
+            tags[..tag_count].last().copied()
+        };
+    }
+
+    fn remove_pending_request(&mut self, message_tag: u64) -> Option<RpcReplyPort<Vec<u8>>> {
+        let port = self.pending_requests.remove(&message_tag);
+        if self.pending_requests.is_empty() {
+            self.pending_request_cleanup_cursor = None;
+        }
+        port
     }
 }
 
@@ -95,11 +174,7 @@ impl Actor for RemoteActor {
         _myself: ActorRef<Self::Msg>,
         session: ActorRef<crate::node::NodeSessionMessage>,
     ) -> Result<Self::State, ActorProcessingErr> {
-        Ok(Self::State {
-            session,
-            message_tag: 0,
-            pending_requests: HashMap::new(),
-        })
+        Ok(Self::State::new(session))
     }
 
     async fn handle(
@@ -117,6 +192,8 @@ impl Actor for RemoteActor {
         message: SerializedMessage,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
+        state.cleanup_closed_pending_requests();
+
         // get the local pid on the remote system
         let to = myself.get_id().pid();
         // messages should be forwarded over the network link (i.e. sent through the node session) to the intended
@@ -144,7 +221,12 @@ impl Actor for RemoteActor {
                     )),
                 };
                 state.pending_requests.insert(tag, reply);
-                let _ = cast!(state.session, NodeSessionMessage::SendMessage(node_msg));
+                if cast!(state.session, NodeSessionMessage::SendMessage(node_msg)).is_err() {
+                    // Dropping the reply port immediately notifies the local
+                    // caller that forwarding failed instead of retaining it
+                    // until the remote actor itself exits.
+                    state.remove_pending_request(tag);
+                }
             }
             SerializedMessage::Cast {
                 args,
@@ -166,7 +248,7 @@ impl Actor for RemoteActor {
             }
             SerializedMessage::CallReply(message_tag, reply_data) => {
                 // Handle the reply to a "Call" message
-                if let Some(port) = state.pending_requests.remove(&message_tag) {
+                if let Some(port) = state.remove_pending_request(message_tag) {
                     let _ = port.send(reply_data);
                 }
             }

--- a/ractor_cluster/src/remote_actor/tests.rs
+++ b/ractor_cluster/src/remote_actor/tests.rs
@@ -31,52 +31,92 @@ impl Actor for FakeNodeSession {
     }
 }
 
+struct TestContext {
+    session: ActorRef<crate::node::NodeSessionMessage>,
+    session_handle: JoinHandle<()>,
+    remote_actor: ActorRef<RemoteActorMessage>,
+    remote_actor_handle: JoinHandle<()>,
+}
+
+impl TestContext {
+    async fn new() -> Self {
+        let (session, session_handle) = FakeNodeSession::get_node_session().await;
+        let (remote_actor, remote_actor_handle) = Actor::spawn(None, RemoteActor, session.clone())
+            .await
+            .expect("Failed to spawn remote actor");
+        Self {
+            session,
+            session_handle,
+            remote_actor,
+            remote_actor_handle,
+        }
+    }
+
+    fn state(&self) -> RemoteActorState {
+        RemoteActorState::new(self.session.clone())
+    }
+
+    async fn shutdown(self) {
+        self.remote_actor.stop(None);
+        self.session.stop(None);
+        self.remote_actor_handle.await.unwrap();
+        self.session_handle.await.unwrap();
+    }
+}
+
+fn serialized_call(reply: RpcReplyPort<Vec<u8>>) -> SerializedMessage {
+    SerializedMessage::Call {
+        variant: "Call".to_string(),
+        args: vec![1, 2, 3],
+        reply,
+        metadata: None,
+    }
+}
+
+fn serialized_cast() -> SerializedMessage {
+    SerializedMessage::Cast {
+        variant: "Cast".to_string(),
+        args: vec![1, 2, 3],
+        metadata: None,
+    }
+}
+
 #[ractor::concurrency::test]
 async fn remote_actor_serialized_message_handling() {
     // setup
-    let (actor, handle) = FakeNodeSession::get_node_session().await;
-    let (remote_actor_ref, remote_actor_handle) = Actor::spawn(None, RemoteActor, actor.clone())
-        .await
-        .expect("Failed to spawn remote actor");
+    let context = TestContext::new().await;
 
     let remote_actor_instance = RemoteActor;
-    let mut remote_actor_state = RemoteActorState {
-        message_tag: 0,
-        pending_requests: HashMap::new(),
-        session: actor.clone(),
-    };
+    let mut remote_actor_state = context.state();
 
     // act & verify
     let bad_handler = remote_actor_instance
         .handle(
-            remote_actor_ref.clone(),
+            context.remote_actor.clone(),
             RemoteActorMessage,
             &mut remote_actor_state,
         )
         .await;
     assert!(bad_handler.is_err());
 
-    let cast = SerializedMessage::Cast {
-        variant: "A".to_string(),
-        args: vec![1, 2, 3],
-        metadata: None,
-    };
     let cast_output = remote_actor_instance
-        .handle_serialized(remote_actor_ref.clone(), cast, &mut remote_actor_state)
+        .handle_serialized(
+            context.remote_actor.clone(),
+            serialized_cast(),
+            &mut remote_actor_state,
+        )
         .await;
     assert!(cast_output.is_ok());
     // cast's don't have pending requests
     assert_eq!(0, remote_actor_state.message_tag);
 
     let (tx, _rx) = ractor::concurrency::oneshot();
-    let call = SerializedMessage::Call {
-        variant: "B".to_string(),
-        args: vec![1, 2, 3],
-        reply: tx.into(),
-        metadata: None,
-    };
     let call_output = remote_actor_instance
-        .handle_serialized(remote_actor_ref.clone(), call, &mut remote_actor_state)
+        .handle_serialized(
+            context.remote_actor.clone(),
+            serialized_call(tx.into()),
+            &mut remote_actor_state,
+        )
         .await;
     assert!(call_output.is_ok());
     assert_eq!(1, remote_actor_state.message_tag);
@@ -84,14 +124,202 @@ async fn remote_actor_serialized_message_handling() {
 
     let reply = SerializedMessage::CallReply(1, vec![3, 4, 5]);
     let reply_output = remote_actor_instance
-        .handle_serialized(remote_actor_ref.clone(), reply, &mut remote_actor_state)
+        .handle_serialized(context.remote_actor.clone(), reply, &mut remote_actor_state)
         .await;
     assert!(reply_output.is_ok());
     assert!(!remote_actor_state.pending_requests.contains_key(&1));
 
     // cleanup
-    remote_actor_ref.stop(None);
-    actor.stop(None);
+    context.shutdown().await;
+}
+
+#[ractor::concurrency::test]
+async fn cancelled_and_timed_out_requests_are_reclaimed_amortized() {
+    let context = TestContext::new().await;
+    let remote_actor_instance = RemoteActor;
+    let mut state = context.state();
+    let live_request_count = PENDING_REQUEST_CLEANUP_BUDGET * 2;
+    let closed_request_count = PENDING_REQUEST_CLEANUP_BUDGET * 8;
+    let mut live_receivers = Vec::with_capacity(live_request_count);
+
+    for _ in 0..live_request_count {
+        let (sender, receiver) = ractor::concurrency::oneshot::<Vec<u8>>();
+        remote_actor_instance
+            .handle_serialized(
+                context.remote_actor.clone(),
+                serialized_call(sender.into()),
+                &mut state,
+            )
+            .await
+            .unwrap();
+        live_receivers.push(receiver);
+    }
+
+    for request in 0..closed_request_count {
+        let (sender, receiver) = ractor::concurrency::oneshot::<Vec<u8>>();
+        let reply: RpcReplyPort<Vec<u8>> = if request % 2 == 0 {
+            drop(receiver);
+            sender.into()
+        } else {
+            let reply = (sender, ractor::concurrency::Duration::ZERO).into();
+            assert!(
+                ractor::concurrency::timeout(ractor::concurrency::Duration::ZERO, receiver)
+                    .await
+                    .is_err()
+            );
+            reply
+        };
+        remote_actor_instance
+            .handle_serialized(
+                context.remote_actor.clone(),
+                serialized_call(reply),
+                &mut state,
+            )
+            .await
+            .unwrap();
+    }
+
+    let cleanup_messages =
+        (live_request_count + closed_request_count + PENDING_REQUEST_CLEANUP_BUDGET - 1)
+            / PENDING_REQUEST_CLEANUP_BUDGET;
+    for _ in 0..cleanup_messages {
+        remote_actor_instance
+            .handle_serialized(context.remote_actor.clone(), serialized_cast(), &mut state)
+            .await
+            .unwrap();
+    }
+
+    assert_eq!(state.pending_requests.len(), live_request_count);
+    for tag in 1..=live_request_count as u64 {
+        assert!(state.pending_requests.contains_key(&tag));
+    }
+
+    for (index, receiver) in live_receivers.into_iter().enumerate() {
+        let tag = index as u64 + 1;
+        let response = tag.to_be_bytes().to_vec();
+        remote_actor_instance
+            .handle_serialized(
+                context.remote_actor.clone(),
+                SerializedMessage::CallReply(tag, response.clone()),
+                &mut state,
+            )
+            .await
+            .unwrap();
+        assert_eq!(receiver.await.unwrap(), response);
+    }
+    assert!(state.pending_requests.is_empty());
+
+    context.shutdown().await;
+}
+
+#[ractor::concurrency::test]
+async fn forwarding_failure_drops_the_pending_reply_port() {
+    let TestContext {
+        session,
+        session_handle,
+        remote_actor,
+        remote_actor_handle,
+    } = TestContext::new().await;
+    session.stop(None);
+    session_handle.await.unwrap();
+
+    let remote_actor_instance = RemoteActor;
+    let mut state = RemoteActorState::new(session);
+    let (sender, receiver) = ractor::concurrency::oneshot::<Vec<u8>>();
+    remote_actor_instance
+        .handle_serialized(
+            remote_actor.clone(),
+            serialized_call(sender.into()),
+            &mut state,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(state.message_tag, 1);
+    assert!(state.pending_requests.is_empty());
+    assert!(receiver.await.is_err());
+
+    remote_actor.stop(None);
     remote_actor_handle.await.unwrap();
-    handle.await.unwrap();
+}
+
+#[ractor::concurrency::test]
+async fn live_concurrent_requests_survive_cleanup_and_reply_out_of_order() {
+    let context = TestContext::new().await;
+    let remote_actor_instance = RemoteActor;
+    let mut state = context.state();
+    let request_count = PENDING_REQUEST_CLEANUP_BUDGET * 3 + 1;
+    let mut receivers = Vec::with_capacity(request_count);
+
+    for _ in 0..request_count {
+        let (sender, receiver) = ractor::concurrency::oneshot::<Vec<u8>>();
+        remote_actor_instance
+            .handle_serialized(
+                context.remote_actor.clone(),
+                serialized_call(sender.into()),
+                &mut state,
+            )
+            .await
+            .unwrap();
+        receivers.push(receiver);
+    }
+    assert_eq!(state.pending_requests.len(), request_count);
+
+    for tag in (1..=request_count as u64).rev() {
+        remote_actor_instance
+            .handle_serialized(
+                context.remote_actor.clone(),
+                SerializedMessage::CallReply(tag, tag.to_be_bytes().to_vec()),
+                &mut state,
+            )
+            .await
+            .unwrap();
+    }
+
+    for (index, receiver) in receivers.into_iter().enumerate() {
+        assert_eq!(
+            receiver.await.unwrap(),
+            (index as u64 + 1).to_be_bytes().to_vec()
+        );
+    }
+    assert!(state.pending_requests.is_empty());
+
+    context.shutdown().await;
+}
+
+#[ractor::concurrency::test]
+async fn late_reply_after_request_cleanup_is_ignored() {
+    let context = TestContext::new().await;
+    let remote_actor_instance = RemoteActor;
+    let mut state = context.state();
+    let (sender, receiver) = ractor::concurrency::oneshot::<Vec<u8>>();
+    drop(receiver);
+
+    remote_actor_instance
+        .handle_serialized(
+            context.remote_actor.clone(),
+            serialized_call(sender.into()),
+            &mut state,
+        )
+        .await
+        .unwrap();
+    assert!(state.pending_requests.contains_key(&1));
+
+    remote_actor_instance
+        .handle_serialized(context.remote_actor.clone(), serialized_cast(), &mut state)
+        .await
+        .unwrap();
+    assert!(state.pending_requests.is_empty());
+
+    remote_actor_instance
+        .handle_serialized(
+            context.remote_actor.clone(),
+            SerializedMessage::CallReply(1, vec![9, 9, 9]),
+            &mut state,
+        )
+        .await
+        .unwrap();
+    assert!(state.pending_requests.is_empty());
+
+    context.shutdown().await;
 }


### PR DESCRIPTION
## Summary

- reclaim remote RPC reply ports after callers time out or cancel
- bound cleanup to 16 entries per serialized message with a round-robin cursor
- remove a pending port immediately when forwarding to the owning session fails

## Why

Pending RPC ports were removed only when a remote reply arrived. A timeout, cancelled caller, unreachable peer, or failed session cast could therefore retain entries for the lifetime of the remote-actor proxy.

The cleanup uses an ordered map and a fixed-size stack buffer. It creates no timer/task per RPC and performs bounded work on each message; sustained traffic advances through the full map. An idle final set is reclaimed on later traffic or actor shutdown.

## Compatibility and cost

There are no wire or public API changes. Map operations become `O(log n)` instead of expected `O(1)`, trading a small bookkeeping cost for deterministic, allocation-free cleanup traversal.

## Validation

- mixed live, cancelled, and zero-timeout RPC cleanup under sustained traffic
- out-of-order concurrent replies remain deliverable during cleanup
- failed session forwarding releases the caller immediately
- late replies after cleanup are harmless
- default and `async-trait` cluster tests, plus blanket-serde integration tests
- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`
