### PR TITLE
feat(macros): generate local messages and supervision handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ impl Counter {
 ```
 
 The generated dispatch remains an exhaustive match, so adding an unhandled enum variant is a
-compile error. For local actors, `messages = CounterMessage` can also generate the enum from
+compile error. For local actors, `message = enum CounterMessage` can also generate the enum from
 handler patterns and parameter types. Focused `#[ractor::supervision(...)]` methods provide the
 same dispatch style for supervision events. The explicit trait-based API remains available when
 its flexibility is preferable. See the [guide](docs/actor-macros.md) and the

--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ impl Counter {
 ```
 
 The generated dispatch remains an exhaustive match, so adding an unhandled enum variant is a
-compile error. The explicit trait-based API remains available when its flexibility is preferable.
-See the [guide](docs/actor-macros.md) and the
+compile error. For local actors, `messages = CounterMessage` can also generate the enum from
+handler patterns and parameter types. Focused `#[ractor::supervision(...)]` methods provide the
+same dispatch style for supervision events. The explicit trait-based API remains available when
+its flexibility is preferable. See the [guide](docs/actor-macros.md) and the
 [`actor_macro` example](ractor/examples/actor_macro.rs) for the supported method shapes.
 
 An example `ping-pong` actor might be the following

--- a/docs/actor-macros.md
+++ b/docs/actor-macros.md
@@ -62,13 +62,13 @@ flat so that the method signature remains an immediate description of the messag
 
 ## Generating local message enums
 
-For local actors, `messages = [visibility] EnumName` generates the message enum from the handler
-patterns and parameter types:
+For local actors, `message = [visibility] enum EnumName` generates the message enum from the
+handler patterns and parameter types:
 
 ```rust
 struct Counter;
 
-#[ractor::actor(messages = pub CounterMessage, state = i64, arguments = i64)]
+#[ractor::actor(message = pub enum CounterMessage, state = i64, arguments = i64)]
 impl Counter {
     async fn pre_start(
         &self,

--- a/docs/actor-macros.md
+++ b/docs/actor-macros.md
@@ -11,7 +11,7 @@ ractor = { version = "0.16", features = ["actor-macros"] }
 ## Defining an actor
 
 Apply `#[ractor::actor]` to an inherent implementation and mark each message handler with
-`#[ractor::message]`:
+`#[ractor::message]`. The usual form uses an explicitly declared message enum:
 
 ```rust
 use ractor::{ActorProcessingErr, ActorRef, RpcReplyPort};
@@ -49,7 +49,8 @@ impl Counter {
 }
 ```
 
-`message` is required. `state` and `arguments` default to `()`. The macro generates the
+Either `message` or the generated-message form described below is required. `state` and
+`arguments` default to `()`. The macro generates the
 `Actor` implementation and an exhaustive `match` over the message enum. Rust therefore reports a
 new or forgotten message variant at compile time. Cargo dependency renames are detected
 automatically, and non-Cargo builds default to `::ractor`. The `crate_path = some::path` option is
@@ -58,6 +59,60 @@ only necessary when a non-Cargo build renames the dependency.
 Tuple, struct, and unit variants are supported. Bindings in the attribute pattern become handler
 parameters with matching names in the same order; `_` can discard an unused field. Keep patterns
 flat so that the method signature remains an immediate description of the message payload.
+
+## Generating local message enums
+
+For local actors, `messages = [visibility] EnumName` generates the message enum from the handler
+patterns and parameter types:
+
+```rust
+struct Counter;
+
+#[ractor::actor(messages = pub CounterMessage, state = i64, arguments = i64)]
+impl Counter {
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<CounterMessage>,
+        initial: i64,
+    ) -> Result<i64, ActorProcessingErr> {
+        Ok(initial)
+    }
+
+    #[ractor::message(Add { amount })]
+    fn add(&self, amount: i64, state: &mut i64) {
+        *state += amount;
+    }
+
+    #[ractor::message(Read(reply))]
+    fn read(&self, reply: RpcReplyPort<i64>, state: &i64) {
+        let _ = reply.send(*state);
+    }
+}
+```
+
+This generates the equivalent of:
+
+```rust
+pub enum CounterMessage {
+    Add { amount: i64 },
+    Read(RpcReplyPort<i64>),
+}
+```
+
+Unit, tuple, and struct variants are supported. Every generated field must have a named binding so
+the macro can find its type; `_` fields are therefore only supported when using an explicit enum.
+The optional visibility defaults to private and can be any normal Rust visibility, such as
+`pub(crate)`. Generated enums currently do not support generic actor implementations.
+
+Generated-message mode deliberately does not add cluster serialization derives or define a wire
+contract. Continue using an explicit message enum for remotely serializable actors. In a build with
+the `cluster` feature, a generated enum used only for local messaging can opt into `Message` with a
+manual implementation:
+
+```rust
+#[cfg(feature = "cluster")]
+impl ractor::Message for CounterMessage {}
+```
 
 ## Handler methods
 
@@ -79,6 +134,37 @@ arguments are `()`, an omitted `pre_start` defaults to `Ok(())`; otherwise it is
 For actors that need custom dispatch, define the normal `handle` method instead of any
 `#[ractor::message]` methods. Raw `handle` and generated handlers are intentionally mutually
 exclusive, keeping the dispatch path unambiguous.
+
+## Supervision handlers
+
+Supervision events can be split into focused methods in the same way as actor messages:
+
+```rust
+#[ractor::supervision(SupervisionEvent::ActorStarted(child))]
+fn child_started(&self, child: ActorCell, state: &mut SupervisorState) {
+    state.children.insert(child.get_id());
+}
+
+#[ractor::supervision(SupervisionEvent::ActorFailed(child, error))]
+async fn child_failed(
+    &self,
+    myself: ActorRef<SupervisorMessage>,
+    child: ActorCell,
+    error: ActorProcessingErr,
+    state: &mut SupervisorState,
+) -> Result<(), ActorProcessingErr> {
+    // Apply the supervisor's restart policy.
+    Ok(())
+}
+```
+
+Supervision handlers may be synchronous or asynchronous, may return a fallible result, and may
+take an optional leading actor reference and trailing state reference. Events matched by a handler
+are fully handled by that method. Unmatched events retain Ractor's default behavior, including
+stopping the supervisor after an unhandled child termination or failure.
+
+A raw `handle_supervisor_evt` method remains available for custom dispatch, but cannot be combined
+with `#[ractor::supervision(...)]` methods in the same actor implementation.
 
 ## Thread-local and cluster actors
 

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -224,7 +224,9 @@ pub use port::OutputPort;
 pub use port::RpcReplyPort;
 #[cfg(feature = "actor-macros")]
 /// Generate an [`Actor`] or [`thread_local::ThreadLocalActor`] implementation
-/// from an inherent implementation block and explicit message handlers.
+/// from an inherent implementation block and focused message or supervision
+/// handlers. Local message enums can optionally be generated from handler
+/// patterns and parameter types.
 ///
 /// Dispatch is exhaustive: adding a message variant without a corresponding
 /// handler does not compile.

--- a/ractor/tests/actor_macros.rs
+++ b/ractor/tests/actor_macros.rs
@@ -7,7 +7,9 @@ use std::cell::Cell;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
-use ractor::{Actor, ActorProcessingErr, ActorRef, RpcReplyPort};
+use ractor::{
+    Actor, ActorCell, ActorProcessingErr, ActorRef, ActorStatus, RpcReplyPort, SupervisionEvent,
+};
 
 struct Counter;
 
@@ -118,6 +120,90 @@ impl RawActor {
     }
 }
 
+struct GeneratedSupervisor;
+
+#[derive(Default)]
+struct SupervisorState {
+    started: usize,
+    terminated: usize,
+    value: i64,
+}
+
+#[ractor::actor(
+    messages = pub MacroSupervisorMessage,
+    state = SupervisorState,
+    crate_path = ::ractor,
+)]
+impl GeneratedSupervisor {
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<MacroSupervisorMessage>,
+        _arguments: (),
+    ) -> Result<SupervisorState, ActorProcessingErr> {
+        Ok(SupervisorState::default())
+    }
+
+    #[ractor::message(Counts(reply))]
+    fn counts(&self, reply: RpcReplyPort<(usize, usize, i64)>, state: &SupervisorState) {
+        let _ = reply.send((state.started, state.terminated, state.value));
+    }
+
+    #[ractor::message(Record { value })]
+    fn record(&self, value: i64, state: &mut SupervisorState) {
+        state.value = value;
+    }
+
+    #[ractor::message(Stop)]
+    fn stop_generated_supervisor(&self, myself: ActorRef<MacroSupervisorMessage>) {
+        myself.stop(None);
+    }
+
+    #[ractor::supervision(SupervisionEvent::ActorStarted(_child))]
+    fn child_started(&self, _child: ActorCell, state: &mut SupervisorState) {
+        state.started += 1;
+    }
+
+    #[ractor::supervision(SupervisionEvent::ActorTerminated(_child, _, _))]
+    fn child_terminated(&self, _child: ActorCell, state: &mut SupervisorState) {
+        state.terminated += 1;
+    }
+}
+
+#[cfg(feature = "cluster")]
+impl ractor::Message for MacroSupervisorMessage {}
+
+struct DefaultingSupervisor;
+
+enum DefaultingSupervisorMessage {
+    Ping,
+}
+
+#[cfg(feature = "cluster")]
+impl ractor::Message for DefaultingSupervisorMessage {}
+
+#[ractor::actor(
+    message = DefaultingSupervisorMessage,
+    state = usize,
+    crate_path = ::ractor,
+)]
+impl DefaultingSupervisor {
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<DefaultingSupervisorMessage>,
+        _arguments: (),
+    ) -> Result<usize, ActorProcessingErr> {
+        Ok(0)
+    }
+
+    #[ractor::message(DefaultingSupervisorMessage::Ping)]
+    fn ping(&self) {}
+
+    #[ractor::supervision(SupervisionEvent::ActorStarted(_child))]
+    fn child_started(&self, _child: ActorCell, state: &mut usize) {
+        *state += 1;
+    }
+}
+
 #[cfg_attr(feature = "async-std", allow(dead_code))]
 #[derive(Default)]
 struct LocalCounter;
@@ -163,6 +249,9 @@ impl LocalCounter {
     fn stop(&self, myself: ActorRef<LocalMessage>) {
         myself.stop(None);
     }
+
+    #[ractor::supervision(SupervisionEvent::ActorStarted(_child))]
+    fn child_started(&self, _child: ActorCell, _state: &Rc<Cell<i64>>) {}
 }
 
 struct GenericActor<T>(PhantomData<T>);
@@ -262,6 +351,55 @@ async fn raw_handle_mode_remains_available() {
 
     actor.stop(None);
     handle.await.expect("raw actor failed to stop cleanly");
+}
+
+#[ractor::concurrency::test]
+async fn generated_messages_and_supervision_handlers_dispatch() {
+    let (supervisor, supervisor_handle) = Actor::spawn(None, GeneratedSupervisor, ())
+        .await
+        .expect("generated supervisor failed to start");
+    let (child, child_handle) = Actor::spawn_linked(None, RawActor, (), supervisor.get_cell())
+        .await
+        .expect("linked child failed to start");
+
+    child.stop(None);
+    child_handle.await.expect("linked child failed to stop");
+
+    supervisor
+        .send_message(MacroSupervisorMessage::Record { value: 42 })
+        .expect("generated struct message failed");
+
+    let counts = ractor::call_t!(supervisor, MacroSupervisorMessage::Counts, 100)
+        .expect("generated supervisor failed to report counts");
+    assert_eq!(counts, (1, 1, 42));
+    assert_eq!(supervisor.get_status(), ActorStatus::Running);
+
+    supervisor
+        .send_message(MacroSupervisorMessage::Stop)
+        .expect("generated supervisor stop message failed");
+    supervisor_handle
+        .await
+        .expect("generated supervisor failed to stop");
+}
+
+#[ractor::concurrency::test]
+async fn unhandled_supervision_events_keep_the_default_shutdown_behavior() {
+    let (supervisor, supervisor_handle) = Actor::spawn(None, DefaultingSupervisor, ())
+        .await
+        .expect("defaulting supervisor failed to start");
+    let (child, child_handle) = Actor::spawn_linked(None, RawActor, (), supervisor.get_cell())
+        .await
+        .expect("linked child failed to start");
+
+    supervisor
+        .send_message(DefaultingSupervisorMessage::Ping)
+        .expect("defaulting supervisor ping failed");
+    child.stop(None);
+    child_handle.await.expect("linked child failed to stop");
+    supervisor_handle
+        .await
+        .expect("defaulting supervisor failed to stop");
+    assert_eq!(supervisor.get_status(), ActorStatus::Stopped);
 }
 
 #[cfg(not(feature = "async-std"))]

--- a/ractor/tests/actor_macros.rs
+++ b/ractor/tests/actor_macros.rs
@@ -7,35 +7,16 @@ use std::cell::Cell;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
+use ractor::actor::messages::BoxedState;
 use ractor::{
-    Actor, ActorCell, ActorProcessingErr, ActorRef, ActorStatus, RpcReplyPort, SupervisionEvent,
+    Actor, ActorCell, ActorId, ActorProcessingErr, ActorRef, ActorStatus, RpcReplyPort,
+    SupervisionEvent,
 };
 
 struct Counter;
 
-enum CounterMessage {
-    Add(i64),
-    #[cfg(any())]
-    Disabled,
-    #[cfg_attr(all(), cfg(any()))]
-    DisabledByCfgAttr,
-    Replace {
-        value: i64,
-    },
-    InternalNames {
-        __ractor_myself: i64,
-        __ractor_message: i64,
-        __ractor_state: i64,
-    },
-    Read(RpcReplyPort<i64>),
-    Stop,
-}
-
-#[cfg(feature = "cluster")]
-impl ractor::Message for CounterMessage {}
-
 #[ractor::actor(
-    message = CounterMessage,
+    message = enum CounterMessage,
     state = std::primitive::i64,
     arguments = i64,
     crate_path = ::ractor,
@@ -49,27 +30,27 @@ impl Counter {
         Ok(initial)
     }
 
-    #[ractor::message(CounterMessage::Add(amount))]
+    #[ractor::message(Add(amount))]
     #[cfg_attr(all(), tracing::instrument(skip(self, state)))]
     fn add(&self, amount: i64, state: &mut i64) {
         *state += amount;
     }
 
     #[cfg(any())]
-    #[ractor::message(CounterMessage::Disabled)]
+    #[ractor::message(Disabled)]
     fn disabled(&self) {}
 
     #[cfg_attr(all(), cfg(any()))]
-    #[ractor::message(CounterMessage::DisabledByCfgAttr)]
+    #[ractor::message(DisabledByCfgAttr)]
     fn disabled_by_cfg_attr(&self) {}
 
-    #[ractor::message(CounterMessage::Replace { value })]
+    #[ractor::message(Replace { value })]
     async fn replace(&self, value: i64, state: &mut i64) -> Result<(), ActorProcessingErr> {
         *state = value;
         Ok(())
     }
 
-    #[ractor::message(CounterMessage::InternalNames {
+    #[ractor::message(InternalNames {
         __ractor_myself,
         __ractor_message,
         __ractor_state,
@@ -86,16 +67,19 @@ impl Counter {
         *state = __ractor_myself + __ractor_message + __ractor_state;
     }
 
-    #[ractor::message(CounterMessage::Read(reply))]
+    #[ractor::message(Read(reply))]
     fn read(&self, reply: RpcReplyPort<i64>, state: &i64) {
         let _ = reply.send(*state);
     }
 
-    #[ractor::message(CounterMessage::Stop)]
+    #[ractor::message(Stop)]
     fn stop(&self, myself: ActorRef<CounterMessage>) {
         myself.stop(None);
     }
 }
+
+#[cfg(feature = "cluster")]
+impl ractor::Message for CounterMessage {}
 
 struct RawActor;
 
@@ -120,17 +104,48 @@ impl RawActor {
     }
 }
 
+struct FailingChild;
+
+enum FailingChildMessage {
+    Fail,
+}
+
+#[cfg(feature = "cluster")]
+impl ractor::Message for FailingChildMessage {}
+
+#[ractor::actor(message = FailingChildMessage, crate_path = ::ractor)]
+impl FailingChild {
+    #[ractor::message(FailingChildMessage::Fail)]
+    fn fail(&self) {
+        panic!("intentional child failure");
+    }
+}
+
 struct GeneratedSupervisor;
 
-#[derive(Default)]
-struct SupervisorState {
-    started: usize,
-    terminated: usize,
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TerminationRecord {
+    actor_id: ActorId,
+    state_was_unit: bool,
+    reason: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FailureRecord {
+    actor_id: ActorId,
+    error: String,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SupervisorState {
+    started: Vec<ActorId>,
+    terminated: Option<TerminationRecord>,
+    failed: Option<FailureRecord>,
     value: i64,
 }
 
 #[ractor::actor(
-    messages = pub MacroSupervisorMessage,
+    message = pub enum MacroSupervisorMessage,
     state = SupervisorState,
     crate_path = ::ractor,
 )]
@@ -144,8 +159,8 @@ impl GeneratedSupervisor {
     }
 
     #[ractor::message(Counts(reply))]
-    fn counts(&self, reply: RpcReplyPort<(usize, usize, i64)>, state: &SupervisorState) {
-        let _ = reply.send((state.started, state.terminated, state.value));
+    fn counts(&self, reply: RpcReplyPort<SupervisorState>, state: &SupervisorState) {
+        let _ = reply.send(state.clone());
     }
 
     #[ractor::message(Record { value })]
@@ -158,14 +173,38 @@ impl GeneratedSupervisor {
         myself.stop(None);
     }
 
-    #[ractor::supervision(SupervisionEvent::ActorStarted(_child))]
-    fn child_started(&self, _child: ActorCell, state: &mut SupervisorState) {
-        state.started += 1;
+    #[ractor::supervision(SupervisionEvent::ActorStarted(child))]
+    fn child_started(&self, child: ActorCell, state: &mut SupervisorState) {
+        state.started.push(child.get_id());
     }
 
-    #[ractor::supervision(SupervisionEvent::ActorTerminated(_child, _, _))]
-    fn child_terminated(&self, _child: ActorCell, state: &mut SupervisorState) {
-        state.terminated += 1;
+    #[ractor::supervision(SupervisionEvent::ActorTerminated(child, final_state, reason,))]
+    fn child_terminated(
+        &self,
+        child: ActorCell,
+        final_state: Option<BoxedState>,
+        reason: Option<String>,
+        state: &mut SupervisorState,
+    ) {
+        let state_was_unit = final_state.is_some_and(|mut value| value.take::<()>().is_ok());
+        state.terminated = Some(TerminationRecord {
+            actor_id: child.get_id(),
+            state_was_unit,
+            reason,
+        });
+    }
+
+    #[ractor::supervision(SupervisionEvent::ActorFailed(child, error))]
+    fn child_failed(
+        &self,
+        child: ActorCell,
+        error: ActorProcessingErr,
+        state: &mut SupervisorState,
+    ) {
+        state.failed = Some(FailureRecord {
+            actor_id: child.get_id(),
+            error: error.to_string(),
+        });
     }
 }
 
@@ -208,19 +247,9 @@ impl DefaultingSupervisor {
 #[derive(Default)]
 struct LocalCounter;
 
-#[cfg_attr(feature = "async-std", allow(dead_code))]
-enum LocalMessage {
-    Add(i64),
-    Read(RpcReplyPort<i64>),
-    Stop,
-}
-
-#[cfg(feature = "cluster")]
-impl ractor::Message for LocalMessage {}
-
 #[ractor::actor(
     thread_local,
-    message = LocalMessage,
+    message = enum LocalMessage,
     state = Rc<Cell<i64>>,
     arguments = i64,
     crate_path = ::ractor,
@@ -235,17 +264,17 @@ impl LocalCounter {
         Ok(Rc::new(Cell::new(initial)))
     }
 
-    #[ractor::message(LocalMessage::Add(amount))]
+    #[ractor::message(Add(amount))]
     fn add(&self, amount: i64, state: &Rc<Cell<i64>>) {
         state.set(state.get() + amount);
     }
 
-    #[ractor::message(LocalMessage::Read(reply))]
+    #[ractor::message(Read(reply))]
     fn read(&self, reply: RpcReplyPort<i64>, state: &Rc<Cell<i64>>) {
         let _ = reply.send(state.get());
     }
 
-    #[ractor::message(LocalMessage::Stop)]
+    #[ractor::message(Stop)]
     fn stop(&self, myself: ActorRef<LocalMessage>) {
         myself.stop(None);
     }
@@ -253,6 +282,9 @@ impl LocalCounter {
     #[ractor::supervision(SupervisionEvent::ActorStarted(_child))]
     fn child_started(&self, _child: ActorCell, _state: &Rc<Cell<i64>>) {}
 }
+
+#[cfg(feature = "cluster")]
+impl ractor::Message for LocalMessage {}
 
 struct GenericActor<T>(PhantomData<T>);
 
@@ -365,13 +397,44 @@ async fn generated_messages_and_supervision_handlers_dispatch() {
     child.stop(None);
     child_handle.await.expect("linked child failed to stop");
 
+    let (failing_child, failing_child_handle) =
+        Actor::spawn_linked(None, FailingChild, (), supervisor.get_cell())
+            .await
+            .expect("failing child failed to start");
+    failing_child
+        .send_message(FailingChildMessage::Fail)
+        .expect("failed to send failure message");
+    failing_child_handle
+        .await
+        .expect("failing child runtime failed to stop");
+
     supervisor
         .send_message(MacroSupervisorMessage::Record { value: 42 })
         .expect("generated struct message failed");
 
-    let counts = ractor::call_t!(supervisor, MacroSupervisorMessage::Counts, 100)
-        .expect("generated supervisor failed to report counts");
-    assert_eq!(counts, (1, 1, 42));
+    let snapshot = ractor::call_t!(supervisor, MacroSupervisorMessage::Counts, 100)
+        .expect("generated supervisor failed to report its state");
+    assert_eq!(
+        snapshot.started,
+        vec![child.get_id(), failing_child.get_id()]
+    );
+    assert_eq!(
+        snapshot.terminated,
+        Some(TerminationRecord {
+            actor_id: child.get_id(),
+            state_was_unit: true,
+            reason: None,
+        })
+    );
+    assert_eq!(
+        snapshot.failed.as_ref().map(|failure| failure.actor_id),
+        Some(failing_child.get_id())
+    );
+    assert!(snapshot
+        .failed
+        .as_ref()
+        .is_some_and(|failure| failure.error.contains("intentional child failure")));
+    assert_eq!(snapshot.value, 42);
     assert_eq!(supervisor.get_status(), ActorStatus::Running);
 
     supervisor

--- a/ractor/tests/ui/actor_macros/generated_message_wildcard.rs
+++ b/ractor/tests/ui/actor_macros/generated_message_wildcard.rs
@@ -1,0 +1,9 @@
+struct GeneratedActor;
+
+#[ractor::actor(messages = GeneratedMessage)]
+impl GeneratedActor {
+    #[ractor::message(Discard(_))]
+    fn discard(&self) {}
+}
+
+fn main() {}

--- a/ractor/tests/ui/actor_macros/generated_message_wildcard.rs
+++ b/ractor/tests/ui/actor_macros/generated_message_wildcard.rs
@@ -1,6 +1,6 @@
 struct GeneratedActor;
 
-#[ractor::actor(messages = GeneratedMessage)]
+#[ractor::actor(message = enum GeneratedMessage)]
 impl GeneratedActor {
     #[ractor::message(Discard(_))]
     fn discard(&self) {}

--- a/ractor/tests/ui/actor_macros/generated_message_wildcard.stderr
+++ b/ractor/tests/ui/actor_macros/generated_message_wildcard.stderr
@@ -1,0 +1,5 @@
+error: generated message patterns cannot discard fields with `_` because every field needs a type
+ --> tests/ui/actor_macros/generated_message_wildcard.rs:3:28
+  |
+3 | #[ractor::actor(messages = GeneratedMessage)]
+  |                            ^^^^^^^^^^^^^^^^

--- a/ractor/tests/ui/actor_macros/generated_message_wildcard.stderr
+++ b/ractor/tests/ui/actor_macros/generated_message_wildcard.stderr
@@ -1,5 +1,5 @@
 error: generated message patterns cannot discard fields with `_` because every field needs a type
- --> tests/ui/actor_macros/generated_message_wildcard.rs:3:28
+ --> tests/ui/actor_macros/generated_message_wildcard.rs:3:32
   |
-3 | #[ractor::actor(messages = GeneratedMessage)]
-  |                            ^^^^^^^^^^^^^^^^
+3 | #[ractor::actor(message = enum GeneratedMessage)]
+  |                                ^^^^^^^^^^^^^^^^

--- a/ractor/tests/ui/actor_macros/mixed_supervision_dispatch.rs
+++ b/ractor/tests/ui/actor_macros/mixed_supervision_dispatch.rs
@@ -1,0 +1,29 @@
+#![allow(unused_imports)]
+
+use ractor::{ActorCell, ActorProcessingErr, ActorRef, SupervisionEvent};
+
+struct MixedSupervisor;
+
+enum Message {
+    Go,
+}
+
+#[ractor::actor(message = Message)]
+impl MixedSupervisor {
+    #[ractor::message(Message::Go)]
+    fn go(&self) {}
+
+    async fn handle_supervisor_evt(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _event: SupervisionEvent,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+
+    #[ractor::supervision(SupervisionEvent::ActorStarted(child))]
+    fn child_started(&self, child: ActorCell) {}
+}
+
+fn main() {}

--- a/ractor/tests/ui/actor_macros/mixed_supervision_dispatch.stderr
+++ b/ractor/tests/ui/actor_macros/mixed_supervision_dispatch.stderr
@@ -1,0 +1,5 @@
+error: define either a raw `handle_supervisor_evt` method or `#[ractor::supervision(...)]` handlers, not both
+  --> tests/ui/actor_macros/mixed_supervision_dispatch.rs:16:14
+   |
+16 |     async fn handle_supervisor_evt(
+   |              ^^^^^^^^^^^^^^^^^^^^^

--- a/ractor_macros/src/config.rs
+++ b/ractor_macros/src/config.rs
@@ -43,7 +43,6 @@ impl Parse for ActorConfig {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         let mut thread_local = false;
         let mut message = None;
-        let mut generated_message = None;
         let mut state = None;
         let mut arguments = None;
         let mut crate_path = None;
@@ -61,17 +60,7 @@ impl Parse for ActorConfig {
                 input.parse::<Token![=]>()?;
                 match key_name.as_str() {
                     "message" => {
-                        set_once(&mut message, input.parse()?, &key, "message")?;
-                    }
-                    "messages" => {
-                        let visibility = input.parse()?;
-                        let ident = input.parse()?;
-                        set_once(
-                            &mut generated_message,
-                            GeneratedMessageConfig { visibility, ident },
-                            &key,
-                            "messages",
-                        )?;
+                        set_once(&mut message, parse_message_config(input)?, &key, "message")?;
                     }
                     "state" => {
                         set_once(&mut state, input.parse()?, &key, "state")?;
@@ -85,7 +74,7 @@ impl Parse for ActorConfig {
                     _ => {
                         return Err(syn::Error::new(
                             key.span(),
-                            "unknown actor option; expected `thread_local`, `message`, `messages`, `state`, `arguments`, or `crate_path`",
+                            "unknown actor option; expected `thread_local`, `message`, `state`, `arguments`, or `crate_path`",
                         ));
                     }
                 }
@@ -97,22 +86,12 @@ impl Parse for ActorConfig {
             input.parse::<Token![,]>()?;
         }
 
-        let message = match (message, generated_message) {
-            (Some(message), None) => MessageConfig::Existing(message),
-            (None, Some(message)) => MessageConfig::Generated(message),
-            (Some(_), Some(message)) => {
-                return Err(syn::Error::new(
-                    message.ident.span(),
-                    "`message` and `messages` are mutually exclusive",
-                ));
-            }
-            (None, None) => {
-                return Err(syn::Error::new(
-                    input.span(),
-                    "missing required actor option `message = ...` or `messages = ...`",
-                ));
-            }
-        };
+        let message = message.ok_or_else(|| {
+            syn::Error::new(
+                input.span(),
+                "missing required actor option `message = ...`",
+            )
+        })?;
 
         Ok(Self {
             thread_local,
@@ -122,6 +101,27 @@ impl Parse for ActorConfig {
             crate_path,
         })
     }
+}
+
+fn parse_message_config(input: ParseStream<'_>) -> Result<MessageConfig> {
+    if input.peek(Token![enum]) {
+        input.parse::<Token![enum]>()?;
+        return Ok(MessageConfig::Generated(GeneratedMessageConfig {
+            visibility: Visibility::Inherited,
+            ident: input.parse()?,
+        }));
+    }
+
+    if input.peek(Token![pub]) {
+        let visibility = input.parse()?;
+        input.parse::<Token![enum]>()?;
+        return Ok(MessageConfig::Generated(GeneratedMessageConfig {
+            visibility,
+            ident: input.parse()?,
+        }));
+    }
+
+    Ok(MessageConfig::Existing(input.parse()?))
 }
 
 fn set_once<T>(slot: &mut Option<T>, value: T, key: &Ident, name: &str) -> Result<()> {

--- a/ractor_macros/src/config.rs
+++ b/ractor_macros/src/config.rs
@@ -4,12 +4,36 @@
 // LICENSE-MIT file in the root directory of this source tree.
 
 use syn::parse::{Parse, ParseStream};
-use syn::{Ident, Path, Result, Token, Type};
+use syn::{Ident, Path, Result, Token, Type, Visibility};
+
+/// An enum generated from the actor's message handlers.
+pub(crate) struct GeneratedMessageConfig {
+    pub(crate) visibility: Visibility,
+    pub(crate) ident: Ident,
+}
+
+/// The message type supplied to `#[ractor::actor(...)]`.
+pub(crate) enum MessageConfig {
+    Existing(Type),
+    Generated(GeneratedMessageConfig),
+}
+
+impl MessageConfig {
+    pub(crate) fn ty(&self) -> Type {
+        match self {
+            Self::Existing(ty) => ty.clone(),
+            Self::Generated(config) => {
+                let ident = &config.ident;
+                syn::parse_quote!(#ident)
+            }
+        }
+    }
+}
 
 /// Configuration supplied to `#[ractor::actor(...)]`.
 pub(crate) struct ActorConfig {
     pub(crate) thread_local: bool,
-    pub(crate) message: Type,
+    pub(crate) message: MessageConfig,
     pub(crate) state: Type,
     pub(crate) arguments: Type,
     pub(crate) crate_path: Option<Path>,
@@ -19,6 +43,7 @@ impl Parse for ActorConfig {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         let mut thread_local = false;
         let mut message = None;
+        let mut generated_message = None;
         let mut state = None;
         let mut arguments = None;
         let mut crate_path = None;
@@ -38,6 +63,16 @@ impl Parse for ActorConfig {
                     "message" => {
                         set_once(&mut message, input.parse()?, &key, "message")?;
                     }
+                    "messages" => {
+                        let visibility = input.parse()?;
+                        let ident = input.parse()?;
+                        set_once(
+                            &mut generated_message,
+                            GeneratedMessageConfig { visibility, ident },
+                            &key,
+                            "messages",
+                        )?;
+                    }
                     "state" => {
                         set_once(&mut state, input.parse()?, &key, "state")?;
                     }
@@ -50,7 +85,7 @@ impl Parse for ActorConfig {
                     _ => {
                         return Err(syn::Error::new(
                             key.span(),
-                            "unknown actor option; expected `thread_local`, `message`, `state`, `arguments`, or `crate_path`",
+                            "unknown actor option; expected `thread_local`, `message`, `messages`, `state`, `arguments`, or `crate_path`",
                         ));
                     }
                 }
@@ -62,12 +97,22 @@ impl Parse for ActorConfig {
             input.parse::<Token![,]>()?;
         }
 
-        let message = message.ok_or_else(|| {
-            syn::Error::new(
-                input.span(),
-                "missing required actor option `message = ...`",
-            )
-        })?;
+        let message = match (message, generated_message) {
+            (Some(message), None) => MessageConfig::Existing(message),
+            (None, Some(message)) => MessageConfig::Generated(message),
+            (Some(_), Some(message)) => {
+                return Err(syn::Error::new(
+                    message.ident.span(),
+                    "`message` and `messages` are mutually exclusive",
+                ));
+            }
+            (None, None) => {
+                return Err(syn::Error::new(
+                    input.span(),
+                    "missing required actor option `message = ...` or `messages = ...`",
+                ));
+            }
+        };
 
         Ok(Self {
             thread_local,

--- a/ractor_macros/src/expand.rs
+++ b/ractor_macros/src/expand.rs
@@ -11,11 +11,11 @@ use quote::{quote, ToTokens};
 use syn::parse::Parser;
 use syn::spanned::Spanned;
 use syn::{
-    punctuated::Punctuated, Attribute, FnArg, ImplItem, ImplItemFn, ItemImpl, Meta, Pat, PatIdent,
-    Path, ReturnType, Signature, Token, Type, TypeReference, Visibility,
+    punctuated::Punctuated, Attribute, FieldPat, FnArg, ImplItem, ImplItemFn, ItemImpl, Member,
+    Meta, Pat, PatIdent, Path, ReturnType, Signature, Token, Type, TypeReference, Visibility,
 };
 
-use crate::config::ActorConfig;
+use crate::config::{ActorConfig, GeneratedMessageConfig, MessageConfig};
 
 const LIFECYCLE_METHODS: &[&str] = &[
     "pre_start",
@@ -31,12 +31,24 @@ pub(crate) fn expand_actor(
     mut actor_impl: ItemImpl,
 ) -> syn::Result<TokenStream> {
     validate_impl(&actor_impl)?;
+    if matches!(&config.message, MessageConfig::Generated(_))
+        && !actor_impl.generics.params.is_empty()
+    {
+        return Err(syn::Error::new(
+            actor_impl.generics.span(),
+            "generated message enums do not yet support generic actor implementations; use `message = ExistingType`",
+        ));
+    }
+    let generated_enum_cfg_attributes = match_arm_cfg_attributes(&actor_impl.attrs)?;
 
     let ractor = resolve_ractor_path(config.crate_path.as_ref());
+    let message_type = config.message.ty();
     let mut inherent_items = Vec::new();
     let mut trait_methods = Vec::new();
-    let mut handlers = Vec::new();
+    let mut message_handlers = Vec::new();
+    let mut supervision_handlers = Vec::new();
     let mut raw_handle_span = None;
+    let mut raw_supervision_span = None;
 
     for item in actor_impl.items {
         let ImplItem::Fn(mut method) = item else {
@@ -44,17 +56,41 @@ pub(crate) fn expand_actor(
             continue;
         };
 
-        let message_attributes = take_message_attributes(&mut method.attrs, &ractor);
+        let message_attributes = take_handler_attributes(&mut method.attrs, &ractor, "message");
+        let supervision_attributes =
+            take_handler_attributes(&mut method.attrs, &ractor, "supervision");
         if message_attributes.len() > 1 {
             return Err(syn::Error::new(
                 message_attributes[1].span(),
                 "message handler methods may only have one `#[ractor::message(...)]` attribute",
             ));
         }
+        if supervision_attributes.len() > 1 {
+            return Err(syn::Error::new(
+                supervision_attributes[1].span(),
+                "supervision handler methods may only have one `#[ractor::supervision(...)]` attribute",
+            ));
+        }
+        if !message_attributes.is_empty() && !supervision_attributes.is_empty() {
+            return Err(syn::Error::new(
+                supervision_attributes[0].span(),
+                "a method cannot be both a message and supervision handler",
+            ));
+        }
 
         if let Some(attribute) = message_attributes.first() {
+            let mut pattern = attribute.parse_args_with(Pat::parse_single)?;
+            if let MessageConfig::Generated(config) = &config.message {
+                qualify_generated_message_pattern(&mut pattern, &config.ident)?;
+            }
+            message_handlers.push(parse_handler(&method, pattern, HandlerKind::Message)?);
+            inherent_items.push(ImplItem::Fn(method));
+            continue;
+        }
+
+        if let Some(attribute) = supervision_attributes.first() {
             let pattern = attribute.parse_args_with(Pat::parse_single)?;
-            handlers.push(parse_handler(&method, pattern)?);
+            supervision_handlers.push(parse_handler(&method, pattern, HandlerKind::Supervision)?);
             inherent_items.push(ImplItem::Fn(method));
             continue;
         }
@@ -63,6 +99,8 @@ pub(crate) fn expand_actor(
             validate_lifecycle_method(&method)?;
             if method.sig.ident == "handle" {
                 raw_handle_span = Some(method.sig.ident.span());
+            } else if method.sig.ident == "handle_supervisor_evt" {
+                raw_supervision_span = Some(method.sig.ident.span());
             }
             trait_methods.push(method);
         } else {
@@ -71,21 +109,30 @@ pub(crate) fn expand_actor(
     }
 
     if let Some(span) = raw_handle_span {
-        if !handlers.is_empty() {
+        if !message_handlers.is_empty() {
             return Err(syn::Error::new(
                 span,
                 "define either a raw `handle` method or `#[ractor::message(...)]` handlers, not both",
             ));
         }
     }
-    if raw_handle_span.is_none() && handlers.is_empty() {
+    if raw_handle_span.is_none() && message_handlers.is_empty() {
         return Err(syn::Error::new(
             actor_impl.self_ty.span(),
             "actor implementation requires a raw `handle` method or at least one `#[ractor::message(...)]` handler",
         ));
     }
+    if let Some(span) = raw_supervision_span {
+        if !supervision_handlers.is_empty() {
+            return Err(syn::Error::new(
+                span,
+                "define either a raw `handle_supervisor_evt` method or `#[ractor::supervision(...)]` handlers, not both",
+            ));
+        }
+    }
 
-    validate_unique_patterns(&handlers)?;
+    validate_unique_patterns(&message_handlers, HandlerKind::Message)?;
+    validate_unique_patterns(&supervision_handlers, HandlerKind::Supervision)?;
 
     let has_pre_start = trait_methods
         .iter()
@@ -101,7 +148,13 @@ pub(crate) fn expand_actor(
     }
 
     if raw_handle_span.is_none() {
-        trait_methods.push(generated_handle(&ractor, &handlers)?);
+        trait_methods.push(generated_handle(&ractor, &message_handlers)?);
+    }
+    if raw_supervision_span.is_none() && !supervision_handlers.is_empty() {
+        trait_methods.push(generated_supervision_handler(
+            &ractor,
+            &supervision_handlers,
+        )?);
     }
 
     let ActorConfig {
@@ -111,6 +164,12 @@ pub(crate) fn expand_actor(
         arguments,
         crate_path: _,
     } = config;
+    let generated_message = match &message {
+        MessageConfig::Existing(_) => TokenStream::new(),
+        MessageConfig::Generated(config) => {
+            generate_message_enum(config, &message_handlers, &generated_enum_cfg_attributes)?
+        }
+    };
     let trait_path = if thread_local {
         quote!(#ractor::thread_local::ThreadLocalActor)
     } else {
@@ -129,7 +188,7 @@ pub(crate) fn expand_actor(
         #(#attrs)*
         #async_trait_attribute
         impl #impl_generics #trait_path for #self_ty #where_clause {
-            type Msg = #message;
+            type Msg = #message_type;
             type State = #state;
             type Arguments = #arguments;
 
@@ -145,6 +204,7 @@ pub(crate) fn expand_actor(
     };
 
     Ok(quote! {
+        #generated_message
         #inherent_impl
         #trait_impl
     })
@@ -265,21 +325,25 @@ mod resolve_ractor_path_tests {
     }
 }
 
-fn take_message_attributes(attributes: &mut Vec<Attribute>, ractor: &Path) -> Vec<Attribute> {
-    let mut message_attributes = Vec::new();
+fn take_handler_attributes(
+    attributes: &mut Vec<Attribute>,
+    ractor: &Path,
+    handler_attribute: &str,
+) -> Vec<Attribute> {
+    let mut handler_attributes = Vec::new();
     attributes.retain(|attribute| {
-        let is_message = is_message_attribute(attribute, ractor);
-        if is_message {
-            message_attributes.push(attribute.clone());
+        let is_handler = is_handler_attribute(attribute, ractor, handler_attribute);
+        if is_handler {
+            handler_attributes.push(attribute.clone());
         }
-        !is_message
+        !is_handler
     });
-    message_attributes
+    handler_attributes
 }
 
-fn is_message_attribute(attribute: &Attribute, ractor: &Path) -> bool {
+fn is_handler_attribute(attribute: &Attribute, ractor: &Path, handler_attribute: &str) -> bool {
     let path = attribute.path();
-    if path.is_ident("message") {
+    if path.is_ident(handler_attribute) {
         return true;
     }
     if path.segments.len() != ractor.segments.len() + 1 {
@@ -293,7 +357,7 @@ fn is_message_attribute(attribute: &Attribute, ractor: &Path) -> bool {
         && path
             .segments
             .last()
-            .is_some_and(|segment| segment.ident == "message")
+            .is_some_and(|segment| segment.ident == handler_attribute)
 }
 
 fn is_lifecycle_method(ident: &syn::Ident) -> bool {
@@ -325,11 +389,48 @@ enum StateAccess {
     Mutable,
 }
 
+#[derive(Clone, Copy)]
+enum HandlerKind {
+    Message,
+    Supervision,
+}
+
+impl HandlerKind {
+    fn method_description(self) -> &'static str {
+        match self {
+            Self::Message => "message handler methods",
+            Self::Supervision => "supervision handler methods",
+        }
+    }
+
+    fn parameter_label(self) -> &'static str {
+        match self {
+            Self::Message => "handler",
+            Self::Supervision => "supervision handler",
+        }
+    }
+
+    fn pattern_label(self) -> &'static str {
+        match self {
+            Self::Message => "message pattern",
+            Self::Supervision => "supervision pattern",
+        }
+    }
+
+    fn event_label(self) -> &'static str {
+        match self {
+            Self::Message => "message",
+            Self::Supervision => "supervision event",
+        }
+    }
+}
+
 struct Handler {
     method_name: syn::Ident,
     pattern: Pat,
     pattern_key: String,
     binding_names: Vec<syn::Ident>,
+    binding_types: Vec<Type>,
     wants_actor_ref: bool,
     state_access: Option<StateAccess>,
     is_async: bool,
@@ -337,12 +438,28 @@ struct Handler {
     cfg_attributes: Vec<Attribute>,
 }
 
-fn parse_handler(method: &ImplItemFn, pattern: Pat) -> syn::Result<Handler> {
-    validate_method_shape(&method.sig, "message handler methods")?;
-    let (pattern_key, binding_names) = parse_message_pattern(&pattern)?;
-    let parameters = typed_parameters(&method.sig)?;
-    let (wants_actor_ref, state_access) =
-        classify_handler_parameters(&parameters, &binding_names, method.sig.ident.span())?;
+fn parse_handler(
+    method: &ImplItemFn,
+    pattern: Pat,
+    handler_kind: HandlerKind,
+) -> syn::Result<Handler> {
+    validate_method_shape(&method.sig, handler_kind.method_description())?;
+    let (pattern_key, binding_names) = parse_handler_pattern(&pattern, handler_kind)?;
+    let parameter_label = handler_kind.parameter_label();
+    let parameters = typed_parameters(&method.sig, parameter_label)?;
+    let (wants_actor_ref, state_access) = classify_handler_parameters(
+        &parameters,
+        &binding_names,
+        method.sig.ident.span(),
+        parameter_label,
+        handler_kind.pattern_label(),
+    )?;
+    let payload_start = usize::from(wants_actor_ref);
+    let payload_end = parameters.len() - usize::from(state_access.is_some());
+    let binding_types = parameters[payload_start..payload_end]
+        .iter()
+        .map(|parameter| (*parameter.ty).clone())
+        .collect();
 
     let cfg_attributes = match_arm_cfg_attributes(&method.attrs)?;
 
@@ -351,6 +468,7 @@ fn parse_handler(method: &ImplItemFn, pattern: Pat) -> syn::Result<Handler> {
         pattern,
         pattern_key,
         binding_names,
+        binding_types,
         wants_actor_ref,
         state_access,
         is_async: method.sig.asyncness.is_some(),
@@ -452,7 +570,10 @@ struct Parameter<'a> {
     ty: &'a Type,
 }
 
-fn typed_parameters(signature: &Signature) -> syn::Result<Vec<Parameter<'_>>> {
+fn typed_parameters<'a>(
+    signature: &'a Signature,
+    handler_label: &str,
+) -> syn::Result<Vec<Parameter<'a>>> {
     signature
         .inputs
         .iter()
@@ -468,7 +589,7 @@ fn typed_parameters(signature: &Signature) -> syn::Result<Vec<Parameter<'_>>> {
                 else {
                     return Err(syn::Error::new(
                         argument.pat.span(),
-                        "handler parameters must be simple identifier bindings",
+                        format!("{handler_label} parameters must be simple identifier bindings"),
                     ));
                 };
                 Ok(Parameter {
@@ -478,7 +599,7 @@ fn typed_parameters(signature: &Signature) -> syn::Result<Vec<Parameter<'_>>> {
             }
             FnArg::Receiver(receiver) => Err(syn::Error::new(
                 receiver.span(),
-                "message handler methods may only have one receiver",
+                format!("{handler_label} methods may only have one receiver"),
             )),
         })
         .collect()
@@ -488,6 +609,8 @@ fn classify_handler_parameters(
     parameters: &[Parameter<'_>],
     bindings: &[syn::Ident],
     error_span: Span,
+    handler_label: &str,
+    pattern_label: &str,
 ) -> syn::Result<(bool, Option<StateAccess>)> {
     let without_state = match_handler_parameters(parameters, bindings, None);
     let with_state = parameters.last().and_then(|parameter| {
@@ -500,11 +623,11 @@ fn classify_handler_parameters(
         (Some(result), None) | (None, Some(result)) => Ok(result),
         (Some(_), Some(_)) => Err(syn::Error::new(
             error_span,
-            "handler parameters are ambiguous; rename the actor reference or state parameter so payload bindings remain explicit",
+            format!("{handler_label} parameters are ambiguous; rename the actor reference or state parameter so payload bindings remain explicit"),
         )),
         (None, None) => Err(syn::Error::new(
             error_span,
-            "handler parameters must match the message pattern bindings, with an optional leading `ActorRef` and optional trailing state reference",
+            format!("{handler_label} parameters must match the {pattern_label} bindings, with an optional leading `ActorRef` and optional trailing state reference"),
         )),
     }
 }
@@ -564,7 +687,63 @@ fn is_actor_ref(ty: &Type) -> bool {
         .is_some_and(|segment| segment.ident == "ActorRef")
 }
 
-fn parse_message_pattern(pattern: &Pat) -> syn::Result<(String, Vec<syn::Ident>)> {
+fn qualify_generated_message_pattern(
+    pattern: &mut Pat,
+    message_ident: &syn::Ident,
+) -> syn::Result<()> {
+    if let Pat::Ident(PatIdent {
+        attrs,
+        by_ref: None,
+        mutability: None,
+        ident,
+        subpat: None,
+    }) = pattern
+    {
+        if attrs.is_empty() {
+            let variant = ident.clone();
+            *pattern = syn::parse_quote!(#message_ident::#variant);
+            return Ok(());
+        }
+    }
+
+    let path = match pattern {
+        Pat::Path(path) if path.qself.is_none() => &mut path.path,
+        Pat::TupleStruct(tuple) if tuple.qself.is_none() => &mut tuple.path,
+        Pat::Struct(structure) if structure.qself.is_none() => &mut structure.path,
+        _ => {
+            return Err(syn::Error::new(
+                pattern.span(),
+                "generated message patterns must name a unit, tuple, or struct enum variant",
+            ));
+        }
+    };
+
+    match path.segments.len() {
+        1 => {
+            let variant = path.segments[0].ident.clone();
+            *path = syn::parse_quote!(#message_ident::#variant);
+        }
+        2 if path.segments[0].ident == *message_ident => {}
+        _ => {
+            return Err(syn::Error::new(
+                path.span(),
+                format!(
+                    "generated message patterns must use `Variant` or `{message_ident}::Variant`"
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn parse_handler_pattern(
+    pattern: &Pat,
+    handler_kind: HandlerKind,
+) -> syn::Result<(String, Vec<syn::Ident>)> {
+    let pattern_description = match handler_kind {
+        HandlerKind::Message => "message patterns",
+        HandlerKind::Supervision => "supervision patterns",
+    };
     let (path, fields): (&Path, Vec<&Pat>) = match pattern {
         Pat::Path(path) if path.qself.is_none() && path.attrs.is_empty() => {
             (&path.path, Vec::new())
@@ -589,13 +768,13 @@ fn parse_message_pattern(pattern: &Pat) -> syn::Result<(String, Vec<syn::Ident>)
         Pat::Struct(structure) if structure.rest.is_some() => {
             return Err(syn::Error::new(
                 structure.span(),
-                "message patterns must list every struct variant field; `..` is not supported",
+                format!("{pattern_description} must list every struct variant field; `..` is not supported"),
             ));
         }
         _ => {
             return Err(syn::Error::new(
                 pattern.span(),
-                "message patterns must be a unit, tuple, or struct enum variant with identifier or `_` fields",
+                format!("{pattern_description} must be a unit, tuple, or struct enum variant with identifier or `_` fields"),
             ));
         }
     };
@@ -614,7 +793,9 @@ fn parse_message_pattern(pattern: &Pat) -> syn::Result<(String, Vec<syn::Ident>)
             _ => {
                 return Err(syn::Error::new(
                     field.span(),
-                    "message pattern fields must be plain identifier bindings or `_`",
+                    format!(
+                        "{pattern_description} fields must be plain identifier bindings or `_`"
+                    ),
                 ));
             }
         }
@@ -623,17 +804,120 @@ fn parse_message_pattern(pattern: &Pat) -> syn::Result<(String, Vec<syn::Ident>)
     Ok((path.to_token_stream().to_string(), bindings))
 }
 
-fn validate_unique_patterns(handlers: &[Handler]) -> syn::Result<()> {
+fn validate_unique_patterns(handlers: &[Handler], handler_kind: HandlerKind) -> syn::Result<()> {
     let mut patterns = HashSet::new();
     for handler in handlers {
         if !patterns.insert(&handler.pattern_key) {
             return Err(syn::Error::new(
                 handler.pattern.span(),
-                "this message variant already has a handler",
+                format!(
+                    "this {} variant already has a handler",
+                    handler_kind.event_label()
+                ),
             ));
         }
     }
     Ok(())
+}
+
+fn generate_message_enum(
+    config: &GeneratedMessageConfig,
+    handlers: &[Handler],
+    cfg_attributes: &[Attribute],
+) -> syn::Result<TokenStream> {
+    let visibility = &config.visibility;
+    let enum_ident = &config.ident;
+    let variants = handlers
+        .iter()
+        .map(generate_message_variant)
+        .collect::<syn::Result<Vec<_>>>()?;
+
+    Ok(quote! {
+        #(#cfg_attributes)*
+        #[allow(missing_debug_implementations, missing_docs)]
+        #visibility enum #enum_ident {
+            #(#variants),*
+        }
+    })
+}
+
+fn generate_message_variant(handler: &Handler) -> syn::Result<TokenStream> {
+    let cfg_attributes = &handler.cfg_attributes;
+    let variant_ident = match &handler.pattern {
+        Pat::Path(path) => path.path.segments.last().map(|segment| &segment.ident),
+        Pat::TupleStruct(tuple) => tuple.path.segments.last().map(|segment| &segment.ident),
+        Pat::Struct(structure) => structure.path.segments.last().map(|segment| &segment.ident),
+        _ => None,
+    }
+    .ok_or_else(|| {
+        syn::Error::new(
+            handler.pattern.span(),
+            "generated message pattern is missing a variant name",
+        )
+    })?;
+
+    match &handler.pattern {
+        Pat::Path(_) => Ok(quote! {
+            #(#cfg_attributes)*
+            #variant_ident
+        }),
+        Pat::TupleStruct(tuple) => {
+            if tuple
+                .elems
+                .iter()
+                .any(|element| matches!(element, Pat::Wild(_)))
+            {
+                return Err(syn::Error::new(
+                    tuple.span(),
+                    "generated message patterns cannot discard fields with `_` because every field needs a type",
+                ));
+            }
+            let field_types = &handler.binding_types;
+            Ok(quote! {
+                #(#cfg_attributes)*
+                #variant_ident(#(#field_types),*)
+            })
+        }
+        Pat::Struct(structure) => {
+            if structure
+                .fields
+                .iter()
+                .any(|field| matches!(field.pat.as_ref(), Pat::Wild(_)))
+            {
+                return Err(syn::Error::new(
+                    structure.span(),
+                    "generated message patterns cannot discard fields with `_` because every field needs a type",
+                ));
+            }
+            let fields = structure
+                .fields
+                .iter()
+                .zip(&handler.binding_types)
+                .map(|(field, ty)| generated_named_field(field, ty))
+                .collect::<syn::Result<Vec<_>>>()?;
+            Ok(quote! {
+                #(#cfg_attributes)*
+                #variant_ident { #(#fields),* }
+            })
+        }
+        _ => unreachable!("handler patterns were validated before enum generation"),
+    }
+}
+
+fn generated_named_field(field: &FieldPat, ty: &Type) -> syn::Result<TokenStream> {
+    if matches!(field.pat.as_ref(), Pat::Wild(_)) {
+        return Err(syn::Error::new(
+            field.span(),
+            "generated message patterns cannot discard fields with `_` because every field needs a type",
+        ));
+    }
+    let Member::Named(field_ident) = &field.member else {
+        return Err(syn::Error::new(
+            field.member.span(),
+            "generated struct message fields must be named",
+        ));
+    };
+    Ok(quote!(#field_ident: #ty))
 }
 
 fn returns_unit(output: &ReturnType) -> bool {
@@ -663,32 +947,7 @@ fn generated_handle(ractor: &Path, handlers: &[Handler]) -> syn::Result<ImplItem
     let myself_ident = syn::Ident::new("__ractor_myself", Span::mixed_site());
     let message_ident = syn::Ident::new("__ractor_message", Span::mixed_site());
     let state_ident = syn::Ident::new("__ractor_state", Span::mixed_site());
-    let arms = handlers.iter().map(|handler| {
-        let cfg_attributes = &handler.cfg_attributes;
-        let pattern = &handler.pattern;
-        let method_name = &handler.method_name;
-        let mut arguments = Vec::new();
-        if handler.wants_actor_ref {
-            arguments.push(quote!(#myself_ident));
-        }
-        arguments.extend(handler.binding_names.iter().map(|binding| quote!(#binding)));
-        if let Some(state_access) = handler.state_access {
-            arguments.push(match state_access {
-                StateAccess::Shared => quote!(&*#state_ident),
-                StateAccess::Mutable => quote!(&mut *#state_ident),
-            });
-        }
-
-        let await_suffix = handler.is_async.then(|| quote!(.await));
-        let try_suffix = handler.is_fallible.then(|| quote!(?));
-        quote! {
-            #(#cfg_attributes)*
-            #pattern => {
-                self.#method_name(#(#arguments),*) #await_suffix #try_suffix;
-                ::core::result::Result::Ok(())
-            }
-        }
-    });
+    let arms = generated_handler_arms(handlers, &myself_ident, &state_ident);
 
     syn::parse2(quote! {
         #[allow(unused_variables)]
@@ -703,4 +962,71 @@ fn generated_handle(ractor: &Path, handlers: &[Handler]) -> syn::Result<ImplItem
             }
         }
     })
+}
+
+fn generated_supervision_handler(ractor: &Path, handlers: &[Handler]) -> syn::Result<ImplItemFn> {
+    let myself_ident = syn::Ident::new("__ractor_myself", Span::mixed_site());
+    let event_ident = syn::Ident::new("__ractor_supervision_event", Span::mixed_site());
+    let state_ident = syn::Ident::new("__ractor_state", Span::mixed_site());
+    let arms = generated_handler_arms(handlers, &myself_ident, &state_ident);
+
+    syn::parse2(quote! {
+        #[allow(unused_variables)]
+        async fn handle_supervisor_evt(
+            &self,
+            #myself_ident: #ractor::ActorRef<Self::Msg>,
+            #event_ident: #ractor::SupervisionEvent,
+            #state_ident: &mut Self::State,
+        ) -> ::core::result::Result<(), #ractor::ActorProcessingErr> {
+            match #event_ident {
+                #(#arms),*,
+                __ractor_unhandled_event => {
+                    match __ractor_unhandled_event {
+                        #ractor::SupervisionEvent::ActorTerminated(_, _, _)
+                        | #ractor::SupervisionEvent::ActorFailed(_, _) => {
+                            #myself_ident.stop(::core::option::Option::None);
+                        }
+                        _ => {}
+                    }
+                    ::core::result::Result::Ok(())
+                }
+            }
+        }
+    })
+}
+
+fn generated_handler_arms(
+    handlers: &[Handler],
+    myself_ident: &syn::Ident,
+    state_ident: &syn::Ident,
+) -> Vec<TokenStream> {
+    handlers
+        .iter()
+        .map(|handler| {
+            let cfg_attributes = &handler.cfg_attributes;
+            let pattern = &handler.pattern;
+            let method_name = &handler.method_name;
+            let mut arguments = Vec::new();
+            if handler.wants_actor_ref {
+                arguments.push(quote!(#myself_ident));
+            }
+            arguments.extend(handler.binding_names.iter().map(|binding| quote!(#binding)));
+            if let Some(state_access) = handler.state_access {
+                arguments.push(match state_access {
+                    StateAccess::Shared => quote!(&*#state_ident),
+                    StateAccess::Mutable => quote!(&mut *#state_ident),
+                });
+            }
+
+            let await_suffix = handler.is_async.then(|| quote!(.await));
+            let try_suffix = handler.is_fallible.then(|| quote!(?));
+            quote! {
+                #(#cfg_attributes)*
+                #pattern => {
+                    self.#method_name(#(#arguments),*) #await_suffix #try_suffix;
+                    ::core::result::Result::Ok(())
+                }
+            }
+        })
+        .collect()
 }

--- a/ractor_macros/src/lib.rs
+++ b/ractor_macros/src/lib.rs
@@ -17,8 +17,10 @@ use crate::config::ActorConfig;
 
 /// Generate a Ractor actor implementation from ordinary inherent methods.
 ///
-/// `message = MessageType` is required. `state` and `arguments` default to
-/// `()`. Add the `thread_local` flag to implement `ThreadLocalActor` instead
+/// Use `message = MessageType` for an existing message type, or
+/// `messages = [visibility] MessageType` to generate a local message enum from
+/// the handler patterns and parameter types. `state` and `arguments` default
+/// to `()`. Add the `thread_local` flag to implement `ThreadLocalActor` instead
 /// of `Actor`.
 ///
 /// Mark handlers with `#[ractor::message(Message::Variant(...))]`. Flat unit,
@@ -32,6 +34,11 @@ use crate::config::ActorConfig;
 /// a handler is a compile error. A canonical raw `handle` method remains
 /// supported, but cannot be mixed with generated message handlers. Other
 /// lifecycle methods keep their normal async trait signatures.
+///
+/// Mark focused supervision handlers with
+/// `#[ractor::supervision(SupervisionEvent::Variant(...))]`. Their parameters
+/// follow the same actor-reference, pattern-binding, and state rules as message
+/// handlers. Unmatched events retain Ractor's default supervision behavior.
 ///
 /// ```ignore
 /// #[ractor::actor(message = CounterMessage, state = u64)]

--- a/ractor_macros/src/lib.rs
+++ b/ractor_macros/src/lib.rs
@@ -18,7 +18,7 @@ use crate::config::ActorConfig;
 /// Generate a Ractor actor implementation from ordinary inherent methods.
 ///
 /// Use `message = MessageType` for an existing message type, or
-/// `messages = [visibility] MessageType` to generate a local message enum from
+/// `message = [visibility] enum MessageType` to generate a local message enum from
 /// the handler patterns and parameter types. `state` and `arguments` default
 /// to `()`. Add the `thread_local` flag to implement `ThreadLocalActor` instead
 /// of `Actor`.


### PR DESCRIPTION
## Summary

- add opt-in `message = [visibility] enum EnumName` generation from message handler patterns and parameter types
- add focused `#[ractor::supervision(...)]` handlers with sync, async, fallible, actor-ref, and state support
- preserve Ractor’s default shutdown behavior for unmatched child termination and failure events
- document the local-only generated-message boundary and retain explicit enums for cluster wire contracts
- migrate established counter and thread-local fixtures to generated messages and validate all fields from started, terminated, and failed supervision events

## Compatibility

The existing `message = ExistingType` syntax and raw lifecycle hooks remain unchanged. Generated enums are explicitly opted into with `message = enum EnumName` (or `message = pub enum EnumName`). Raw `handle_supervisor_evt` and focused supervision handlers are intentionally mutually exclusive. Generated message enums do not add cluster serialization derives.

## Validation

- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`
- `cargo test`
- focused actor-macro tests with native async traits, `async-trait`, and `cluster`