### PR TITLE
Make cluster span propagation genuinely optional

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,10 @@ jobs:
           - name: Test ractor_cluster with native async traits
             package: ractor_cluster
             # flags:
+          - name: Test ractor_cluster without message span propagation
+            package: ractor_cluster
+            flags: --no-default-features
+            verify_no_span: true
           - name: Test ractor_cluster with async_trait
             package: ractor_cluster
             flags: -F async-trait
@@ -68,6 +72,16 @@ jobs:
         with:
           command: test
           args: --package ${{matrix.package}} ${{matrix.flags}}
+
+      - name: Verify message span propagation is disabled
+        if: matrix.verify_no_span
+        shell: bash
+        run: |
+          if cargo tree --package ractor_cluster --no-default-features --edges features --invert ractor \
+            | grep -Fq 'ractor feature "message_span_propogation"'; then
+            echo 'ractor/message_span_propogation was unexpectedly enabled' >&2
+            exit 1
+          fi
 
       - name: Test everything
         uses: actions-rs/cargo@v1

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -19,7 +19,7 @@ monitors = ["ractor/monitors"]
 message_span_propogation = ["ractor/message_span_propogation"]
 async-trait = ["dep:async-trait", "ractor/async-trait"]
 
-default = []
+default = ["message_span_propogation"]
 
 [build-dependencies]
 protoc-bin-vendored = "3"
@@ -30,7 +30,7 @@ prost-build = { version = "0.14" }
 bytes = { version = "1" }
 prost = { version = "0.14" }
 prost-types = { version = "0.14" }
-ractor = { version = "0.15.0", default-features = false, features = ["tokio_runtime", "message_span_propogation", "cluster"], path = "../ractor" }
+ractor = { version = "0.15.0", default-features = false, features = ["tokio_runtime", "cluster"], path = "../ractor" }
 ractor_cluster_derive = { version = "0.15.0", path = "../ractor_cluster_derive" }
 rand = "0.10"
 socket2 = { version = "0.6", features = ["all"] }


### PR DESCRIPTION
## Summary

- make `ractor_cluster/message_span_propogation` actually control the corresponding `ractor` feature
- preserve the existing span-enabled default while making `--no-default-features` a real opt-out
- add CI coverage for both the build and resolved dependency feature graph

## Why

`ractor_cluster` exposed a forwarding feature, but its `ractor` dependency enabled span propagation unconditionally. Consumers therefore paid for span storage and propagation even after disabling all `ractor_cluster` default features.

## Compatibility

Default builds retain their current behavior. Only explicit no-default builds change, matching the crate's documented feature contract. Cargo's normal additive feature unification still applies if another dependency enables `ractor/message_span_propogation`.

## Validation

- default and `--no-default-features` cluster test suites
- no-default plus `async-trait` feature resolution inspection
- CI assertion that the no-default graph omits `ractor/message_span_propogation`
- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`
