### PR TITLE
fix(macros): resolve ractor outside Cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ resolver = "3"
 
 [workspace.package]
 rust-version = "1.85"
-version = "0.16.0"
+version = "0.16.1"

--- a/docs/actor-macros.md
+++ b/docs/actor-macros.md
@@ -51,8 +51,9 @@ impl Counter {
 
 `message` is required. `state` and `arguments` default to `()`. The macro generates the
 `Actor` implementation and an exhaustive `match` over the message enum. Rust therefore reports a
-new or forgotten message variant at compile time. Renamed `ractor` dependencies are detected
-automatically; `crate_path = some::path` is available when a re-export requires an explicit path.
+new or forgotten message variant at compile time. Cargo dependency renames are detected
+automatically, and non-Cargo builds default to `::ractor`. The `crate_path = some::path` option is
+only necessary when a non-Cargo build renames the dependency.
 
 Tuple, struct, and unit variants are supported. Bindings in the attribute pattern become handler
 parameters with matching names in the same order; `_` can discard an unused field. Keep patterns

--- a/ractor/examples/actor_macro.rs
+++ b/ractor/examples/actor_macro.rs
@@ -36,6 +36,7 @@ impl ractor::Message for CounterMessage {}
     message = CounterMessage,
     state = i64,
     arguments = i64,
+    crate_path = ::ractor,
 )]
 impl Counter {
     async fn pre_start(

--- a/ractor/tests/actor_macros.rs
+++ b/ractor/tests/actor_macros.rs
@@ -36,6 +36,7 @@ impl ractor::Message for CounterMessage {}
     message = CounterMessage,
     state = std::primitive::i64,
     arguments = i64,
+    crate_path = ::ractor,
 )]
 impl Counter {
     async fn pre_start(
@@ -103,7 +104,7 @@ enum RawMessage {
 #[cfg(feature = "cluster")]
 impl ractor::Message for RawMessage {}
 
-#[ractor::actor(message = RawMessage)]
+#[ractor::actor(message = RawMessage, crate_path = ::ractor)]
 impl RawActor {
     async fn handle(
         &self,
@@ -136,6 +137,7 @@ impl ractor::Message for LocalMessage {}
     message = LocalMessage,
     state = Rc<Cell<i64>>,
     arguments = i64,
+    crate_path = ::ractor,
 )]
 #[cfg_attr(feature = "async-std", allow(dead_code))]
 impl LocalCounter {
@@ -172,7 +174,7 @@ enum GenericMessage<T> {
 #[cfg(feature = "cluster")]
 impl<T: Send + 'static> ractor::Message for GenericMessage<T> {}
 
-#[ractor::actor(message = GenericMessage<T>)]
+#[ractor::actor(message = GenericMessage<T>, crate_path = ::ractor)]
 impl<T> GenericActor<T>
 where
     T: Send + Sync + 'static,
@@ -203,7 +205,7 @@ mod shadowed_prelude_names {
     #[cfg(feature = "cluster")]
     impl ractor::Message for Message {}
 
-    #[ractor::actor(message = Message)]
+    #[ractor::actor(message = Message, crate_path = ::ractor)]
     impl ShadowedActor {
         #[ractor::message(Message::Run)]
         fn run(&self) {

--- a/ractor_macros/src/expand.rs
+++ b/ractor_macros/src/expand.rs
@@ -32,7 +32,7 @@ pub(crate) fn expand_actor(
 ) -> syn::Result<TokenStream> {
     validate_impl(&actor_impl)?;
 
-    let ractor = resolve_ractor_path(config.crate_path.as_ref())?;
+    let ractor = resolve_ractor_path(config.crate_path.as_ref());
     let mut inherent_items = Vec::new();
     let mut trait_methods = Vec::new();
     let mut handlers = Vec::new();
@@ -201,23 +201,67 @@ fn path_ends_with_async_trait(path: &Path) -> bool {
         .is_some_and(|segment| segment.ident == "async_trait")
 }
 
-fn resolve_ractor_path(explicit_path: Option<&Path>) -> syn::Result<Path> {
+fn resolve_ractor_path(explicit_path: Option<&Path>) -> Path {
+    resolve_ractor_path_with(explicit_path, || crate_name("ractor"))
+}
+
+fn resolve_ractor_path_with<E>(
+    explicit_path: Option<&Path>,
+    find_crate: impl FnOnce() -> Result<FoundCrate, E>,
+) -> Path {
     if let Some(path) = explicit_path {
-        return Ok(path.clone());
+        return path.clone();
     }
 
-    match crate_name("ractor") {
-        Ok(FoundCrate::Itself) => Ok(syn::parse_quote!(::ractor)),
+    match find_crate() {
+        Ok(FoundCrate::Itself) => syn::parse_quote!(crate),
         Ok(FoundCrate::Name(name)) => {
             let crate_ident = syn::Ident::new(&name.replace('-', "_"), Span::call_site());
-            Ok(syn::parse_quote!(::#crate_ident))
+            syn::parse_quote!(::#crate_ident)
         }
-        Err(error) => Err(syn::Error::new(
-            Span::call_site(),
-            format!(
-                "could not find the `ractor` dependency ({error}); use `crate_path = ...` to specify its path"
-            ),
-        )),
+        Err(_) => syn::parse_quote!(::ractor),
+    }
+}
+
+#[cfg(test)]
+mod resolve_ractor_path_tests {
+    use super::*;
+
+    fn path_string(path: &Path) -> String {
+        path.to_token_stream().to_string()
+    }
+
+    #[test]
+    fn lookup_failure_falls_back_to_ractor() {
+        let path = resolve_ractor_path_with(None, || Err::<FoundCrate, _>("lookup failed"));
+
+        assert_eq!(path_string(&path), ":: ractor");
+    }
+
+    #[test]
+    fn explicit_path_takes_priority() {
+        let explicit: Path = syn::parse_quote!(reexport::ractor);
+        let path = resolve_ractor_path_with(Some(&explicit), || -> Result<FoundCrate, ()> {
+            panic!("crate lookup should not run when crate_path is explicit")
+        });
+
+        assert_eq!(path_string(&path), path_string(&explicit));
+    }
+
+    #[test]
+    fn renamed_dependency_uses_discovered_name() {
+        let path = resolve_ractor_path_with(None, || {
+            Ok::<_, ()>(FoundCrate::Name("renamed-ractor".to_owned()))
+        });
+
+        assert_eq!(path_string(&path), ":: renamed_ractor");
+    }
+
+    #[test]
+    fn self_crate_uses_crate_path() {
+        let path = resolve_ractor_path_with(None, || Ok::<_, ()>(FoundCrate::Itself));
+
+        assert_eq!(path_string(&path), "crate");
     }
 }
 


### PR DESCRIPTION
## Summary

- fall back to `::ractor` when Cargo crate discovery is unavailable
- preserve explicit overrides, self-crate resolution, and renamed Cargo dependencies
- document when non-Cargo builds need `crate_path` and add focused resolver tests

Suitable for the 0.16.1 patch release. This does not publish a release.

## Validation

- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`
- `cargo test`