### PR TITLE
Harden node session heartbeats

### DIFF
--- a/ractor_cluster/src/node/node_session.rs
+++ b/ractor_cluster/src/node/node_session.rs
@@ -41,6 +41,9 @@ use crate::NodeServerMessage;
 
 const MIN_PING_LATENCY_MS: u64 = 1000;
 const MAX_PING_LATENCY_MS: u64 = 5000;
+const MIN_PROTOBUF_TIMESTAMP_SECONDS: i64 = -62_135_596_800;
+const MAX_PROTOBUF_TIMESTAMP_SECONDS: i64 = 253_402_300_799;
+const NANOSECONDS_PER_SECOND: i32 = 1_000_000_000;
 
 #[cfg(test)]
 mod tests;
@@ -536,25 +539,7 @@ impl NodeSession {
                     });
                 }
                 control_protocol::control_message::Msg::Pong(pong) => {
-                    let ts: std::time::SystemTime = pong
-                        .timestamp
-                        .expect("Timestamp missing in Pong")
-                        .try_into()
-                        .expect("Failed to convert Pong(Timestamp) to SystemTime");
-                    let inst = ts
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .expect("Time went backwards");
-                    let delta_ms = (state.epoch.elapsed() - inst).as_millis();
-                    tracing::debug!("Ping -> Pong took {delta_ms}ms");
-                    if delta_ms > 50 {
-                        tracing::warn!(
-                            "Super long ping detected {} - {} ({delta_ms}ms)",
-                            state.local_addr,
-                            state.peer_addr,
-                        );
-                    }
-                    // schedule next ping
-                    state.schedule_tcp_ping();
+                    state.handle_pong(pong);
                 }
                 control_protocol::control_message::Msg::PgJoin(join) => {
                     let mut cells = vec![];
@@ -691,7 +676,7 @@ impl NodeSession {
         );
 
         // startup the ping healthcheck activity
-        state.schedule_tcp_ping();
+        state.start_ping_loop();
 
         // trigger enumeration of the remote peer's node sessions for transitive connections
         if let NodeConnectionMode::Transitive = self.connection_mode {
@@ -803,13 +788,46 @@ impl NodeSession {
     }
 }
 
+#[derive(Debug)]
+struct AbortOnDropTask {
+    handle: Option<ractor::concurrency::JoinHandle<()>>,
+}
+
+impl AbortOnDropTask {
+    fn new(handle: ractor::concurrency::JoinHandle<()>) -> Self {
+        Self {
+            handle: Some(handle),
+        }
+    }
+
+    fn abort(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+impl Drop for AbortOnDropTask {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}
+
+#[derive(Debug, Default)]
+struct PongWarnings {
+    invalid: bool,
+    slow: bool,
+}
+
 /// The state of the node session
 #[derive(Debug)]
 pub struct NodeSessionState {
     tcp: Option<ActorRef<SessionMessage>>,
+    ping_task: Option<AbortOnDropTask>,
     peer_addr: SocketAddr,
     local_addr: SocketAddr,
     epoch: Instant,
+    pong_warnings: PongWarnings,
     name: Option<auth_protocol::NameMessage>,
     auth: AuthenticationState,
     ready: ReadyState,
@@ -853,28 +871,99 @@ impl NodeSessionState {
         }
     }
 
-    fn schedule_tcp_ping(&self) {
-        let epoch = self.epoch;
-        if let Some(tcp) = &self.tcp {
-            #[allow(clippy::let_underscore_future)]
-            let _ = tcp.send_after(Self::get_send_delay(), move || {
-                let ping = control_protocol::ControlMessage {
-                    msg: Some(control_protocol::control_message::Msg::Ping(
-                        control_protocol::Ping {
-                            timestamp: Some(prost_types::Timestamp::from(
-                                SystemTime::UNIX_EPOCH + epoch.elapsed(),
-                            )),
-                        },
-                    )),
-                };
-                let net_msg = crate::protocol::NetworkMessage {
-                    message: Some(crate::protocol::meta::network_message::Message::Control(
-                        ping,
-                    )),
-                };
-                SessionMessage::Send(net_msg)
-            });
+    fn start_ping_loop(&mut self) {
+        self.start_ping_loop_with_delay(Self::get_send_delay);
+    }
+
+    fn start_ping_loop_with_delay<F>(&mut self, next_delay: F) -> bool
+    where
+        F: Fn() -> Duration + Send + 'static,
+    {
+        if self.ping_task.is_some() {
+            return false;
         }
+        let tcp = match self.tcp.clone() {
+            Some(tcp) => tcp,
+            None => return false,
+        };
+
+        let epoch = self.epoch;
+        self.ping_task = Some(AbortOnDropTask::new(ractor::concurrency::spawn(
+            async move {
+                loop {
+                    ractor::concurrency::sleep(next_delay()).await;
+                    let ping = control_protocol::ControlMessage {
+                        msg: Some(control_protocol::control_message::Msg::Ping(
+                            control_protocol::Ping {
+                                timestamp: Some(prost_types::Timestamp::from(
+                                    SystemTime::UNIX_EPOCH + epoch.elapsed(),
+                                )),
+                            },
+                        )),
+                    };
+                    let net_msg = crate::protocol::NetworkMessage {
+                        message: Some(crate::protocol::meta::network_message::Message::Control(
+                            ping,
+                        )),
+                    };
+                    if tcp.cast(SessionMessage::Send(net_msg)).is_err() {
+                        break;
+                    }
+                }
+            },
+        )));
+        true
+    }
+
+    fn handle_pong(&mut self, pong: control_protocol::Pong) {
+        match self.pong_latency(pong.timestamp) {
+            Ok(delta) => {
+                let delta_ms = delta.as_millis();
+                tracing::debug!("Ping -> Pong took {delta_ms}ms");
+                if delta_ms > 50 && !self.pong_warnings.slow {
+                    tracing::warn!(
+                        "Slow ping detected {} - {} ({delta_ms}ms); further slow Pongs will only be logged at debug level",
+                        self.local_addr,
+                        self.peer_addr,
+                    );
+                    self.pong_warnings.slow = true;
+                }
+            }
+            Err(reason) if !self.pong_warnings.invalid => {
+                tracing::warn!(
+                    "Ignoring invalid Pong from {} to {}: {reason}; further invalid Pongs will be ignored",
+                    self.peer_addr,
+                    self.local_addr,
+                );
+                self.pong_warnings.invalid = true;
+            }
+            Err(_) => {}
+        }
+    }
+
+    fn pong_latency(
+        &self,
+        timestamp: Option<prost_types::Timestamp>,
+    ) -> Result<Duration, &'static str> {
+        let timestamp = timestamp.ok_or("timestamp is missing")?;
+        // `prost_types` normalizes invalid values during conversion, so validate
+        // the documented `google.protobuf.Timestamp` wire range first.
+        if !(MIN_PROTOBUF_TIMESTAMP_SECONDS..=MAX_PROTOBUF_TIMESTAMP_SECONDS)
+            .contains(&timestamp.seconds)
+            || !(0..NANOSECONDS_PER_SECOND).contains(&timestamp.nanos)
+        {
+            return Err("timestamp is outside the protobuf Timestamp range");
+        }
+        let timestamp: SystemTime = timestamp
+            .try_into()
+            .map_err(|_| "timestamp is out of range")?;
+        let sent_at = timestamp
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|_| "timestamp predates the Unix epoch")?;
+        self.epoch
+            .elapsed()
+            .checked_sub(sent_at)
+            .ok_or("timestamp is ahead of this session's clock")
     }
 
     fn get_send_delay() -> Duration {
@@ -907,6 +996,7 @@ impl Actor for NodeSession {
 
         let state = Self::State {
             tcp: Some(actor),
+            ping_task: None,
             name: None,
             auth: if self.is_server {
                 AuthenticationState::AsServer(auth::ServerAuthenticationProcess::init())
@@ -918,6 +1008,7 @@ impl Actor for NodeSession {
             peer_addr,
             local_addr,
             epoch: Instant::now(),
+            pong_warnings: PongWarnings::default(),
         };
 
         // If a client-connection, startup the handshake
@@ -935,8 +1026,12 @@ impl Actor for NodeSession {
     async fn post_stop(
         &self,
         myself: ActorRef<Self::Msg>,
-        _state: &mut Self::State,
+        state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
+        if let Some(mut ping_task) = state.ping_task.take() {
+            ping_task.abort();
+        }
+
         // unhook monitoring sessions
         ractor::pg::demonitor_scope(
             ractor::pg::ALL_SCOPES_NOTIFICATION.to_string(),

--- a/ractor_cluster/src/node/node_session/tests.rs
+++ b/ractor_cluster/src/node/node_session/tests.rs
@@ -5,10 +5,12 @@
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Instant;
+use std::time::SystemTime;
 
 use ractor::concurrency::sleep;
 
@@ -78,6 +80,165 @@ impl Actor for DummyNodeSession {
     }
 }
 
+struct PingCounter {
+    pings: Arc<AtomicU8>,
+}
+
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+impl Actor for PingCounter {
+    type Msg = SessionMessage;
+    type State = ();
+    type Arguments = ();
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(())
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        if matches!(
+            message,
+            SessionMessage::Send(crate::protocol::NetworkMessage {
+                message: Some(crate::protocol::meta::network_message::Message::Control(
+                    control_protocol::ControlMessage {
+                        msg: Some(control_protocol::control_message::Msg::Ping(_)),
+                    },
+                )),
+            })
+        ) {
+            self.pings.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(())
+    }
+}
+
+fn authenticated_state(tcp: Option<ActorRef<SessionMessage>>) -> NodeSessionState {
+    NodeSessionState {
+        auth: AuthenticationState::AsClient(auth::ClientAuthenticationProcess::Ok),
+        ready: ReadyState::Open,
+        local_addr: SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0),
+        peer_addr: SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0),
+        name: None,
+        remote_actors: HashMap::new(),
+        tcp,
+        ping_task: None,
+        epoch: Instant::now(),
+        pong_warnings: PongWarnings::default(),
+    }
+}
+
+#[test]
+fn node_session_rejects_malformed_pongs_without_scheduling_work() {
+    let mut state = authenticated_state(None);
+    let future_timestamp = prost_types::Timestamp::from(
+        SystemTime::UNIX_EPOCH + state.epoch.elapsed() + Duration::from_secs(60),
+    );
+    let malformed_timestamps = [
+        None,
+        Some(prost_types::Timestamp {
+            seconds: 0,
+            nanos: 1_000_000_000,
+        }),
+        Some(prost_types::Timestamp {
+            seconds: -1,
+            nanos: 0,
+        }),
+        Some(future_timestamp),
+    ];
+
+    for timestamp in malformed_timestamps {
+        assert!(state.pong_latency(timestamp.clone()).is_err());
+        state.handle_pong(control_protocol::Pong { timestamp });
+    }
+
+    assert!(state.pong_warnings.invalid);
+    assert!(state.ping_task.is_none());
+    assert!(state
+        .pong_latency(Some(prost_types::Timestamp::from(SystemTime::UNIX_EPOCH)))
+        .is_ok());
+
+    state.epoch = Instant::now()
+        .checked_sub(Duration::from_secs(1))
+        .expect("Failed to create an earlier monotonic epoch");
+    for _ in 0..2 {
+        state.handle_pong(control_protocol::Pong {
+            timestamp: Some(prost_types::Timestamp::from(SystemTime::UNIX_EPOCH)),
+        });
+    }
+    assert!(state.pong_warnings.slow);
+}
+
+#[ractor::concurrency::test]
+async fn node_session_ping_loop_is_single_and_state_owned() {
+    let pings = Arc::new(AtomicU8::new(0));
+    let (tcp, tcp_handle) = Actor::spawn(
+        None,
+        PingCounter {
+            pings: pings.clone(),
+        },
+        (),
+    )
+    .await
+    .expect("Failed to start ping counter");
+    let mut state = authenticated_state(Some(tcp.clone()));
+    let task_capture = Arc::new(AtomicBool::new(false));
+    let weak_task_capture = Arc::downgrade(&task_capture);
+
+    assert!(state.start_ping_loop_with_delay(move || {
+        task_capture.store(true, Ordering::Relaxed);
+        Duration::from_millis(5)
+    }));
+    assert!(!state.start_ping_loop_with_delay(|| Duration::from_millis(1)));
+
+    let two_pings_without_a_pong =
+        ractor::concurrency::timeout(Duration::from_millis(250), async {
+            while pings.load(Ordering::Relaxed) < 2 {
+                sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await;
+    assert!(two_pings_without_a_pong.is_ok());
+
+    for _ in 0..10 {
+        state.handle_pong(control_protocol::Pong {
+            timestamp: Some(prost_types::Timestamp::from(SystemTime::UNIX_EPOCH)),
+        });
+    }
+    let prior_pings = pings.load(Ordering::Relaxed);
+    let ping_after_unsolicited_pongs =
+        ractor::concurrency::timeout(Duration::from_millis(250), async {
+            while pings.load(Ordering::Relaxed) == prior_pings {
+                sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await;
+    assert!(ping_after_unsolicited_pongs.is_ok());
+
+    drop(state);
+    let task_released = ractor::concurrency::timeout(Duration::from_millis(250), async {
+        while weak_task_capture.upgrade().is_some() {
+            sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await;
+    assert!(task_released.is_ok());
+
+    let pings_after_state_drop = pings.load(Ordering::Relaxed);
+    sleep(Duration::from_millis(25)).await;
+    assert_eq!(pings_after_state_drop, pings.load(Ordering::Relaxed));
+
+    tcp.stop(None);
+    tcp_handle.await.unwrap();
+}
+
 #[ractor::concurrency::test]
 async fn node_sesison_client_auth_success() {
     let (dummy_server, dummy_shandle) = Actor::spawn(None, DummyNodeServer, ())
@@ -113,7 +274,9 @@ async fn node_sesison_client_auth_success() {
         name: None,
         remote_actors: HashMap::new(),
         tcp: None,
+        ping_task: None,
         epoch: Instant::now(),
+        pong_warnings: PongWarnings::default(),
     };
 
     // Client sends their name, Server responds with Ok
@@ -259,7 +422,9 @@ async fn node_session_client_auth_session_state_failures() {
         name: None,
         remote_actors: HashMap::new(),
         tcp: None,
+        ping_task: None,
         epoch: Instant::now(),
+        pong_warnings: PongWarnings::default(),
     };
 
     // Client sends their name, Server responds with Ok
@@ -390,7 +555,9 @@ async fn node_session_server_auth_success() {
         name: None,
         remote_actors: HashMap::new(),
         tcp: None,
+        ping_task: None,
         epoch: Instant::now(),
+        pong_warnings: PongWarnings::default(),
     };
 
     // Client sends their name
@@ -485,7 +652,9 @@ async fn node_session_server_auth_session_state_failures() {
         name: None,
         remote_actors: HashMap::new(),
         tcp: None,
+        ping_task: None,
         epoch: Instant::now(),
+        pong_warnings: PongWarnings::default(),
     };
 
     // Other session continues, this one dies
@@ -635,7 +804,9 @@ async fn node_session_handle_node_msg() {
         name: None,
         remote_actors: HashMap::new(),
         tcp: None,
+        ping_task: None,
         epoch: Instant::now(),
+        pong_warnings: PongWarnings::default(),
     };
     // add the "remote" actor
     state
@@ -733,7 +904,9 @@ async fn node_session_handle_control() {
         name: None,
         remote_actors: HashMap::new(),
         tcp: None,
+        ping_task: None,
         epoch: Instant::now(),
+        pong_warnings: PongWarnings::default(),
     };
 
     // check spawn creates a remote actor


### PR DESCRIPTION
## Summary

- run exactly one session-owned periodic ping loop after authentication
- make ping cadence independent of receiving a Pong
- reject missing, malformed, pre-epoch, and future Pong timestamps without panicking
- rate-limit invalid- and slow-Pong warnings to one per session

## Why

The previous reply-driven scheduling had three failure modes: a lost Pong stopped heartbeats permanently, every unsolicited Pong created another timer chain, and malformed timestamps could panic the `NodeSession`. A malicious authenticated peer could therefore amplify background work or terminate the session actor.

The loop now lives for the session lifetime, exits when the transport closes, and uses abort-on-drop ownership so normal stops, kills, and panics all cancel it. Pong handling only records valid latency.

## Compatibility and scope

There are no public API or wire-format changes. This preserves the existing randomized 1–5 second cadence and does not add a heartbeat timeout/disconnect policy.

## Validation

- multiple pings continue without any Pong
- repeated unsolicited Pongs cannot start another loop
- missing, invalid, pre-epoch, and future timestamps are ignored safely
- dropping session state cancels the loop and releases its captured transport
- default and `async-trait` cluster test suites
- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`
