### PR TITLE
feat(actor): add ergonomic actor definition macros

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,14 +21,17 @@ jobs:
       - name: Check workspace defaults and all targets
         run: cargo check --workspace --all-targets
 
+      - name: Check actor macros with native async traits
+        run: cargo check --package ractor --features actor-macros --all-targets
+
       - name: Check async traits with Tokio
-        run: cargo check --package ractor --features async-trait
+        run: cargo check --package ractor --features async-trait,actor-macros --all-targets
 
       - name: Check async traits with async-std
-        run: cargo check --package ractor --no-default-features --features async-std,async-trait
+        run: cargo check --package ractor --no-default-features --features async-std,async-trait,actor-macros --all-targets
 
       - name: Check optional ractor APIs
-        run: cargo check --package ractor --features cluster,monitors,blanket_serde,output-port-v2
+        run: cargo check --package ractor --features cluster,monitors,blanket_serde,output-port-v2,actor-macros --all-targets
 
       - name: Check ractor_cluster with async traits
         run: cargo check --package ractor_cluster --features async-trait
@@ -49,6 +52,15 @@ jobs:
           - name: Test ractor with async-trait
             package: ractor
             flags: -F async-trait
+          - name: Test actor macros with native async traits
+            package: ractor
+            flags: -F actor-macros
+          - name: Test actor macros with async-trait
+            package: ractor
+            flags: --no-default-features -F tokio_runtime,async-trait,actor-macros
+          - name: Test actor macros with async-std and async-trait
+            package: ractor
+            flags: --no-default-features -F async-std,async-trait,actor-macros
           - name: Test ractor without span propogation
             package: ractor
             flags: --no-default-features -F tokio_runtime

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,6 +32,14 @@ jobs:
           mkdir -p "${HOME}/.local/bin"
           curl -sL https://github.com/mozilla/grcov/releases/download/v0.8.10/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf - -C "${HOME}/.local/bin"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Exercise actor macros for coverage
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: -Cinstrument-coverage
+          LLVM_PROFILE_FILE: cargo-test-%p-%m.profraw
+        run: cargo test --package ractor --features actor-macros --test actor_macros
+
       - name: Run xtask coverage
         uses: actions-rs/cargo@v1
         with:
@@ -47,4 +55,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }} # required
           verbose: true # optional (default = false)
           name: ractor # optional
-

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,17 @@ jobs:
       run: cargo login $CRATES_IO_TOKEN
       env:
         CRATES_IO_TOKEN: ${{ secrets.crates_io_token }}
-    
+
+    - name: Dry run publish ractor_macros
+      run: cargo publish --dry-run --manifest-path Cargo.toml -p ractor_macros
+    - name: Publish ractor_macros
+      run: cargo publish --manifest-path Cargo.toml -p ractor_macros
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
+
+    - name: Wait for necessary ractor_macros version to be available
+      run: bash ./.github/workflows/wait_for_crate_dependency.sh ractor ractor_macros
+
     - name: Dry run publish ractor
       run: cargo publish --dry-run --manifest-path Cargo.toml -p ractor
     - name: Publish crate ractor
@@ -49,4 +59,3 @@ jobs:
       run: cargo publish --manifest-path Cargo.toml -p ractor_cluster
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.crates_io_token }}
-        

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "ractor",
+    "ractor_macros",
     "ractor_cluster",
     "ractor_cluster_derive",
     "ractor_playground",

--- a/README.md
+++ b/README.md
@@ -83,11 +83,51 @@ The minimum supported Rust version (MSRV) of `ractor` is `1.85`.
 2. `async-std`, which enables usage of `async-std`'s asynchronous runtime instead of the `tokio` runtime. **However** `tokio` with the `sync` feature remains a dependency because we utilize the messaging synchronization primatives from `tokio` regardless of runtime as they are not specific to the `tokio` runtime. This work is tracked in [#173](https://github.com/slawlor/ractor/pull/173). You can remove default features to "minimize" the tokio dependencies to just the synchronization primatives.
 3. `monitors`, Adds support for an erlang-style monitoring api which is an alternative to direct linkage. Akin to [Process Monitors](https://www.erlang.org/doc/system/ref_man_processes.html#monitors)
 4. `message_span_propogation`, Propagates the span through the message between actors to keep tracing context.
+5. `actor-macros`, which provides opt-in attribute macros for defining actors with one small method per message variant. See the [actor macro guide](docs/actor-macros.md).
 
 ## Working with Actors
 
 Actors in `ractor` are very lightweight and can be treated as thread-safe. Each actor will only call one of its handler functions at a time, and they will
 never be executed in parallel. Following the actor model leads to microservices with well-defined state and processing logic.
+
+### Reducing actor boilerplate
+
+Enable the `actor-macros` feature to generate the `Actor` implementation from an inherent
+implementation whose methods describe the messages they handle:
+
+```toml
+[dependencies]
+ractor = { version = "0.16", features = ["actor-macros"] }
+```
+
+```rust
+struct Counter;
+
+enum CounterMessage {
+    Add(u64),
+}
+
+#[ractor::actor(message = CounterMessage, state = u64)]
+impl Counter {
+    async fn pre_start(
+        &self,
+        _myself: ractor::ActorRef<CounterMessage>,
+        _arguments: (),
+    ) -> Result<u64, ractor::ActorProcessingErr> {
+        Ok(0)
+    }
+
+    #[ractor::message(CounterMessage::Add(amount))]
+    fn add(&self, amount: u64, state: &mut u64) {
+        *state += amount;
+    }
+}
+```
+
+The generated dispatch remains an exhaustive match, so adding an unhandled enum variant is a
+compile error. The explicit trait-based API remains available when its flexibility is preferable.
+See the [guide](docs/actor-macros.md) and the
+[`actor_macro` example](ractor/examples/actor_macro.rs) for the supported method shapes.
 
 An example `ping-pong` actor might be the following
 

--- a/docs/actor-macros.md
+++ b/docs/actor-macros.md
@@ -1,0 +1,100 @@
+# Actor definition macros
+
+The optional `actor-macros` feature removes the repetitive associated types and message dispatch
+from an actor definition while leaving its behavior visible as ordinary Rust methods.
+
+```toml
+[dependencies]
+ractor = { version = "0.16", features = ["actor-macros"] }
+```
+
+## Defining an actor
+
+Apply `#[ractor::actor]` to an inherent implementation and mark each message handler with
+`#[ractor::message]`:
+
+```rust
+use ractor::{ActorProcessingErr, ActorRef, RpcReplyPort};
+
+struct Counter;
+
+enum CounterMessage {
+    Add(i64),
+    Read(RpcReplyPort<i64>),
+}
+
+#[ractor::actor(
+    message = CounterMessage,
+    state = i64,
+    arguments = i64,
+)]
+impl Counter {
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<CounterMessage>,
+        initial: i64,
+    ) -> Result<i64, ActorProcessingErr> {
+        Ok(initial)
+    }
+
+    #[ractor::message(CounterMessage::Add(amount))]
+    fn add(&self, amount: i64, state: &mut i64) {
+        *state += amount;
+    }
+
+    #[ractor::message(CounterMessage::Read(reply))]
+    fn read(&self, reply: RpcReplyPort<i64>, state: &i64) {
+        let _ = reply.send(*state);
+    }
+}
+```
+
+`message` is required. `state` and `arguments` default to `()`. The macro generates the
+`Actor` implementation and an exhaustive `match` over the message enum. Rust therefore reports a
+new or forgotten message variant at compile time. Renamed `ractor` dependencies are detected
+automatically; `crate_path = some::path` is available when a re-export requires an explicit path.
+
+Tuple, struct, and unit variants are supported. Bindings in the attribute pattern become handler
+parameters with matching names in the same order; `_` can discard an unused field. Keep patterns
+flat so that the method signature remains an immediate description of the message payload.
+
+## Handler methods
+
+A generated handler can be synchronous or asynchronous and has this shape:
+
+```text
+&self, [ActorRef<Message>], [bound message fields...], [&State | &mut State]
+```
+
+The actor reference and state parameters are optional. Use `&State` for read-only access or
+`&mut State` to update state. A handler with no explicit return type (or `-> ()`) is infallible. A
+handler with an explicit non-unit return type is propagated through `Actor::handle` with `?`, so it
+must support that operator; `Result` is the usual choice.
+
+Lifecycle hooks such as `pre_start`, `post_start`, `handle_supervisor_evt`, and `post_stop` can be
+written with their normal trait signatures inside the same implementation. If both state and
+arguments are `()`, an omitted `pre_start` defaults to `Ok(())`; otherwise it is required.
+
+For actors that need custom dispatch, define the normal `handle` method instead of any
+`#[ractor::message]` methods. Raw `handle` and generated handlers are intentionally mutually
+exclusive, keeping the dispatch path unambiguous.
+
+## Thread-local and cluster actors
+
+Add `thread_local` to generate a `ThreadLocalActor` implementation:
+
+```rust
+#[derive(Default)]
+struct UiActor;
+
+#[ractor::actor(thread_local, message = UiMessage, state = UiState)]
+impl UiActor {
+    // lifecycle hooks and #[ractor::message(...)] handlers
+}
+```
+
+The macro only defines actor behavior. Cluster wire compatibility remains an explicit property of
+the message type: continue deriving `RactorMessage` for local-only cluster builds or
+`RactorClusterMessage` for remotely serializable messages.
+
+See the complete [`actor_macro` example](../ractor/examples/actor_macro.rs).

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -27,7 +27,8 @@ message_span_propogation = []
 output-port-v2 = []
 tokio_runtime = ["tokio/time", "tokio/rt", "tokio/macros", "tokio/tracing"]
 blanket_serde = ["serde", "pot", "cluster"]
-async-trait = ["dep:async-trait"]
+async-trait = ["dep:async-trait", "ractor_macros?/async-trait"]
+actor-macros = ["dep:ractor_macros"]
 
 default = ["tokio_runtime", "message_span_propogation"]
 
@@ -44,6 +45,7 @@ strum = { version = "0.28", features = ["derive"] }
 # async-std feature 'unstable' is required for spawn_local: https://docs.rs/async-std/latest/async_std/task/fn.spawn_local.html
 async-std = { version = "1", features = ["attributes", "unstable"], optional = true }
 async-trait = { version = "0.1", optional = true }
+ractor_macros = { path = "../ractor_macros", version = "0.16.0", optional = true }
 tokio = { version = "1", features = ["sync"] }
 tracing = { version = "0.1", features = ["attributes"] }
 
@@ -73,6 +75,7 @@ serial_test = "3.5"
 rand = "0.10"
 tracing-glog = "0.4"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+trybuild = "1"
 
 ractor_example_entry_proc = { path = "../ractor_example_entry_proc" }
 
@@ -116,3 +119,11 @@ required-features = []
 name = "factory"
 harness = false
 required-features = []
+
+[[test]]
+name = "actor_macros"
+required-features = ["actor-macros"]
+
+[[example]]
+name = "actor_macro"
+required-features = ["actor-macros"]

--- a/ractor/examples/actor_macro.rs
+++ b/ractor/examples/actor_macro.rs
@@ -1,0 +1,82 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! A concise counter actor defined with the optional actor macros.
+//!
+//! Execute with
+//!
+//! ```text
+//! cargo run --example actor_macro --features actor-macros
+//! ```
+
+#![allow(clippy::incompatible_msrv)]
+
+extern crate ractor;
+
+use ractor::call_t;
+use ractor::Actor;
+use ractor::ActorProcessingErr;
+use ractor::ActorRef;
+use ractor::RpcReplyPort;
+
+struct Counter;
+
+enum CounterMessage {
+    Add(i64),
+    Read(RpcReplyPort<i64>),
+    Stop,
+}
+
+#[cfg(feature = "cluster")]
+impl ractor::Message for CounterMessage {}
+
+#[ractor::actor(
+    message = CounterMessage,
+    state = i64,
+    arguments = i64,
+)]
+impl Counter {
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<CounterMessage>,
+        initial: i64,
+    ) -> Result<i64, ActorProcessingErr> {
+        Ok(initial)
+    }
+
+    #[ractor::message(CounterMessage::Add(amount))]
+    fn add(&self, amount: i64, state: &mut i64) {
+        *state += amount;
+    }
+
+    #[ractor::message(CounterMessage::Read(reply))]
+    fn read(&self, reply: RpcReplyPort<i64>, state: &i64) {
+        let _ = reply.send(*state);
+    }
+
+    #[ractor::message(CounterMessage::Stop)]
+    fn stop(&self, myself: ActorRef<CounterMessage>) {
+        myself.stop(None);
+    }
+}
+
+#[ractor_example_entry_proc::ractor_example_entry]
+async fn main() {
+    let (actor, handle) = Actor::spawn(None, Counter, 10)
+        .await
+        .expect("counter failed to start");
+
+    actor
+        .send_message(CounterMessage::Add(5))
+        .expect("increment message failed");
+    let count =
+        call_t!(actor, CounterMessage::Read, 100).expect("counter failed to answer the RPC");
+    assert_eq!(count, 15);
+
+    actor
+        .send_message(CounterMessage::Stop)
+        .expect("stop message failed");
+    handle.await.expect("counter failed to stop cleanly");
+}

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -162,6 +162,12 @@
     unsafe_code
 )]
 
+// Macro expansions use this stable absolute path both inside this crate and from
+// package-local examples and integration tests.
+#[cfg(feature = "actor-macros")]
+#[allow(unused_extern_crates)]
+extern crate self as ractor;
+
 // ======================== Modules ======================== //
 
 pub mod actor;
@@ -216,6 +222,28 @@ use paste as _;
 pub use port::OutputMessage;
 pub use port::OutputPort;
 pub use port::RpcReplyPort;
+#[cfg(feature = "actor-macros")]
+/// Generate an [`Actor`] or [`thread_local::ThreadLocalActor`] implementation
+/// from an inherent implementation block and explicit message handlers.
+///
+/// Dispatch is exhaustive: adding a message variant without a corresponding
+/// handler does not compile.
+///
+/// ```compile_fail
+/// struct IncompleteActor;
+///
+/// enum Message {
+///     Handled,
+///     Forgotten,
+/// }
+///
+/// #[ractor::actor(message = Message)]
+/// impl IncompleteActor {
+///     #[ractor::message(Message::Handled)]
+///     fn handled(&self) {}
+/// }
+/// ```
+pub use ractor_macros::actor;
 #[cfg(test)]
 use rand as _;
 #[cfg(feature = "cluster")]
@@ -224,6 +252,8 @@ pub use serialization::BytesConvertable;
 use tracing_glog as _;
 #[cfg(test)]
 use tracing_subscriber as _;
+#[cfg(test)]
+use trybuild as _;
 
 // ======================== Type aliases and Trait definitions ======================== //
 

--- a/ractor/tests/actor_macros.rs
+++ b/ractor/tests/actor_macros.rs
@@ -1,0 +1,312 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use std::cell::Cell;
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+
+struct Counter;
+
+enum CounterMessage {
+    Add(i64),
+    #[cfg(any())]
+    Disabled,
+    #[cfg_attr(all(), cfg(any()))]
+    DisabledByCfgAttr,
+    Replace {
+        value: i64,
+    },
+    InternalNames {
+        __ractor_myself: i64,
+        __ractor_message: i64,
+        __ractor_state: i64,
+    },
+    Read(RpcReplyPort<i64>),
+    Stop,
+}
+
+#[cfg(feature = "cluster")]
+impl ractor::Message for CounterMessage {}
+
+#[ractor::actor(
+    message = CounterMessage,
+    state = std::primitive::i64,
+    arguments = i64,
+)]
+impl Counter {
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<CounterMessage>,
+        initial: i64,
+    ) -> Result<i64, ActorProcessingErr> {
+        Ok(initial)
+    }
+
+    #[ractor::message(CounterMessage::Add(amount))]
+    #[cfg_attr(all(), tracing::instrument(skip(self, state)))]
+    fn add(&self, amount: i64, state: &mut i64) {
+        *state += amount;
+    }
+
+    #[cfg(any())]
+    #[ractor::message(CounterMessage::Disabled)]
+    fn disabled(&self) {}
+
+    #[cfg_attr(all(), cfg(any()))]
+    #[ractor::message(CounterMessage::DisabledByCfgAttr)]
+    fn disabled_by_cfg_attr(&self) {}
+
+    #[ractor::message(CounterMessage::Replace { value })]
+    async fn replace(&self, value: i64, state: &mut i64) -> Result<(), ActorProcessingErr> {
+        *state = value;
+        Ok(())
+    }
+
+    #[ractor::message(CounterMessage::InternalNames {
+        __ractor_myself,
+        __ractor_message,
+        __ractor_state,
+    })]
+    fn internal_names(
+        &self,
+        myself: ActorRef<CounterMessage>,
+        __ractor_myself: i64,
+        __ractor_message: i64,
+        __ractor_state: i64,
+        state: &mut i64,
+    ) {
+        assert_eq!(myself.get_status(), ractor::ActorStatus::Running);
+        *state = __ractor_myself + __ractor_message + __ractor_state;
+    }
+
+    #[ractor::message(CounterMessage::Read(reply))]
+    fn read(&self, reply: RpcReplyPort<i64>, state: &i64) {
+        let _ = reply.send(*state);
+    }
+
+    #[ractor::message(CounterMessage::Stop)]
+    fn stop(&self, myself: ActorRef<CounterMessage>) {
+        myself.stop(None);
+    }
+}
+
+struct RawActor;
+
+enum RawMessage {
+    Ping(RpcReplyPort<&'static str>),
+}
+
+#[cfg(feature = "cluster")]
+impl ractor::Message for RawMessage {}
+
+#[ractor::actor(message = RawMessage)]
+impl RawActor {
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        let RawMessage::Ping(reply) = message;
+        let _ = reply.send("pong");
+        Ok(())
+    }
+}
+
+#[cfg_attr(feature = "async-std", allow(dead_code))]
+#[derive(Default)]
+struct LocalCounter;
+
+#[cfg_attr(feature = "async-std", allow(dead_code))]
+enum LocalMessage {
+    Add(i64),
+    Read(RpcReplyPort<i64>),
+    Stop,
+}
+
+#[cfg(feature = "cluster")]
+impl ractor::Message for LocalMessage {}
+
+#[ractor::actor(
+    thread_local,
+    message = LocalMessage,
+    state = Rc<Cell<i64>>,
+    arguments = i64,
+)]
+#[cfg_attr(feature = "async-std", allow(dead_code))]
+impl LocalCounter {
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<LocalMessage>,
+        initial: i64,
+    ) -> Result<Rc<Cell<i64>>, ActorProcessingErr> {
+        Ok(Rc::new(Cell::new(initial)))
+    }
+
+    #[ractor::message(LocalMessage::Add(amount))]
+    fn add(&self, amount: i64, state: &Rc<Cell<i64>>) {
+        state.set(state.get() + amount);
+    }
+
+    #[ractor::message(LocalMessage::Read(reply))]
+    fn read(&self, reply: RpcReplyPort<i64>, state: &Rc<Cell<i64>>) {
+        let _ = reply.send(state.get());
+    }
+
+    #[ractor::message(LocalMessage::Stop)]
+    fn stop(&self, myself: ActorRef<LocalMessage>) {
+        myself.stop(None);
+    }
+}
+
+struct GenericActor<T>(PhantomData<T>);
+
+enum GenericMessage<T> {
+    Echo { value: T, reply: RpcReplyPort<T> },
+}
+
+#[cfg(feature = "cluster")]
+impl<T: Send + 'static> ractor::Message for GenericMessage<T> {}
+
+#[ractor::actor(message = GenericMessage<T>)]
+impl<T> GenericActor<T>
+where
+    T: Send + Sync + 'static,
+{
+    #[ractor::message(GenericMessage::Echo { value, reply })]
+    fn echo(&self, value: T, reply: RpcReplyPort<T>) {
+        let _ = reply.send(value);
+    }
+}
+
+mod shadowed_prelude_names {
+    use super::Actor;
+
+    type Result<T> = Option<T>;
+
+    enum Shadow {
+        Ok,
+    }
+
+    use Shadow::Ok;
+
+    struct ShadowedActor;
+
+    enum Message {
+        Run,
+    }
+
+    #[cfg(feature = "cluster")]
+    impl ractor::Message for Message {}
+
+    #[ractor::actor(message = Message)]
+    impl ShadowedActor {
+        #[ractor::message(Message::Run)]
+        fn run(&self) {
+            let _: Result<()> = Some(());
+            let _ = Ok;
+        }
+    }
+
+    pub(super) fn assert_compiles() {
+        fn assert_actor<T: Actor<Msg = Message>>() {}
+
+        assert_actor::<ShadowedActor>();
+        let _ = Message::Run;
+    }
+}
+
+#[ractor::concurrency::test]
+async fn generated_handlers_dispatch_messages_and_state() {
+    let (actor, handle) = Actor::spawn(None, Counter, 5)
+        .await
+        .expect("counter failed to start");
+
+    actor
+        .send_message(CounterMessage::Add(7))
+        .expect("add message failed");
+    actor
+        .send_message(CounterMessage::Replace { value: 20 })
+        .expect("replace message failed");
+    actor
+        .send_message(CounterMessage::InternalNames {
+            __ractor_myself: 3,
+            __ractor_message: 4,
+            __ractor_state: 5,
+        })
+        .expect("internal-name message failed");
+    let value =
+        ractor::call_t!(actor, CounterMessage::Read, 100).expect("counter failed to answer");
+    assert_eq!(value, 12);
+
+    actor
+        .send_message(CounterMessage::Stop)
+        .expect("stop message failed");
+    handle.await.expect("counter failed to stop cleanly");
+}
+
+#[ractor::concurrency::test]
+async fn raw_handle_mode_remains_available() {
+    let (actor, handle) = Actor::spawn(None, RawActor, ())
+        .await
+        .expect("raw actor failed to start");
+
+    let response = ractor::call_t!(actor, RawMessage::Ping, 100).expect("raw actor call failed");
+    assert_eq!(response, "pong");
+
+    actor.stop(None);
+    handle.await.expect("raw actor failed to stop cleanly");
+}
+
+#[cfg(not(feature = "async-std"))]
+#[ractor::concurrency::test]
+async fn thread_local_actor_supports_non_send_state() {
+    let spawner = ractor::thread_local::ThreadLocalActorSpawner::new();
+    let (actor, handle) = ractor::spawn_local::<LocalCounter>(10, spawner)
+        .await
+        .expect("local counter failed to start");
+
+    actor
+        .send_message(LocalMessage::Add(4))
+        .expect("local add message failed");
+    let value =
+        ractor::call_t!(actor, LocalMessage::Read, 100).expect("local counter failed to answer");
+    assert_eq!(value, 14);
+
+    actor
+        .send_message(LocalMessage::Stop)
+        .expect("local stop message failed");
+    actor
+        .wait(Some(ractor::concurrency::Duration::from_secs(1)))
+        .await
+        .expect("local counter failed to stop cleanly");
+    drop(handle);
+}
+
+#[test]
+fn generic_actor_impls_preserve_bounds() {
+    fn assert_actor<T: Actor<Msg = GenericMessage<String>>>() {}
+
+    assert_actor::<GenericActor<String>>();
+    let (reply, _receiver) = ractor::concurrency::oneshot();
+    let _message = GenericMessage::Echo {
+        value: String::new(),
+        reply: reply.into(),
+    };
+}
+
+#[test]
+fn generated_code_ignores_shadowed_prelude_names() {
+    shadowed_prelude_names::assert_compiles();
+}
+
+#[cfg(all(not(feature = "async-trait"), not(feature = "cluster")))]
+#[test]
+fn actor_macro_diagnostics_are_actionable() {
+    let tests = trybuild::TestCases::new();
+    tests.compile_fail("tests/ui/actor_macros/*.rs");
+}

--- a/ractor/tests/ui/actor_macros/mixed_dispatch.rs
+++ b/ractor/tests/ui/actor_macros/mixed_dispatch.rs
@@ -1,0 +1,26 @@
+#![allow(unused_imports)]
+
+use ractor::{ActorProcessingErr, ActorRef};
+
+struct MixedActor;
+
+enum Message {
+    Go,
+}
+
+#[ractor::actor(message = Message)]
+impl MixedActor {
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _message: Self::Msg,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+
+    #[ractor::message(Message::Go)]
+    fn go(&self) {}
+}
+
+fn main() {}

--- a/ractor/tests/ui/actor_macros/mixed_dispatch.stderr
+++ b/ractor/tests/ui/actor_macros/mixed_dispatch.stderr
@@ -1,0 +1,5 @@
+error: define either a raw `handle` method or `#[ractor::message(...)]` handlers, not both
+  --> tests/ui/actor_macros/mixed_dispatch.rs:13:14
+   |
+13 |     async fn handle(
+   |              ^^^^^^

--- a/ractor/tests/ui/actor_macros/parameter_mismatch.rs
+++ b/ractor/tests/ui/actor_macros/parameter_mismatch.rs
@@ -1,0 +1,13 @@
+struct MismatchedActor;
+
+enum Message {
+    Add(u64),
+}
+
+#[ractor::actor(message = Message)]
+impl MismatchedActor {
+    #[ractor::message(Message::Add(amount))]
+    fn add(&self, value: u64) {}
+}
+
+fn main() {}

--- a/ractor/tests/ui/actor_macros/parameter_mismatch.stderr
+++ b/ractor/tests/ui/actor_macros/parameter_mismatch.stderr
@@ -1,0 +1,5 @@
+error: handler parameters must match the message pattern bindings, with an optional leading `ActorRef` and optional trailing state reference
+  --> tests/ui/actor_macros/parameter_mismatch.rs:10:8
+   |
+10 |     fn add(&self, value: u64) {}
+   |        ^^^

--- a/ractor/tests/ui/actor_macros/pre_start_required.rs
+++ b/ractor/tests/ui/actor_macros/pre_start_required.rs
@@ -1,0 +1,13 @@
+struct StatefulActor;
+
+enum Message {
+    Read,
+}
+
+#[ractor::actor(message = Message, state = u64)]
+impl StatefulActor {
+    #[ractor::message(Message::Read)]
+    fn read(&self, _state: &u64) {}
+}
+
+fn main() {}

--- a/ractor/tests/ui/actor_macros/pre_start_required.stderr
+++ b/ractor/tests/ui/actor_macros/pre_start_required.stderr
@@ -1,0 +1,5 @@
+error: `pre_start` is required unless both `state` and `arguments` are `()`
+ --> tests/ui/actor_macros/pre_start_required.rs:8:6
+  |
+8 | impl StatefulActor {
+  |      ^^^^^^^^^^^^^

--- a/ractor_cluster_integration_tests/Cargo.toml
+++ b/ractor_cluster_integration_tests/Cargo.toml
@@ -22,7 +22,7 @@ default = []
 anyhow = "1"
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
-ractor = { default-features = false, features = ["tokio_runtime", "message_span_propogation", "cluster"], path = "../ractor" }
+ractor = { default-features = false, features = ["tokio_runtime", "message_span_propogation", "cluster", "actor-macros"], path = "../ractor" }
 ractor_cluster = { path = "../ractor_cluster" }
 rand = "0.10"
 tokio-rustls = { version = "0.26" }

--- a/ractor_cluster_integration_tests/src/tests/external_transport.rs
+++ b/ractor_cluster_integration_tests/src/tests/external_transport.rs
@@ -66,17 +66,17 @@ struct ExternalProbeArgs {
     label: String,
 }
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
-impl Actor for ExternalProbeActor {
-    type Msg = ExternalProbeMessage;
-    type State = ExternalProbeState;
-    type Arguments = ExternalProbeArgs;
-
+#[ractor::actor(
+    message = ExternalProbeMessage,
+    state = ExternalProbeState,
+    arguments = ExternalProbeArgs,
+)]
+impl ExternalProbeActor {
     async fn pre_start(
         &self,
-        myself: ActorRef<Self::Msg>,
+        myself: ActorRef<ExternalProbeMessage>,
         args: ExternalProbeArgs,
-    ) -> Result<Self::State, ActorProcessingErr> {
+    ) -> Result<ExternalProbeState, ActorProcessingErr> {
         ractor::pg::join(EXTERNAL_GROUP.to_string(), vec![myself.get_cell()]);
         Ok(ExternalProbeState {
             label: args.label,
@@ -84,82 +84,82 @@ impl Actor for ExternalProbeActor {
         })
     }
 
-    async fn handle(
+    #[ractor::message(ExternalProbeMessage::Kickoff)]
+    async fn kickoff(
         &self,
-        myself: ActorRef<Self::Msg>,
-        message: Self::Msg,
-        state: &mut Self::State,
+        myself: ActorRef<ExternalProbeMessage>,
+        state: &mut ExternalProbeState,
     ) -> Result<(), ActorProcessingErr> {
-        match message {
-            ExternalProbeMessage::Kickoff => {
-                if state.complete {
-                    return Ok(());
-                }
+        if state.complete {
+            return Ok(());
+        }
 
-                let remote_members = ractor::pg::get_members(&EXTERNAL_GROUP.to_string())
-                    .into_iter()
-                    .filter(|actor| !actor.get_id().is_local())
-                    .map(ActorRef::<Self::Msg>::from)
-                    .collect::<Vec<_>>();
+        let remote_members = ractor::pg::get_members(&EXTERNAL_GROUP.to_string())
+            .into_iter()
+            .filter(|actor| !actor.get_id().is_local())
+            .map(ActorRef::<ExternalProbeMessage>::from)
+            .collect::<Vec<_>>();
 
-                if remote_members.is_empty() {
-                    let handle = myself.clone();
-                    ractor::concurrency::spawn(async move {
-                        sleep(Duration::from_millis(PROBE_RETRY_DELAY_MS)).await;
-                        let _ = handle.cast(ExternalProbeMessage::Kickoff);
-                    });
-                    return Ok(());
-                }
+        if remote_members.is_empty() {
+            let handle = myself.clone();
+            ractor::concurrency::spawn(async move {
+                sleep(Duration::from_millis(PROBE_RETRY_DELAY_MS)).await;
+                let _ = handle.cast(ExternalProbeMessage::Kickoff);
+            });
+            return Ok(());
+        }
 
-                for remote in remote_members {
-                    match ractor::call_t!(
-                        remote,
-                        ExternalProbeMessage::Ping,
-                        PROBE_RPC_TIMEOUT_MS,
-                        state.label.clone()
-                    ) {
-                        Ok(reply) => {
-                            tracing::info!(
-                                "{} received external transport reply '{reply}'",
-                                state.label
-                            );
-                            if reply.contains(&state.label) {
-                                state.complete = true;
-                                break;
-                            }
-                        }
-                        Err(err) => {
-                            tracing::warn!(
-                                "{} failed to ping remote external probe: {err}",
-                                state.label
-                            );
-                        }
+        for remote in remote_members {
+            match ractor::call_t!(
+                remote,
+                ExternalProbeMessage::Ping,
+                PROBE_RPC_TIMEOUT_MS,
+                state.label.clone()
+            ) {
+                Ok(reply) => {
+                    tracing::info!(
+                        "{} received external transport reply '{reply}'",
+                        state.label
+                    );
+                    if reply.contains(&state.label) {
+                        state.complete = true;
+                        break;
                     }
                 }
-
-                if !state.complete {
-                    let handle = myself.clone();
-                    ractor::concurrency::spawn(async move {
-                        sleep(Duration::from_millis(PROBE_RETRY_DELAY_MS)).await;
-                        let _ = handle.cast(ExternalProbeMessage::Kickoff);
-                    });
+                Err(err) => {
+                    tracing::warn!(
+                        "{} failed to ping remote external probe: {err}",
+                        state.label
+                    );
                 }
-            }
-            ExternalProbeMessage::Ping(requestor, reply) => {
-                let response = format!("Hello {requestor} from {}", state.label);
-                let _ = reply.send(response.clone());
-                state.complete = true;
-                tracing::info!(
-                    "{} responded to external transport probe with '{response}'",
-                    state.label
-                );
-            }
-            ExternalProbeMessage::IsComplete(reply) => {
-                let _ = reply.send(state.complete);
             }
         }
 
+        if !state.complete {
+            let handle = myself.clone();
+            ractor::concurrency::spawn(async move {
+                sleep(Duration::from_millis(PROBE_RETRY_DELAY_MS)).await;
+                let _ = handle.cast(ExternalProbeMessage::Kickoff);
+            });
+        }
+
         Ok(())
+    }
+
+    #[ractor::message(ExternalProbeMessage::Ping(requestor, reply))]
+    fn ping(&self, requestor: String, reply: RpcReplyPort<String>, state: &mut ExternalProbeState) {
+        let response = format!("Hello {requestor} from {}", state.label);
+        let _ = reply.send(response.clone());
+        state.complete = true;
+        tracing::info!(
+            "{} responded to external transport probe with '{response}'",
+            state.label
+        );
+    }
+
+    #[ractor::message(ExternalProbeMessage::IsComplete(reply))]
+    fn is_complete(&self, reply: RpcReplyPort<bool>, state: &ExternalProbeState) {
+        let _ = reply.send(state.complete);
     }
 }
 

--- a/ractor_cluster_integration_tests/src/tests/pg_groups.rs
+++ b/ractor_cluster_integration_tests/src/tests/pg_groups.rs
@@ -42,17 +42,13 @@ struct HelloActorState {
     done: bool,
 }
 
-#[cfg_attr(feature = "async-trait", ractor::async_trait)]
-impl Actor for HelloActor {
-    type Msg = HelloActorMessage;
-    type State = HelloActorState;
-    type Arguments = ();
-
+#[ractor::actor(message = HelloActorMessage, state = HelloActorState)]
+impl HelloActor {
     async fn pre_start(
         &self,
-        myself: ActorRef<Self::Msg>,
+        myself: ActorRef<HelloActorMessage>,
         _: (),
-    ) -> Result<Self::State, ActorProcessingErr> {
+    ) -> Result<HelloActorState, ActorProcessingErr> {
         ractor::pg::join("test".to_string(), vec![myself.get_cell()]);
         Ok(HelloActorState {
             count: 0,
@@ -60,44 +56,38 @@ impl Actor for HelloActor {
         })
     }
 
-    async fn handle(
-        &self,
-        _myself: ActorRef<Self::Msg>,
-        message: Self::Msg,
-        state: &mut Self::State,
-    ) -> Result<(), ActorProcessingErr> {
+    #[ractor::message(HelloActorMessage::Hey(message))]
+    fn hey(&self, message: String, state: &mut HelloActorState) -> Result<(), ActorProcessingErr> {
         let group = "test".to_string();
         let remote_actors = ractor::pg::get_members(&group)
             .into_iter()
             .filter(|actor| !actor.get_id().is_local())
-            .map(ActorRef::<Self::Msg>::from)
+            .map(ActorRef::<HelloActorMessage>::from)
             .collect::<Vec<_>>();
-        match message {
-            Self::Msg::Hey(message) => {
-                assert!(
-                    message.starts_with("Hey there"),
-                    "Invalid hey message received"
-                );
-                tracing::info!(
-                    "Received a hey {}, replying in kind to {} remote actors",
-                    message,
-                    remote_actors.len()
-                );
-                for act in remote_actors {
-                    act.cast(HelloActorMessage::Hey(message.clone()))?;
-                }
-                state.count += 1;
+        assert!(
+            message.starts_with("Hey there"),
+            "Invalid hey message received"
+        );
+        tracing::info!(
+            "Received a hey {}, replying in kind to {} remote actors",
+            message,
+            remote_actors.len()
+        );
+        for actor in remote_actors {
+            actor.cast(HelloActorMessage::Hey(message.clone()))?;
+        }
+        state.count += 1;
 
-                if state.count > NUM_HELLOS {
-                    state.done = true;
-                }
-            }
-            Self::Msg::IsDone(reply) => {
-                let _ = reply.send(state.done);
-            }
+        if state.count > NUM_HELLOS {
+            state.done = true;
         }
 
         Ok(())
+    }
+
+    #[ractor::message(HelloActorMessage::IsDone(reply))]
+    fn is_done(&self, reply: RpcReplyPort<bool>, state: &HelloActorState) {
+        let _ = reply.send(state.done);
     }
 }
 

--- a/ractor_macros/Cargo.toml
+++ b/ractor_macros/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ractor_macros"
+version.workspace = true
+authors = ["Sean Lawlor <slawlor>"]
+description = "Ergonomic actor definition macros for ractor"
+license = "MIT"
+edition = "2021"
+keywords = ["actor", "ractor", "macros"]
+categories = ["asynchronous"]
+repository = "https://github.com/slawlor/ractor"
+readme = "../README.md"
+rust-version.workspace = true
+
+[lib]
+proc-macro = true
+
+[features]
+async-trait = []
+
+[dependencies]
+proc-macro-crate = "3"
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/ractor_macros/src/config.rs
+++ b/ractor_macros/src/config.rs
@@ -1,0 +1,91 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use syn::parse::{Parse, ParseStream};
+use syn::{Ident, Path, Result, Token, Type};
+
+/// Configuration supplied to `#[ractor::actor(...)]`.
+pub(crate) struct ActorConfig {
+    pub(crate) thread_local: bool,
+    pub(crate) message: Type,
+    pub(crate) state: Type,
+    pub(crate) arguments: Type,
+    pub(crate) crate_path: Option<Path>,
+}
+
+impl Parse for ActorConfig {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let mut thread_local = false;
+        let mut message = None;
+        let mut state = None;
+        let mut arguments = None;
+        let mut crate_path = None;
+
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            let key_name = key.to_string();
+
+            if key_name == "thread_local" {
+                if thread_local {
+                    return Err(syn::Error::new(key.span(), "duplicate `thread_local` flag"));
+                }
+                thread_local = true;
+            } else {
+                input.parse::<Token![=]>()?;
+                match key_name.as_str() {
+                    "message" => {
+                        set_once(&mut message, input.parse()?, &key, "message")?;
+                    }
+                    "state" => {
+                        set_once(&mut state, input.parse()?, &key, "state")?;
+                    }
+                    "arguments" => {
+                        set_once(&mut arguments, input.parse()?, &key, "arguments")?;
+                    }
+                    "crate_path" => {
+                        set_once(&mut crate_path, input.parse()?, &key, "crate_path")?;
+                    }
+                    _ => {
+                        return Err(syn::Error::new(
+                            key.span(),
+                            "unknown actor option; expected `thread_local`, `message`, `state`, `arguments`, or `crate_path`",
+                        ));
+                    }
+                }
+            }
+
+            if input.is_empty() {
+                break;
+            }
+            input.parse::<Token![,]>()?;
+        }
+
+        let message = message.ok_or_else(|| {
+            syn::Error::new(
+                input.span(),
+                "missing required actor option `message = ...`",
+            )
+        })?;
+
+        Ok(Self {
+            thread_local,
+            message,
+            state: state.unwrap_or_else(|| syn::parse_quote!(())),
+            arguments: arguments.unwrap_or_else(|| syn::parse_quote!(())),
+            crate_path,
+        })
+    }
+}
+
+fn set_once<T>(slot: &mut Option<T>, value: T, key: &Ident, name: &str) -> Result<()> {
+    if slot.is_some() {
+        return Err(syn::Error::new(
+            key.span(),
+            format!("duplicate `{name}` option"),
+        ));
+    }
+    *slot = Some(value);
+    Ok(())
+}

--- a/ractor_macros/src/expand.rs
+++ b/ractor_macros/src/expand.rs
@@ -1,0 +1,662 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use std::collections::HashSet;
+
+use proc_macro2::{Span, TokenStream};
+use proc_macro_crate::{crate_name, FoundCrate};
+use quote::{quote, ToTokens};
+use syn::parse::Parser;
+use syn::spanned::Spanned;
+use syn::{
+    punctuated::Punctuated, Attribute, FnArg, ImplItem, ImplItemFn, ItemImpl, Meta, Pat, PatIdent,
+    Path, ReturnType, Signature, Token, Type, TypeReference, Visibility,
+};
+
+use crate::config::ActorConfig;
+
+const LIFECYCLE_METHODS: &[&str] = &[
+    "pre_start",
+    "post_start",
+    "post_stop",
+    "handle",
+    "handle_serialized",
+    "handle_supervisor_evt",
+];
+
+pub(crate) fn expand_actor(
+    config: ActorConfig,
+    mut actor_impl: ItemImpl,
+) -> syn::Result<TokenStream> {
+    validate_impl(&actor_impl)?;
+
+    let ractor = resolve_ractor_path(config.crate_path.as_ref())?;
+    let mut inherent_items = Vec::new();
+    let mut trait_methods = Vec::new();
+    let mut handlers = Vec::new();
+    let mut raw_handle_span = None;
+
+    for item in actor_impl.items {
+        let ImplItem::Fn(mut method) = item else {
+            inherent_items.push(item);
+            continue;
+        };
+
+        let message_attributes = take_message_attributes(&mut method.attrs, &ractor);
+        if message_attributes.len() > 1 {
+            return Err(syn::Error::new(
+                message_attributes[1].span(),
+                "message handler methods may only have one `#[ractor::message(...)]` attribute",
+            ));
+        }
+
+        if let Some(attribute) = message_attributes.first() {
+            let pattern = attribute.parse_args_with(Pat::parse_single)?;
+            handlers.push(parse_handler(&method, pattern)?);
+            inherent_items.push(ImplItem::Fn(method));
+            continue;
+        }
+
+        if is_lifecycle_method(&method.sig.ident) {
+            validate_lifecycle_method(&method)?;
+            if method.sig.ident == "handle" {
+                raw_handle_span = Some(method.sig.ident.span());
+            }
+            trait_methods.push(method);
+        } else {
+            inherent_items.push(ImplItem::Fn(method));
+        }
+    }
+
+    if let Some(span) = raw_handle_span {
+        if !handlers.is_empty() {
+            return Err(syn::Error::new(
+                span,
+                "define either a raw `handle` method or `#[ractor::message(...)]` handlers, not both",
+            ));
+        }
+    }
+    if raw_handle_span.is_none() && handlers.is_empty() {
+        return Err(syn::Error::new(
+            actor_impl.self_ty.span(),
+            "actor implementation requires a raw `handle` method or at least one `#[ractor::message(...)]` handler",
+        ));
+    }
+
+    validate_unique_patterns(&handlers)?;
+
+    let has_pre_start = trait_methods
+        .iter()
+        .any(|method| method.sig.ident == "pre_start");
+    if !has_pre_start {
+        if !is_unit_type(&config.state) || !is_unit_type(&config.arguments) {
+            return Err(syn::Error::new(
+                actor_impl.self_ty.span(),
+                "`pre_start` is required unless both `state` and `arguments` are `()`",
+            ));
+        }
+        trait_methods.push(default_pre_start(&ractor));
+    }
+
+    if raw_handle_span.is_none() {
+        trait_methods.push(generated_handle(&ractor, &handlers)?);
+    }
+
+    let ActorConfig {
+        thread_local,
+        message,
+        state,
+        arguments,
+        crate_path: _,
+    } = config;
+    let trait_path = if thread_local {
+        quote!(#ractor::thread_local::ThreadLocalActor)
+    } else {
+        quote!(#ractor::Actor)
+    };
+    let async_trait_attribute = if !thread_local && cfg!(feature = "async-trait") {
+        quote!(#[#ractor::async_trait])
+    } else {
+        TokenStream::new()
+    };
+
+    let attrs = &actor_impl.attrs;
+    let self_ty = &actor_impl.self_ty;
+    let (impl_generics, _, where_clause) = actor_impl.generics.split_for_impl();
+    let trait_impl = quote! {
+        #(#attrs)*
+        #async_trait_attribute
+        impl #impl_generics #trait_path for #self_ty #where_clause {
+            type Msg = #message;
+            type State = #state;
+            type Arguments = #arguments;
+
+            #(#trait_methods)*
+        }
+    };
+
+    let inherent_impl = if inherent_items.is_empty() {
+        TokenStream::new()
+    } else {
+        actor_impl.items = inherent_items;
+        quote!(#actor_impl)
+    };
+
+    Ok(quote! {
+        #inherent_impl
+        #trait_impl
+    })
+}
+
+fn validate_impl(actor_impl: &ItemImpl) -> syn::Result<()> {
+    if actor_impl.trait_.is_some() {
+        return Err(syn::Error::new(
+            actor_impl.impl_token.span,
+            "`#[ractor::actor]` must be applied to an inherent implementation block",
+        ));
+    }
+    if actor_impl.unsafety.is_some() {
+        return Err(syn::Error::new(
+            actor_impl.impl_token.span,
+            "unsafe actor implementation blocks are not supported",
+        ));
+    }
+    if let Some(attribute) = actor_impl
+        .attrs
+        .iter()
+        .find(|attribute| applies_async_trait(attribute))
+    {
+        return Err(syn::Error::new(
+            attribute.span(),
+            "remove `async_trait` from this implementation; `#[ractor::actor]` applies it when needed",
+        ));
+    }
+    Ok(())
+}
+
+fn applies_async_trait(attribute: &Attribute) -> bool {
+    if path_ends_with_async_trait(attribute.path()) {
+        return true;
+    }
+    if !attribute.path().is_ident("cfg_attr") {
+        return false;
+    }
+
+    attribute
+        .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+        .map(|items| {
+            items
+                .iter()
+                .skip(1)
+                .any(|meta| path_ends_with_async_trait(meta.path()))
+        })
+        .unwrap_or(false)
+}
+
+fn path_ends_with_async_trait(path: &Path) -> bool {
+    path.segments
+        .last()
+        .is_some_and(|segment| segment.ident == "async_trait")
+}
+
+fn resolve_ractor_path(explicit_path: Option<&Path>) -> syn::Result<Path> {
+    if let Some(path) = explicit_path {
+        return Ok(path.clone());
+    }
+
+    match crate_name("ractor") {
+        Ok(FoundCrate::Itself) => Ok(syn::parse_quote!(::ractor)),
+        Ok(FoundCrate::Name(name)) => {
+            let crate_ident = syn::Ident::new(&name.replace('-', "_"), Span::call_site());
+            Ok(syn::parse_quote!(::#crate_ident))
+        }
+        Err(error) => Err(syn::Error::new(
+            Span::call_site(),
+            format!(
+                "could not find the `ractor` dependency ({error}); use `crate_path = ...` to specify its path"
+            ),
+        )),
+    }
+}
+
+fn take_message_attributes(attributes: &mut Vec<Attribute>, ractor: &Path) -> Vec<Attribute> {
+    let mut message_attributes = Vec::new();
+    attributes.retain(|attribute| {
+        let is_message = is_message_attribute(attribute, ractor);
+        if is_message {
+            message_attributes.push(attribute.clone());
+        }
+        !is_message
+    });
+    message_attributes
+}
+
+fn is_message_attribute(attribute: &Attribute, ractor: &Path) -> bool {
+    let path = attribute.path();
+    if path.is_ident("message") {
+        return true;
+    }
+    if path.segments.len() != ractor.segments.len() + 1 {
+        return false;
+    }
+
+    path.segments
+        .iter()
+        .zip(&ractor.segments)
+        .all(|(actual, expected)| actual.ident == expected.ident)
+        && path
+            .segments
+            .last()
+            .is_some_and(|segment| segment.ident == "message")
+}
+
+fn is_lifecycle_method(ident: &syn::Ident) -> bool {
+    LIFECYCLE_METHODS
+        .iter()
+        .any(|method_name| ident == method_name)
+}
+
+fn validate_lifecycle_method(method: &ImplItemFn) -> syn::Result<()> {
+    if !matches!(method.vis, Visibility::Inherited) {
+        return Err(syn::Error::new(
+            method.vis.span(),
+            "actor lifecycle methods must be private",
+        ));
+    }
+    validate_method_shape(&method.sig, "actor lifecycle methods")?;
+    if method.sig.asyncness.is_none() {
+        return Err(syn::Error::new(
+            method.sig.fn_token.span,
+            "actor lifecycle methods must be `async fn`",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum StateAccess {
+    Shared,
+    Mutable,
+}
+
+struct Handler {
+    method_name: syn::Ident,
+    pattern: Pat,
+    pattern_key: String,
+    binding_names: Vec<syn::Ident>,
+    wants_actor_ref: bool,
+    state_access: Option<StateAccess>,
+    is_async: bool,
+    is_fallible: bool,
+    cfg_attributes: Vec<Attribute>,
+}
+
+fn parse_handler(method: &ImplItemFn, pattern: Pat) -> syn::Result<Handler> {
+    validate_method_shape(&method.sig, "message handler methods")?;
+    let (pattern_key, binding_names) = parse_message_pattern(&pattern)?;
+    let parameters = typed_parameters(&method.sig)?;
+    let (wants_actor_ref, state_access) =
+        classify_handler_parameters(&parameters, &binding_names, method.sig.ident.span())?;
+
+    let cfg_attributes = match_arm_cfg_attributes(&method.attrs)?;
+
+    Ok(Handler {
+        method_name: method.sig.ident.clone(),
+        pattern,
+        pattern_key,
+        binding_names,
+        wants_actor_ref,
+        state_access,
+        is_async: method.sig.asyncness.is_some(),
+        is_fallible: !returns_unit(&method.sig.output),
+        cfg_attributes,
+    })
+}
+
+fn match_arm_cfg_attributes(attributes: &[Attribute]) -> syn::Result<Vec<Attribute>> {
+    let mut filtered_attributes = Vec::new();
+    for attribute in attributes {
+        if let Some(meta) = filter_cfg_meta(&attribute.meta)? {
+            let mut filtered_attribute = attribute.clone();
+            filtered_attribute.meta = meta;
+            filtered_attributes.push(filtered_attribute);
+        }
+    }
+    Ok(filtered_attributes)
+}
+
+fn filter_cfg_meta(meta: &Meta) -> syn::Result<Option<Meta>> {
+    if meta.path().is_ident("cfg") {
+        return Ok(Some(meta.clone()));
+    }
+    if !meta.path().is_ident("cfg_attr") {
+        return Ok(None);
+    }
+
+    let Meta::List(list) = meta else {
+        return Err(syn::Error::new(
+            meta.span(),
+            "`cfg_attr` must use list syntax",
+        ));
+    };
+    let items = Punctuated::<Meta, Token![,]>::parse_terminated.parse2(list.tokens.clone())?;
+    let mut items = items.into_iter();
+    let Some(condition) = items.next() else {
+        return Err(syn::Error::new(
+            meta.span(),
+            "`cfg_attr` requires a condition and at least one attribute",
+        ));
+    };
+    if items.len() == 0 {
+        return Err(syn::Error::new(
+            meta.span(),
+            "`cfg_attr` requires a condition and at least one attribute",
+        ));
+    }
+
+    let mut filtered = Vec::new();
+    for nested in items {
+        if let Some(nested) = filter_cfg_meta(&nested)? {
+            filtered.push(nested);
+        }
+    }
+    if filtered.is_empty() {
+        return Ok(None);
+    }
+
+    let mut filtered_list = list.clone();
+    filtered_list.tokens = quote!(#condition, #(#filtered),*);
+    Ok(Some(Meta::List(filtered_list)))
+}
+
+fn validate_method_shape(signature: &Signature, description: &str) -> syn::Result<()> {
+    if signature.constness.is_some()
+        || signature.unsafety.is_some()
+        || signature.abi.is_some()
+        || signature.variadic.is_some()
+        || !signature.generics.params.is_empty()
+        || signature.generics.where_clause.is_some()
+    {
+        return Err(syn::Error::new(
+            signature.span(),
+            format!("{description} cannot be const, unsafe, extern, variadic, or generic"),
+        ));
+    }
+
+    let Some(FnArg::Receiver(receiver)) = signature.inputs.first() else {
+        return Err(syn::Error::new(
+            signature.span(),
+            format!("{description} must begin with `&self`"),
+        ));
+    };
+    if receiver.reference.is_none()
+        || receiver.mutability.is_some()
+        || receiver.colon_token.is_some()
+    {
+        return Err(syn::Error::new(
+            receiver.span(),
+            format!("{description} must use an immutable `&self` receiver"),
+        ));
+    }
+    Ok(())
+}
+
+struct Parameter<'a> {
+    ident: &'a syn::Ident,
+    ty: &'a Type,
+}
+
+fn typed_parameters(signature: &Signature) -> syn::Result<Vec<Parameter<'_>>> {
+    signature
+        .inputs
+        .iter()
+        .skip(1)
+        .map(|argument| match argument {
+            FnArg::Typed(argument) => {
+                let Pat::Ident(PatIdent {
+                    by_ref: None,
+                    ident,
+                    subpat: None,
+                    ..
+                }) = argument.pat.as_ref()
+                else {
+                    return Err(syn::Error::new(
+                        argument.pat.span(),
+                        "handler parameters must be simple identifier bindings",
+                    ));
+                };
+                Ok(Parameter {
+                    ident,
+                    ty: argument.ty.as_ref(),
+                })
+            }
+            FnArg::Receiver(receiver) => Err(syn::Error::new(
+                receiver.span(),
+                "message handler methods may only have one receiver",
+            )),
+        })
+        .collect()
+}
+
+fn classify_handler_parameters(
+    parameters: &[Parameter<'_>],
+    bindings: &[syn::Ident],
+    error_span: Span,
+) -> syn::Result<(bool, Option<StateAccess>)> {
+    let without_state = match_handler_parameters(parameters, bindings, None);
+    let with_state = parameters.last().and_then(|parameter| {
+        state_reference_access(parameter.ty).and_then(|access| {
+            match_handler_parameters(&parameters[..parameters.len() - 1], bindings, Some(access))
+        })
+    });
+
+    match (without_state, with_state) {
+        (Some(result), None) | (None, Some(result)) => Ok(result),
+        (Some(_), Some(_)) => Err(syn::Error::new(
+            error_span,
+            "handler parameters are ambiguous; rename the actor reference or state parameter so payload bindings remain explicit",
+        )),
+        (None, None) => Err(syn::Error::new(
+            error_span,
+            "handler parameters must match the message pattern bindings, with an optional leading `ActorRef` and optional trailing state reference",
+        )),
+    }
+}
+
+fn match_handler_parameters(
+    parameters: &[Parameter<'_>],
+    bindings: &[syn::Ident],
+    state_access: Option<StateAccess>,
+) -> Option<(bool, Option<StateAccess>)> {
+    let (wants_actor_ref, payload_parameters) = if parameters.len() == bindings.len() {
+        (false, parameters)
+    } else if parameters.len() == bindings.len() + 1
+        && parameters
+            .first()
+            .is_some_and(|parameter| is_actor_ref(parameter.ty))
+    {
+        (true, &parameters[1..])
+    } else {
+        return None;
+    };
+
+    payload_parameters
+        .iter()
+        .zip(bindings)
+        .all(|(parameter, binding)| parameter.ident == binding)
+        .then_some((wants_actor_ref, state_access))
+}
+
+fn state_reference_access(ty: &Type) -> Option<StateAccess> {
+    let Type::Reference(TypeReference { mutability, .. }) = unparenthesized_type(ty) else {
+        return None;
+    };
+    Some(if mutability.is_some() {
+        StateAccess::Mutable
+    } else {
+        StateAccess::Shared
+    })
+}
+
+fn unparenthesized_type(mut ty: &Type) -> &Type {
+    loop {
+        ty = match ty {
+            Type::Group(group) => group.elem.as_ref(),
+            Type::Paren(parenthesized) => parenthesized.elem.as_ref(),
+            _ => return ty,
+        };
+    }
+}
+
+fn is_actor_ref(ty: &Type) -> bool {
+    let Type::Path(path) = unparenthesized_type(ty) else {
+        return false;
+    };
+    path.path
+        .segments
+        .last()
+        .is_some_and(|segment| segment.ident == "ActorRef")
+}
+
+fn parse_message_pattern(pattern: &Pat) -> syn::Result<(String, Vec<syn::Ident>)> {
+    let (path, fields): (&Path, Vec<&Pat>) = match pattern {
+        Pat::Path(path) if path.qself.is_none() && path.attrs.is_empty() => {
+            (&path.path, Vec::new())
+        }
+        Pat::TupleStruct(tuple) if tuple.qself.is_none() && tuple.attrs.is_empty() => {
+            (&tuple.path, tuple.elems.iter().collect())
+        }
+        Pat::Struct(structure)
+            if structure.qself.is_none()
+                && structure.attrs.is_empty()
+                && structure.rest.is_none() =>
+        {
+            (
+                &structure.path,
+                structure
+                    .fields
+                    .iter()
+                    .map(|field| field.pat.as_ref())
+                    .collect(),
+            )
+        }
+        Pat::Struct(structure) if structure.rest.is_some() => {
+            return Err(syn::Error::new(
+                structure.span(),
+                "message patterns must list every struct variant field; `..` is not supported",
+            ));
+        }
+        _ => {
+            return Err(syn::Error::new(
+                pattern.span(),
+                "message patterns must be a unit, tuple, or struct enum variant with identifier or `_` fields",
+            ));
+        }
+    };
+
+    let mut bindings = Vec::new();
+    for field in fields {
+        match field {
+            Pat::Ident(PatIdent {
+                attrs,
+                by_ref: None,
+                mutability: None,
+                ident,
+                subpat: None,
+            }) if attrs.is_empty() => bindings.push(ident.clone()),
+            Pat::Wild(wildcard) if wildcard.attrs.is_empty() => {}
+            _ => {
+                return Err(syn::Error::new(
+                    field.span(),
+                    "message pattern fields must be plain identifier bindings or `_`",
+                ));
+            }
+        }
+    }
+
+    Ok((path.to_token_stream().to_string(), bindings))
+}
+
+fn validate_unique_patterns(handlers: &[Handler]) -> syn::Result<()> {
+    let mut patterns = HashSet::new();
+    for handler in handlers {
+        if !patterns.insert(&handler.pattern_key) {
+            return Err(syn::Error::new(
+                handler.pattern.span(),
+                "this message variant already has a handler",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn returns_unit(output: &ReturnType) -> bool {
+    match output {
+        ReturnType::Default => true,
+        ReturnType::Type(_, ty) => is_unit_type(ty),
+    }
+}
+
+fn is_unit_type(ty: &Type) -> bool {
+    matches!(unparenthesized_type(ty), Type::Tuple(tuple) if tuple.elems.is_empty())
+}
+
+fn default_pre_start(ractor: &Path) -> ImplItemFn {
+    syn::parse_quote! {
+        async fn pre_start(
+            &self,
+            _myself: #ractor::ActorRef<Self::Msg>,
+            _args: Self::Arguments,
+        ) -> ::core::result::Result<Self::State, #ractor::ActorProcessingErr> {
+            ::core::result::Result::Ok(())
+        }
+    }
+}
+
+fn generated_handle(ractor: &Path, handlers: &[Handler]) -> syn::Result<ImplItemFn> {
+    let myself_ident = syn::Ident::new("__ractor_myself", Span::mixed_site());
+    let message_ident = syn::Ident::new("__ractor_message", Span::mixed_site());
+    let state_ident = syn::Ident::new("__ractor_state", Span::mixed_site());
+    let arms = handlers.iter().map(|handler| {
+        let cfg_attributes = &handler.cfg_attributes;
+        let pattern = &handler.pattern;
+        let method_name = &handler.method_name;
+        let mut arguments = Vec::new();
+        if handler.wants_actor_ref {
+            arguments.push(quote!(#myself_ident));
+        }
+        arguments.extend(handler.binding_names.iter().map(|binding| quote!(#binding)));
+        if let Some(state_access) = handler.state_access {
+            arguments.push(match state_access {
+                StateAccess::Shared => quote!(&*#state_ident),
+                StateAccess::Mutable => quote!(&mut *#state_ident),
+            });
+        }
+
+        let await_suffix = handler.is_async.then(|| quote!(.await));
+        let try_suffix = handler.is_fallible.then(|| quote!(?));
+        quote! {
+            #(#cfg_attributes)*
+            #pattern => {
+                self.#method_name(#(#arguments),*) #await_suffix #try_suffix;
+                ::core::result::Result::Ok(())
+            }
+        }
+    });
+
+    syn::parse2(quote! {
+        #[allow(unused_variables)]
+        async fn handle(
+            &self,
+            #myself_ident: #ractor::ActorRef<Self::Msg>,
+            #message_ident: Self::Msg,
+            #state_ident: &mut Self::State,
+        ) -> ::core::result::Result<(), #ractor::ActorProcessingErr> {
+            match #message_ident {
+                #(#arms),*
+            }
+        }
+    })
+}

--- a/ractor_macros/src/lib.rs
+++ b/ractor_macros/src/lib.rs
@@ -1,0 +1,62 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! Procedural macros for concise, explicit Ractor actor definitions.
+
+extern crate proc_macro;
+
+mod config;
+mod expand;
+
+use proc_macro::TokenStream;
+use syn::parse_macro_input;
+
+use crate::config::ActorConfig;
+
+/// Generate a Ractor actor implementation from ordinary inherent methods.
+///
+/// `message = MessageType` is required. `state` and `arguments` default to
+/// `()`. Add the `thread_local` flag to implement `ThreadLocalActor` instead
+/// of `Actor`.
+///
+/// Mark handlers with `#[ractor::message(Message::Variant(...))]`. Flat unit,
+/// tuple, and struct variant patterns are supported, and their named bindings
+/// must appear as method parameters in the same order. A handler may also take
+/// an `ActorRef` first and `&State` or `&mut State` last. Handlers can be sync
+/// or async; any explicit non-unit return must support `?` and is propagated
+/// into the generated `handle` method.
+///
+/// The generated dispatch is exhaustive, so adding a message variant without
+/// a handler is a compile error. A canonical raw `handle` method remains
+/// supported, but cannot be mixed with generated message handlers. Other
+/// lifecycle methods keep their normal async trait signatures.
+///
+/// ```ignore
+/// #[ractor::actor(message = CounterMessage, state = u64)]
+/// impl Counter {
+///     async fn pre_start(
+///         &self,
+///         _myself: ractor::ActorRef<CounterMessage>,
+///         _args: (),
+///     ) -> Result<u64, ractor::ActorProcessingErr> {
+///         Ok(0)
+///     }
+///
+///     #[ractor::message(CounterMessage::Add(amount))]
+///     fn add(&self, amount: u64, state: &mut u64) {
+///         *state += amount;
+///     }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn actor(attributes: TokenStream, item: TokenStream) -> TokenStream {
+    let config = parse_macro_input!(attributes as ActorConfig);
+    let actor_impl = parse_macro_input!(item as syn::ItemImpl);
+
+    match expand::expand_actor(config, actor_impl) {
+        Ok(expanded) => expanded.into(),
+        Err(error) => error.into_compile_error().into(),
+    }
+}


### PR DESCRIPTION
## Summary

- add the opt-in `actor-macros` feature and new `ractor_macros` proc-macro crate
- generate exhaustive `Actor` and `ThreadLocalActor` dispatch from small per-message methods
- support unit, tuple, and struct variants; sync/async and fallible handlers; optional actor references and shared/mutable state
- preserve lifecycle hooks, raw `handle`, generics, bounds, conditional compilation, and explicit cluster serialization
- add a guide, runnable example, actionable compile diagnostics, and publishing support

## Coverage and real-world use

- convert the PG synchronization and external-transport cluster actors to the macro pattern
- exercise cluster-derived RPC messages, ActorRef injection, arguments, and shared/mutable state in existing integration scenarios
- explicitly instrument the feature-gated macro suite during coverage runs; it was previously skipped, producing the 0% report

## Compatibility

- targets the Rust 1.85 / Ractor 0.16 baseline merged in #455
- opt-in only: no new default runtime dispatch layer
- forwards `async-trait` behavior and composes with async-std and cluster builds
- publishes `ractor_macros` before `ractor`, then waits for registry availability

## Validation

- Rust 1.85 workspace tests: 181 core, 39 cluster, 16 integration, plus doctests
- focused native, `async-trait`, async-std, cluster, generic, raw-handle, thread-local, cfg, hygiene, and UI diagnostic coverage
- native and `async-trait` cluster integration suites
- warning-free rustdoc and verified `ractor_macros` package
- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`

Independent adversarial review completed with no remaining blockers.