### PR TITLE
Prepare Ractor 0.16 with a Rust 1.85 MSRV

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,35 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
+  msrv:
+    name: Rust 1.85 MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Install Rust 1.85
+        uses: dtolnay/rust-toolchain@1.85.0
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Check workspace defaults and all targets
+        run: cargo check --workspace --all-targets
+
+      - name: Check async traits with Tokio
+        run: cargo check --package ractor --features async-trait
+
+      - name: Check async traits with async-std
+        run: cargo check --package ractor --no-default-features --features async-std,async-trait
+
+      - name: Check optional ractor APIs
+        run: cargo check --package ractor --features cluster,monitors,blanket_serde,output-port-v2
+
+      - name: Check ractor_cluster with async traits
+        run: cargo check --package ractor_cluster --features async-trait
+
+      - name: Check the ractor WASM library
+        run: cargo check --package ractor --lib --target wasm32-unknown-unknown
+
   test:
     name: ${{matrix.name}}
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,8 +236,7 @@ Default features: `tokio_runtime`, `message_span_propogation`
 
 ### Runtime Requirements
 
-- MSRV: Rust 1.64
-- Native async fn in traits requires Rust >= 1.75 (otherwise use `async-trait` feature)
+- MSRV: Rust 1.85
 - Thread-local actors REQUIRE tokio runtime with `rt` feature
 - WASM support available (target `wasm32-unknown-unknown`)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,8 @@ members = [
     "ractor_example_entry_proc",
     "xtask",
 ]
-resolver = "2"
+resolver = "3"
+
+[workspace.package]
+rust-version = "1.85"
+version = "0.16.0"

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Install `ractor` by adding the following to your Cargo.toml dependencies.
 
 ```toml
 [dependencies]
-ractor = "0.15"
+ractor = "0.16"
 ```
 
-The minimum supported Rust version (MSRV) of `ractor` is `1.64`. However to utilize the native `async fn` support in traits and not rely on the `async-trait` crate's desugaring functionliaty, you need to be on Rust version `>= 1.75`. The stabilization of `async fn` in traits [was recently added](https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html).
+The minimum supported Rust version (MSRV) of `ractor` is `1.85`.
 
 ## Features
 

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor"
-version = "0.15.13"
+version.workspace = true
 authors = ["Sean Lawlor", "Evan Au", "Dillon George"]
 description = "A actor framework for Rust"
 documentation = "https://docs.rs/ractor"
@@ -11,7 +11,7 @@ repository = "https://github.com/slawlor/ractor"
 readme = "../README.md"
 homepage = "https://github.com/slawlor/ractor"
 categories = ["asynchronous"]
-rust-version = "1.64"
+rust-version.workspace = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
@@ -69,7 +69,7 @@ backtrace = "0.3"
 
 function_name = "0.3"
 paste = "1"
-serial_test = "4.0.1"
+serial_test = "3.5"
 rand = "0.10"
 tracing-glog = "0.4"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -85,7 +85,7 @@ tokio = { version = "1.30", features = [
     "rt-multi-thread",
     "tracing",
 ] }
-criterion = "0.8"
+criterion = "0.7"
 tracing-test = "0.2"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
@@ -95,7 +95,7 @@ wasm-bindgen-test = "0.3.50"
 #   https://docs.rs/getrandom/latest/getrandom/#webassembly-support
 #
 getrandom = { version = "0.4", features = ["wasm_js"] }
-criterion = { version = "0.8", default-features = false }
+criterion = { version = "0.7", default-features = false }
 
 [[bench]]
 name = "actor"

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -12,11 +12,10 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ractor = "0.15"
+//! ractor = "0.16"
 //! ```
 //!
-//! The minimum supported Rust version (MSRV) is 1.64. However if you disable the `async-trait` feature, then you need Rust >= 1.75 due to the native
-//! use of `async fn` in traits. See the [Rust blog](https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html).
+//! The minimum supported Rust version (MSRV) is 1.85.
 //!
 //! ## Getting started
 //!

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster"
-version = "0.15.13"
+version.workspace = true
 authors = ["Sean Lawlor <slawlor>"]
 description = "Distributed cluster environment of Ractor actors"
 documentation = "https://docs.rs/ractor"
@@ -12,7 +12,7 @@ readme = "README.md"
 homepage = "https://github.com/slawlor/ractor"
 categories = ["asynchronous"]
 build = "src/build.rs"
-rust-version = "1.64"
+rust-version.workspace = true
 
 [features]
 monitors = ["ractor/monitors"]
@@ -30,8 +30,8 @@ prost-build = { version = "0.14" }
 bytes = { version = "1" }
 prost = { version = "0.14" }
 prost-types = { version = "0.14" }
-ractor = { version = "0.15.0", default-features = false, features = ["tokio_runtime", "cluster"], path = "../ractor" }
-ractor_cluster_derive = { version = "0.15.0", path = "../ractor_cluster_derive" }
+ractor = { version = "0.16.0", default-features = false, features = ["tokio_runtime", "cluster"], path = "../ractor" }
+ractor_cluster_derive = { version = "0.16.0", path = "../ractor_cluster_derive" }
 rand = "0.10"
 socket2 = { version = "0.6", features = ["all"] }
 sha2 = "0.11"
@@ -42,7 +42,7 @@ tracing = "0.1"
 async-trait = { version = "0.1", optional = true }
 
 [dev-dependencies]
-criterion = "0.8"
+criterion = "0.7"
 tokio = { version = "1", features = ["rt", "time", "sync", "macros", "net", "io-util", "rt-multi-thread"] }
 
 [[bench]]

--- a/ractor_cluster_derive/Cargo.toml
+++ b/ractor_cluster_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ractor_cluster_derive"
-version = "0.15.13"
+version.workspace = true
 authors = ["Sean Lawlor <slawlor>"]
 description = "Derives for ractor_cluster"
 license = "MIT"
@@ -9,7 +9,7 @@ categories = []
 keywords = ["actor", "ractor"]
 repository = "https://github.com/slawlor/ractor"
 readme = "../README.md"
-rust-version = "1.64"
+rust-version.workspace = true
 
 [lib]
 name = "ractor_cluster_derive"

--- a/ractor_cluster_integration_tests/Cargo.toml
+++ b/ractor_cluster_integration_tests/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["actor", "ractor"]
 repository = "https://github.com/slawlor/ractor"
 readme = "../README.md"
 publish = false
+rust-version.workspace = true
 
 [features]
 blanket_serde = ["ractor/blanket_serde"]

--- a/ractor_example_entry_proc/Cargo.toml
+++ b/ractor_example_entry_proc/Cargo.toml
@@ -5,11 +5,12 @@ authors = ["Sean Lawlor <slawlor>"]
 description = "A wrapper for tokio::main which uses different arguments on wasm"
 license = "MIT"
 edition = "2021"
+publish = false
 categories = []
 keywords = ["actor", "ractor"]
 repository = "https://github.com/slawlor/ractor"
 readme = "../README.md"
-rust-version = "1.64"
+rust-version.workspace = true
 
 [lib]
 name = "ractor_example_entry_proc"

--- a/ractor_playground/Cargo.toml
+++ b/ractor_playground/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["actor", "ractor"]
 repository = "https://github.com/slawlor/ractor"
 readme = "../README.md"
 publish = false
+rust-version.workspace = true
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,6 +4,7 @@ default-run = "xtask"
 version = "0.1.0"
 edition = "2021"
 publish = false
+rust-version.workspace = true
 
 [dependencies]
 xtaskops = "0.4"


### PR DESCRIPTION
## Summary

- move the public release crates (`ractor`, `ractor_cluster`, and `ractor_cluster_derive`) to 0.16.0 and align cluster dependency requirements and installation snippets
- keep the internal `ractor_example_entry_proc` helper at 0.0.0 and explicitly mark it non-publishable
- set Rust 1.85 as the shared MSRV for every workspace package
- adopt Cargo resolver 3 so dependency selection respects that floor
- preserve Bon 3.9 while using Rust-1.85-compatible Criterion 0.7 and serial_test 3.5 lines
- add a dedicated Rust 1.85 compilation matrix for workspace targets, runtime variants, optional APIs, cluster, and WASM

The existing publish workflow already releases `ractor` and `ractor_cluster_derive` before `ractor_cluster`, which is required for the new 0.16.0 dependency constraints.

## Validation

- `cargo +1.85.0 metadata --no-deps --format-version 1`
- `cargo +1.85.0 check --workspace --all-targets`
- `cargo +1.85.0 test --workspace --all-targets`
- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`