### PR TITLE
feat(macros): add focused RPC handlers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ resolver = "3"
 
 [workspace.package]
 rust-version = "1.85"
-version = "0.16.1"
+version = "0.16.2"

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ struct Counter;
 
 enum CounterMessage {
     Add(u64),
+    Read(ractor::RpcReplyPort<u64>),
 }
 
 #[ractor::actor(message = CounterMessage, state = u64)]
@@ -121,14 +122,22 @@ impl Counter {
     fn add(&self, amount: u64, state: &mut u64) {
         *state += amount;
     }
+
+    #[ractor::rpc(CounterMessage::Read(reply))]
+    fn read(&self, state: &u64) -> u64 {
+        *state
+    }
 }
 ```
 
-The generated dispatch remains an exhaustive match, so adding an unhandled enum variant is a
-compile error. For local actors, `message = enum CounterMessage` can also generate the enum from
-handler patterns and parameter types. Focused `#[ractor::supervision(...)]` methods provide the
-same dispatch style for supervision events. The explicit trait-based API remains available when
-its flexibility is preferable. See the [guide](docs/actor-macros.md) and the
+When focused message or RPC handlers are present, their generated dispatch is exhaustive, so
+adding an unhandled enum variant is a compile error. With neither focused handlers nor a raw
+`handle`, the actor inherits the trait's no-op message handler; this supports lifecycle- and
+supervision-only actors. For local actors, `message = enum CounterMessage` can also generate the
+enum from handler patterns and parameter types. Focused `#[ractor::supervision(...)]` methods
+provide the same dispatch style for supervision events, while `#[ractor::rpc(...)]` sends a
+handler's return value through the omitted reply-port binding. The explicit trait-based API
+remains available when its flexibility is preferable. See the [guide](docs/actor-macros.md) and the
 [`actor_macro` example](ractor/examples/actor_macro.rs) for the supported method shapes.
 
 An example `ping-pong` actor might be the following

--- a/docs/actor-macros.md
+++ b/docs/actor-macros.md
@@ -42,19 +42,20 @@ impl Counter {
         *state += amount;
     }
 
-    #[ractor::message(CounterMessage::Read(reply))]
-    fn read(&self, reply: RpcReplyPort<i64>, state: &i64) {
-        let _ = reply.send(*state);
+    #[ractor::rpc(CounterMessage::Read(reply))]
+    fn read(&self, state: &i64) -> i64 {
+        *state
     }
 }
 ```
 
 Either `message` or the generated-message form described below is required. `state` and
 `arguments` default to `()`. The macro generates the
-`Actor` implementation and an exhaustive `match` over the message enum. Rust therefore reports a
-new or forgotten message variant at compile time. Cargo dependency renames are detected
-automatically, and non-Cargo builds default to `::ractor`. The `crate_path = some::path` option is
-only necessary when a non-Cargo build renames the dependency.
+`Actor` implementation and, when focused message or RPC handlers are present, an exhaustive
+`match` over the message enum. Rust therefore reports a new or forgotten message variant at
+compile time in focused-dispatch mode. Cargo dependency renames are detected automatically, and
+non-Cargo builds default to `::ractor`. The `crate_path = some::path` option is only necessary when
+a non-Cargo build renames the dependency.
 
 Tuple, struct, and unit variants are supported. Bindings in the attribute pattern become handler
 parameters with matching names in the same order; `_` can discard an unused field. Keep patterns
@@ -83,9 +84,9 @@ impl Counter {
         *state += amount;
     }
 
-    #[ractor::message(Read(reply))]
-    fn read(&self, reply: RpcReplyPort<i64>, state: &i64) {
-        let _ = reply.send(*state);
+    #[ractor::rpc(Read)]
+    fn read(&self, state: &i64) -> i64 {
+        *state
     }
 }
 ```
@@ -103,6 +104,10 @@ Unit, tuple, and struct variants are supported. Every generated field must have 
 the macro can find its type; `_` fields are therefore only supported when using an explicit enum.
 The optional visibility defaults to private and can be any normal Rust visibility, such as
 `pub(crate)`. Generated enums currently do not support generic actor implementations.
+
+The unit-form RPC attribute above describes a request with no payload. The generated enum still
+contains the reply port, so `Read` becomes `Read(RpcReplyPort<i64>)`. A tuple or struct RPC pattern
+can instead name the reply binding explicitly, as described below.
 
 Generated-message mode deliberately does not add cluster serialization derives or define a wire
 contract. Continue using an explicit message enum for remotely serializable actors. In a build with
@@ -132,8 +137,96 @@ written with their normal trait signatures inside the same implementation. If bo
 arguments are `()`, an omitted `pre_start` defaults to `Ok(())`; otherwise it is required.
 
 For actors that need custom dispatch, define the normal `handle` method instead of any
-`#[ractor::message]` methods. Raw `handle` and generated handlers are intentionally mutually
-exclusive, keeping the dispatch path unambiguous.
+`#[ractor::message]` or `#[ractor::rpc]` methods. Raw `handle` and focused handlers are
+intentionally mutually exclusive, keeping the dispatch path unambiguous.
+
+An actor may also omit both forms. In that case the macro emits no `handle` method and inherits
+the actor trait's no-op default. This is useful for actors that only run lifecycle hooks or process
+focused `#[ractor::supervision(...)]` events. The `message` option is still required to select the
+actor's message type; `message = enum EmptyMessage` produces an empty local enum when there are no
+focused message or RPC handlers.
+
+## RPC handlers
+
+Use `#[ractor::rpc]` when a message contains an `RpcReplyPort` and the handler should return its
+reply directly. Exactly one named binding from the pattern must be absent from the method
+parameters. That binding is the reply port; all other bindings follow the same ordering and
+optional actor-reference/state rules as one-way message handlers:
+
+```rust
+enum StoreMessage {
+    Get {
+        key: String,
+        reply: RpcReplyPort<Option<String>>,
+    },
+    AddAndRead(i64, RpcReplyPort<i64>, i64),
+}
+
+#[ractor::rpc(StoreMessage::Get { key, reply })]
+async fn get(&self, key: String, state: &StoreState) -> Option<String> {
+    state.get(&key).cloned()
+}
+
+#[ractor::rpc(StoreMessage::AddAndRead(left, reply, right))]
+fn add_and_read(&self, left: i64, right: i64, state: &StoreState) -> i64 {
+    left + right + state.offset
+}
+```
+
+The reply port may occur at any tuple or struct field position. A unit pattern such as
+`#[ractor::rpc(StoreMessage::Status)]` is shorthand for an RPC with no request fields; the
+explicit enum must still define `Status(RpcReplyPort<Reply>)`. For generated message enums, the
+macro adds that field automatically.
+
+The `call!` and `call_t!` convenience forms place the reply port after their supplied tuple
+arguments. For a middle-position port or a struct variant, use `ActorRef::call` with a closure so
+the message construction remains explicit:
+
+```rust
+let result = store
+    .call(
+        |reply| StoreMessage::AddAndRead(20, reply, 22),
+        Some(ractor::concurrency::Duration::from_millis(100)),
+    )
+    .await?;
+
+let value = store
+    .call(
+        |reply| StoreMessage::Get {
+            key: "answer".to_owned(),
+            reply,
+        },
+        Some(ractor::concurrency::Duration::from_millis(100)),
+    )
+    .await?;
+```
+
+By default, the handler's complete return type is the reply type. This is intentional: a domain
+result such as `Result<Value, DomainError>` is sent to the caller unchanged. Reply types must be
+concrete; `impl Trait` cannot appear within them because generated message fields and reply ports
+must be able to name the type.
+
+```rust
+#[ractor::rpc(StoreMessage::Validate(reply))]
+fn validate(&self, state: &StoreState) -> Result<Value, DomainError> {
+    state.validate()
+}
+```
+
+To propagate an actor-processing error from the generated `handle` method instead, specify the
+successful reply type explicitly. The generated dispatch applies `?` to the handler call and only
+sends the successful value:
+
+```rust
+#[ractor::rpc(StoreMessage::Read(reply), reply = Value)]
+async fn read(&self, state: &StoreState) -> Result<Value, ActorProcessingErr> {
+    state.read().await
+}
+```
+
+Failure to send because the caller dropped its receiver is ignored and does not fail the actor.
+Use an ordinary `#[ractor::message]` handler when code needs to inspect, retain, forward, or send
+through the reply port manually.
 
 ## Supervision handlers
 
@@ -182,6 +275,8 @@ impl UiActor {
 
 The macro only defines actor behavior. Cluster wire compatibility remains an explicit property of
 the message type: continue deriving `RactorMessage` for local-only cluster builds or
-`RactorClusterMessage` for remotely serializable messages.
+`RactorClusterMessage` for remotely serializable messages. A focused actor
+`#[ractor::rpc(...)]` handler does not generate or alter the enum's cluster `#[rpc]` metadata,
+serialization, or wire contract; those remain on the explicit message enum.
 
 See the complete [`actor_macro` example](../ractor/examples/actor_macro.rs).

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -45,7 +45,7 @@ strum = { version = "0.28", features = ["derive"] }
 # async-std feature 'unstable' is required for spawn_local: https://docs.rs/async-std/latest/async_std/task/fn.spawn_local.html
 async-std = { version = "1", features = ["attributes", "unstable"], optional = true }
 async-trait = { version = "0.1", optional = true }
-ractor_macros = { path = "../ractor_macros", version = "0.16.0", optional = true }
+ractor_macros = { path = "../ractor_macros", version = "0.16.2", optional = true }
 tokio = { version = "1", features = ["sync"] }
 tracing = { version = "0.1", features = ["attributes"] }
 

--- a/ractor/examples/actor_macro.rs
+++ b/ractor/examples/actor_macro.rs
@@ -52,9 +52,9 @@ impl Counter {
         *state += amount;
     }
 
-    #[ractor::message(CounterMessage::Read(reply))]
-    fn read(&self, reply: RpcReplyPort<i64>, state: &i64) {
-        let _ = reply.send(*state);
+    #[ractor::rpc(CounterMessage::Read(reply))]
+    fn read(&self, state: &i64) -> i64 {
+        *state
     }
 
     #[ractor::message(CounterMessage::Stop)]

--- a/ractor/src/lib.rs
+++ b/ractor/src/lib.rs
@@ -226,10 +226,13 @@ pub use port::RpcReplyPort;
 /// Generate an [`Actor`] or [`thread_local::ThreadLocalActor`] implementation
 /// from an inherent implementation block and focused message or supervision
 /// handlers. Local message enums can optionally be generated from handler
-/// patterns and parameter types.
+/// patterns and parameter types. Focused RPC handlers return their reply
+/// directly and send it through the pattern's omitted reply-port binding.
 ///
-/// Dispatch is exhaustive: adding a message variant without a corresponding
-/// handler does not compile.
+/// When focused message or RPC handlers are present, dispatch is exhaustive:
+/// adding a message variant without a corresponding handler does not compile.
+/// Actors with no raw or focused message handler inherit the trait's no-op
+/// default, which is useful for lifecycle- and supervision-only actors.
 ///
 /// ```compile_fail
 /// struct IncompleteActor;

--- a/ractor/tests/actor_macros.rs
+++ b/ractor/tests/actor_macros.rs
@@ -67,9 +67,46 @@ impl Counter {
         *state = __ractor_myself + __ractor_message + __ractor_state;
     }
 
-    #[ractor::message(Read(reply))]
-    fn read(&self, reply: RpcReplyPort<i64>, state: &i64) {
-        let _ = reply.send(*state);
+    #[ractor::rpc(Read)]
+    fn read(&self, state: &i64) -> i64 {
+        *state
+    }
+
+    #[ractor::rpc(Sum {
+        left,
+        reply,
+        right,
+    })]
+    async fn sum(
+        &self,
+        myself: ActorRef<CounterMessage>,
+        left: i64,
+        right: i64,
+        state: &i64,
+    ) -> i64 {
+        assert_eq!(myself.get_status(), ActorStatus::Running);
+        left + right + *state
+    }
+
+    #[ractor::rpc(ResultPayload(reply))]
+    fn result_payload(&self, state: &i64) -> Result<i64, &'static str> {
+        Ok(*state)
+    }
+
+    #[ractor::rpc(Fallible(reply), reply = i64)]
+    fn fallible(&self, state: &i64) -> Result<i64, ActorProcessingErr> {
+        Ok(*state)
+    }
+
+    #[ractor::rpc(DroppedReply(reply))]
+    fn dropped_reply(&self, state: &i64) -> i64 {
+        *state
+    }
+
+    #[cfg(any())]
+    #[ractor::rpc(DisabledRpc(reply))]
+    fn disabled_rpc(&self) -> i64 {
+        0
     }
 
     #[ractor::message(Stop)]
@@ -103,6 +140,90 @@ impl RawActor {
         Ok(())
     }
 }
+
+struct ExistingRpcActor;
+
+enum ExistingRpcMessage {
+    NoPayload(RpcReplyPort<&'static str>),
+    Tuple(i64, RpcReplyPort<i64>, i64),
+    Struct {
+        reply: RpcReplyPort<String>,
+        prefix: String,
+    },
+    Fail(RpcReplyPort<u64>),
+    Stop,
+    #[cfg(any())]
+    Disabled(RpcReplyPort<()>),
+}
+
+#[cfg(feature = "cluster")]
+impl ractor::Message for ExistingRpcMessage {}
+
+#[ractor::actor(message = ExistingRpcMessage, crate_path = ::ractor)]
+impl ExistingRpcActor {
+    #[ractor::rpc(ExistingRpcMessage::NoPayload)]
+    fn no_payload(&self) -> &'static str {
+        "pong"
+    }
+
+    #[ractor::rpc(ExistingRpcMessage::Tuple(left, reply, right))]
+    async fn tuple(&self, left: i64, right: i64) -> i64 {
+        left + right
+    }
+
+    #[ractor::rpc(ExistingRpcMessage::Struct { reply, prefix })]
+    fn structure(&self, prefix: String) -> String {
+        format!("{prefix}-reply")
+    }
+
+    #[ractor::rpc(ExistingRpcMessage::Fail(reply), reply = u64)]
+    fn fail(&self) -> Result<u64, ActorProcessingErr> {
+        Err("intentional RPC processing failure".into())
+    }
+
+    #[ractor::message(ExistingRpcMessage::Stop)]
+    fn stop(&self, myself: ActorRef<ExistingRpcMessage>) {
+        myself.stop(None);
+    }
+
+    #[cfg(any())]
+    #[ractor::rpc(ExistingRpcMessage::Disabled(reply))]
+    fn disabled(&self) {}
+}
+
+struct SupervisionOnlyActor {
+    events: ractor::concurrency::MpscUnboundedSender<&'static str>,
+}
+
+#[ractor::actor(message = (), crate_path = ::ractor)]
+impl SupervisionOnlyActor {
+    #[ractor::supervision(SupervisionEvent::ActorStarted(_child))]
+    fn child_started(&self, _child: ActorCell) {
+        let _ = self.events.send("started");
+    }
+
+    #[ractor::supervision(SupervisionEvent::ActorTerminated(_child, _, _))]
+    fn child_terminated(&self, _child: ActorCell) {
+        let _ = self.events.send("terminated");
+    }
+}
+
+struct GeneratedEmptyActor;
+
+#[ractor::actor(
+    message = enum GeneratedEmptyMessage,
+    crate_path = ::ractor,
+)]
+impl GeneratedEmptyActor {}
+
+#[cfg(feature = "cluster")]
+impl ractor::Message for GeneratedEmptyMessage {}
+
+#[derive(Default)]
+struct LocalDefaultHandleActor;
+
+#[ractor::actor(thread_local, message = (), crate_path = ::ractor)]
+impl LocalDefaultHandleActor {}
 
 struct FailingChild;
 
@@ -269,9 +390,9 @@ impl LocalCounter {
         state.set(state.get() + amount);
     }
 
-    #[ractor::message(Read(reply))]
-    fn read(&self, reply: RpcReplyPort<i64>, state: &Rc<Cell<i64>>) {
-        let _ = reply.send(state.get());
+    #[ractor::rpc(Read(reply))]
+    fn read(&self, state: &Rc<Cell<i64>>) -> i64 {
+        state.get()
     }
 
     #[ractor::message(Stop)]
@@ -366,10 +487,97 @@ async fn generated_handlers_dispatch_messages_and_state() {
         ractor::call_t!(actor, CounterMessage::Read, 100).expect("counter failed to answer");
     assert_eq!(value, 12);
 
+    let sum = actor
+        .call(
+            |reply| CounterMessage::Sum {
+                left: 8,
+                reply,
+                right: 9,
+            },
+            Some(ractor::concurrency::Duration::from_millis(100)),
+        )
+        .await
+        .expect("sum RPC message failed")
+        .expect("sum RPC failed to answer");
+    assert_eq!(sum, 29);
+
+    let result_payload = ractor::call_t!(actor, CounterMessage::ResultPayload, 100)
+        .expect("result-payload RPC failed to answer");
+    assert_eq!(result_payload, Ok(12));
+    let fallible = ractor::call_t!(actor, CounterMessage::Fallible, 100)
+        .expect("fallible RPC failed to answer");
+    assert_eq!(fallible, 12);
+
+    let (reply, receiver) = ractor::concurrency::oneshot();
+    drop(receiver);
+    actor
+        .send_message(CounterMessage::DroppedReply(reply.into()))
+        .expect("dropped-receiver RPC message failed");
+    let value_after_dropped_receiver = ractor::call_t!(actor, CounterMessage::Read, 100)
+        .expect("counter stopped after an RPC receiver was dropped");
+    assert_eq!(value_after_dropped_receiver, 12);
+
     actor
         .send_message(CounterMessage::Stop)
         .expect("stop message failed");
     handle.await.expect("counter failed to stop cleanly");
+}
+
+#[ractor::concurrency::test]
+async fn existing_message_enums_support_focused_rpc_handlers() {
+    let (actor, handle) = Actor::spawn(None, ExistingRpcActor, ())
+        .await
+        .expect("existing-message RPC actor failed to start");
+
+    let no_payload =
+        ractor::call_t!(actor, ExistingRpcMessage::NoPayload, 100).expect("unit-form RPC failed");
+    assert_eq!(no_payload, "pong");
+
+    let tuple = actor
+        .call(
+            |reply| ExistingRpcMessage::Tuple(20, reply, 22),
+            Some(ractor::concurrency::Duration::from_millis(100)),
+        )
+        .await
+        .expect("tuple RPC message failed")
+        .expect("tuple RPC failed to answer");
+    assert_eq!(tuple, 42);
+
+    let structure = actor
+        .call(
+            |reply| ExistingRpcMessage::Struct {
+                reply,
+                prefix: "focused".to_owned(),
+            },
+            Some(ractor::concurrency::Duration::from_millis(100)),
+        )
+        .await
+        .expect("struct RPC message failed")
+        .expect("struct RPC failed to answer");
+    assert_eq!(structure, "focused-reply");
+
+    actor
+        .send_message(ExistingRpcMessage::Stop)
+        .expect("existing-message RPC actor stop failed");
+    handle
+        .await
+        .expect("existing-message RPC actor failed to stop cleanly");
+
+    let (failing_actor, failing_handle) = Actor::spawn(None, ExistingRpcActor, ())
+        .await
+        .expect("failing RPC actor failed to start");
+    let failure = failing_actor
+        .call(
+            ExistingRpcMessage::Fail,
+            Some(ractor::concurrency::Duration::from_millis(100)),
+        )
+        .await
+        .expect("failing RPC message could not be sent");
+    assert!(failure.is_send_error());
+    failing_handle
+        .await
+        .expect("failing RPC actor runtime failed to stop");
+    assert_eq!(failing_actor.get_status(), ActorStatus::Stopped);
 }
 
 #[ractor::concurrency::test]
@@ -465,6 +673,52 @@ async fn unhandled_supervision_events_keep_the_default_shutdown_behavior() {
     assert_eq!(supervisor.get_status(), ActorStatus::Stopped);
 }
 
+#[ractor::concurrency::test]
+async fn supervision_only_actor_inherits_the_default_message_handler() {
+    let (events, mut received_events) = ractor::concurrency::mpsc_unbounded();
+    let (supervisor, supervisor_handle) = Actor::spawn(None, SupervisionOnlyActor { events }, ())
+        .await
+        .expect("supervision-only actor failed to start");
+
+    supervisor
+        .send_message(())
+        .expect("unit message failed to send to supervision-only actor");
+
+    let (child, child_handle) = Actor::spawn_linked(None, RawActor, (), supervisor.get_cell())
+        .await
+        .expect("linked child failed to start");
+    let started = ractor::concurrency::timeout(
+        ractor::concurrency::Duration::from_secs(1),
+        received_events.recv(),
+    )
+    .await
+    .expect("timed out waiting for child-started event")
+    .expect("supervision event channel closed");
+    assert_eq!(started, "started");
+
+    child.stop(None);
+    child_handle.await.expect("linked child failed to stop");
+    let terminated = ractor::concurrency::timeout(
+        ractor::concurrency::Duration::from_secs(1),
+        received_events.recv(),
+    )
+    .await
+    .expect("timed out waiting for child-terminated event")
+    .expect("supervision event channel closed");
+    assert_eq!(terminated, "terminated");
+
+    supervisor
+        .send_message(())
+        .expect("second unit message failed to send");
+    ractor::concurrency::sleep(ractor::concurrency::Duration::from_millis(10)).await;
+    assert_eq!(supervisor.get_status(), ActorStatus::Running);
+
+    supervisor.stop(None);
+    supervisor_handle
+        .await
+        .expect("supervision-only actor failed to stop cleanly");
+}
+
 #[cfg(not(feature = "async-std"))]
 #[ractor::concurrency::test]
 async fn thread_local_actor_supports_non_send_state() {
@@ -505,6 +759,17 @@ fn generic_actor_impls_preserve_bounds() {
 #[test]
 fn generated_code_ignores_shadowed_prelude_names() {
     shadowed_prelude_names::assert_compiles();
+}
+
+#[test]
+fn actors_without_dispatch_methods_inherit_trait_defaults() {
+    fn assert_actor<T: Actor>() {}
+    fn assert_generated_actor<T: Actor<Msg = GeneratedEmptyMessage>>() {}
+    fn assert_thread_local<T: ractor::thread_local::ThreadLocalActor<Msg = ()>>() {}
+
+    assert_actor::<SupervisionOnlyActor>();
+    assert_generated_actor::<GeneratedEmptyActor>();
+    assert_thread_local::<LocalDefaultHandleActor>();
 }
 
 #[cfg(all(not(feature = "async-trait"), not(feature = "cluster")))]

--- a/ractor/tests/ui/actor_macros/rpc_ambiguous_reply.rs
+++ b/ractor/tests/ui/actor_macros/rpc_ambiguous_reply.rs
@@ -1,0 +1,15 @@
+struct AmbiguousReplyActor;
+
+enum Message {
+    Read(u64, u64),
+}
+
+#[ractor::actor(message = Message)]
+impl AmbiguousReplyActor {
+    #[ractor::rpc(Message::Read(reply, reply))]
+    fn read(&self, reply: u64) -> u64 {
+        reply
+    }
+}
+
+fn main() {}

--- a/ractor/tests/ui/actor_macros/rpc_ambiguous_reply.stderr
+++ b/ractor/tests/ui/actor_macros/rpc_ambiguous_reply.stderr
@@ -1,0 +1,5 @@
+error: RPC reply port is ambiguous; exactly one RPC pattern binding must be absent from the method parameters
+  --> tests/ui/actor_macros/rpc_ambiguous_reply.rs:10:8
+   |
+10 |     fn read(&self, reply: u64) -> u64 {
+   |        ^^^^

--- a/ractor/tests/ui/actor_macros/rpc_explicit_nested_impl_trait_reply.rs
+++ b/ractor/tests/ui/actor_macros/rpc_explicit_nested_impl_trait_reply.rs
@@ -1,0 +1,11 @@
+struct ExplicitImplTraitReplyActor;
+
+#[ractor::actor(message = enum Message)]
+impl ExplicitImplTraitReplyActor {
+    #[ractor::rpc(Read(reply), reply = Option<impl std::fmt::Display>)]
+    fn read(&self) -> Result<Option<u64>, ractor::ActorProcessingErr> {
+        Ok(Some(42))
+    }
+}
+
+fn main() {}

--- a/ractor/tests/ui/actor_macros/rpc_explicit_nested_impl_trait_reply.stderr
+++ b/ractor/tests/ui/actor_macros/rpc_explicit_nested_impl_trait_reply.stderr
@@ -1,0 +1,5 @@
+error: RPC reply types must be concrete; `impl Trait` is not supported anywhere in a reply type
+ --> tests/ui/actor_macros/rpc_explicit_nested_impl_trait_reply.rs:5:47
+  |
+5 |     #[ractor::rpc(Read(reply), reply = Option<impl std::fmt::Display>)]
+  |                                               ^^^^

--- a/ractor/tests/ui/actor_macros/rpc_missing_reply.rs
+++ b/ractor/tests/ui/actor_macros/rpc_missing_reply.rs
@@ -1,0 +1,17 @@
+use ractor::RpcReplyPort;
+
+struct MissingReplyActor;
+
+enum Message {
+    Read(u64, RpcReplyPort<u64>),
+}
+
+#[ractor::actor(message = Message)]
+impl MissingReplyActor {
+    #[ractor::rpc(Message::Read(value, reply))]
+    fn read(&self, value: u64, reply: RpcReplyPort<u64>) -> u64 {
+        value + usize::from(reply.is_closed()) as u64
+    }
+}
+
+fn main() {}

--- a/ractor/tests/ui/actor_macros/rpc_missing_reply.stderr
+++ b/ractor/tests/ui/actor_macros/rpc_missing_reply.stderr
@@ -1,0 +1,5 @@
+error: RPC handler parameters must match every RPC pattern binding except exactly one reply-port binding, with an optional leading `ActorRef` and optional trailing state reference
+  --> tests/ui/actor_macros/rpc_missing_reply.rs:12:8
+   |
+12 |     fn read(&self, value: u64, reply: RpcReplyPort<u64>) -> u64 {
+   |        ^^^^

--- a/ractor/tests/ui/actor_macros/rpc_mixed_raw_dispatch.rs
+++ b/ractor/tests/ui/actor_macros/rpc_mixed_raw_dispatch.rs
@@ -1,0 +1,28 @@
+#![allow(unused_imports)]
+
+use ractor::{ActorProcessingErr, ActorRef, RpcReplyPort};
+
+struct MixedRpcActor;
+
+enum Message {
+    Read(RpcReplyPort<u64>),
+}
+
+#[ractor::actor(message = Message)]
+impl MixedRpcActor {
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _message: Self::Msg,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+
+    #[ractor::rpc(Message::Read(reply))]
+    fn read(&self) -> u64 {
+        42
+    }
+}
+
+fn main() {}

--- a/ractor/tests/ui/actor_macros/rpc_mixed_raw_dispatch.stderr
+++ b/ractor/tests/ui/actor_macros/rpc_mixed_raw_dispatch.stderr
@@ -1,5 +1,5 @@
 error: define either a raw `handle` method or focused `#[ractor::message(...)]`/`#[ractor::rpc(...)]` handlers, not both
-  --> tests/ui/actor_macros/mixed_dispatch.rs:13:14
+  --> tests/ui/actor_macros/rpc_mixed_raw_dispatch.rs:13:14
    |
 13 |     async fn handle(
    |              ^^^^^^

--- a/ractor/tests/ui/actor_macros/rpc_nested_impl_trait_reply.rs
+++ b/ractor/tests/ui/actor_macros/rpc_nested_impl_trait_reply.rs
@@ -1,0 +1,11 @@
+struct ImplTraitReplyActor;
+
+#[ractor::actor(message = enum Message)]
+impl ImplTraitReplyActor {
+    #[ractor::rpc(Read(reply))]
+    fn read(&self) -> Option<impl std::fmt::Display> {
+        Some(42_u64)
+    }
+}
+
+fn main() {}

--- a/ractor/tests/ui/actor_macros/rpc_nested_impl_trait_reply.stderr
+++ b/ractor/tests/ui/actor_macros/rpc_nested_impl_trait_reply.stderr
@@ -1,0 +1,5 @@
+error: RPC reply types must be concrete; `impl Trait` is not supported anywhere in a reply type
+ --> tests/ui/actor_macros/rpc_nested_impl_trait_reply.rs:6:30
+  |
+6 |     fn read(&self) -> Option<impl std::fmt::Display> {
+  |                              ^^^^

--- a/ractor_macros/Cargo.toml
+++ b/ractor_macros/Cargo.toml
@@ -21,4 +21,4 @@ async-trait = []
 proc-macro-crate = "3"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2", features = ["full"] }
+syn = { version = "2", features = ["full", "visit"] }

--- a/ractor_macros/src/expand.rs
+++ b/ractor_macros/src/expand.rs
@@ -8,8 +8,9 @@ use std::collections::HashSet;
 use proc_macro2::{Span, TokenStream};
 use proc_macro_crate::{crate_name, FoundCrate};
 use quote::{quote, ToTokens};
-use syn::parse::Parser;
+use syn::parse::{Parse, ParseStream, Parser};
 use syn::spanned::Spanned;
+use syn::visit::Visit;
 use syn::{
     punctuated::Punctuated, Attribute, FieldPat, FnArg, ImplItem, ImplItemFn, ItemImpl, Member,
     Meta, Pat, PatIdent, Path, ReturnType, Signature, Token, Type, TypeReference, Visibility,
@@ -45,7 +46,7 @@ pub(crate) fn expand_actor(
     let message_type = config.message.ty();
     let mut inherent_items = Vec::new();
     let mut trait_methods = Vec::new();
-    let mut message_handlers = Vec::new();
+    let mut dispatch_handlers = Vec::new();
     let mut supervision_handlers = Vec::new();
     let mut raw_handle_span = None;
     let mut raw_supervision_span = None;
@@ -56,9 +57,11 @@ pub(crate) fn expand_actor(
             continue;
         };
 
-        let message_attributes = take_handler_attributes(&mut method.attrs, &ractor, "message");
+        let message_attributes =
+            take_handler_attributes(&mut method.attrs, &ractor, "message", true);
+        let rpc_attributes = take_handler_attributes(&mut method.attrs, &ractor, "rpc", false);
         let supervision_attributes =
-            take_handler_attributes(&mut method.attrs, &ractor, "supervision");
+            take_handler_attributes(&mut method.attrs, &ractor, "supervision", true);
         if message_attributes.len() > 1 {
             return Err(syn::Error::new(
                 message_attributes[1].span(),
@@ -71,10 +74,19 @@ pub(crate) fn expand_actor(
                 "supervision handler methods may only have one `#[ractor::supervision(...)]` attribute",
             ));
         }
-        if !message_attributes.is_empty() && !supervision_attributes.is_empty() {
+        if rpc_attributes.len() > 1 {
             return Err(syn::Error::new(
-                supervision_attributes[0].span(),
-                "a method cannot be both a message and supervision handler",
+                rpc_attributes[1].span(),
+                "RPC handler methods may only have one `#[ractor::rpc(...)]` attribute",
+            ));
+        }
+        let handler_attribute_count = usize::from(!message_attributes.is_empty())
+            + usize::from(!rpc_attributes.is_empty())
+            + usize::from(!supervision_attributes.is_empty());
+        if handler_attribute_count > 1 {
+            return Err(syn::Error::new(
+                method.sig.ident.span(),
+                "a method can only be one of a message, RPC, or supervision handler",
             ));
         }
 
@@ -83,7 +95,21 @@ pub(crate) fn expand_actor(
             if let MessageConfig::Generated(config) = &config.message {
                 qualify_generated_message_pattern(&mut pattern, &config.ident)?;
             }
-            message_handlers.push(parse_handler(&method, pattern, HandlerKind::Message)?);
+            dispatch_handlers.push(parse_handler(&method, pattern, HandlerKind::Message)?);
+            inherent_items.push(ImplItem::Fn(method));
+            continue;
+        }
+
+        if let Some(attribute) = rpc_attributes.first() {
+            let RpcHandlerAttribute {
+                mut pattern,
+                reply_type,
+            } = attribute.parse_args()?;
+            if let MessageConfig::Generated(config) = &config.message {
+                qualify_generated_message_pattern(&mut pattern, &config.ident)?;
+            }
+            inject_unit_rpc_reply(&mut pattern)?;
+            dispatch_handlers.push(parse_rpc_handler(&method, pattern, reply_type, &ractor)?);
             inherent_items.push(ImplItem::Fn(method));
             continue;
         }
@@ -109,18 +135,12 @@ pub(crate) fn expand_actor(
     }
 
     if let Some(span) = raw_handle_span {
-        if !message_handlers.is_empty() {
+        if !dispatch_handlers.is_empty() {
             return Err(syn::Error::new(
                 span,
-                "define either a raw `handle` method or `#[ractor::message(...)]` handlers, not both",
+                "define either a raw `handle` method or focused `#[ractor::message(...)]`/`#[ractor::rpc(...)]` handlers, not both",
             ));
         }
-    }
-    if raw_handle_span.is_none() && message_handlers.is_empty() {
-        return Err(syn::Error::new(
-            actor_impl.self_ty.span(),
-            "actor implementation requires a raw `handle` method or at least one `#[ractor::message(...)]` handler",
-        ));
     }
     if let Some(span) = raw_supervision_span {
         if !supervision_handlers.is_empty() {
@@ -131,7 +151,7 @@ pub(crate) fn expand_actor(
         }
     }
 
-    validate_unique_patterns(&message_handlers, HandlerKind::Message)?;
+    validate_unique_patterns(&dispatch_handlers, HandlerKind::Message)?;
     validate_unique_patterns(&supervision_handlers, HandlerKind::Supervision)?;
 
     let has_pre_start = trait_methods
@@ -147,8 +167,8 @@ pub(crate) fn expand_actor(
         trait_methods.push(default_pre_start(&ractor));
     }
 
-    if raw_handle_span.is_none() {
-        trait_methods.push(generated_handle(&ractor, &message_handlers)?);
+    if raw_handle_span.is_none() && !dispatch_handlers.is_empty() {
+        trait_methods.push(generated_handle(&ractor, &dispatch_handlers)?);
     }
     if raw_supervision_span.is_none() && !supervision_handlers.is_empty() {
         trait_methods.push(generated_supervision_handler(
@@ -167,7 +187,7 @@ pub(crate) fn expand_actor(
     let generated_message = match &message {
         MessageConfig::Existing(_) => TokenStream::new(),
         MessageConfig::Generated(config) => {
-            generate_message_enum(config, &message_handlers, &generated_enum_cfg_attributes)?
+            generate_message_enum(config, &dispatch_handlers, &generated_enum_cfg_attributes)?
         }
     };
     let trait_path = if thread_local {
@@ -329,10 +349,11 @@ fn take_handler_attributes(
     attributes: &mut Vec<Attribute>,
     ractor: &Path,
     handler_attribute: &str,
+    allow_bare: bool,
 ) -> Vec<Attribute> {
     let mut handler_attributes = Vec::new();
     attributes.retain(|attribute| {
-        let is_handler = is_handler_attribute(attribute, ractor, handler_attribute);
+        let is_handler = is_handler_attribute(attribute, ractor, handler_attribute, allow_bare);
         if is_handler {
             handler_attributes.push(attribute.clone());
         }
@@ -341,9 +362,14 @@ fn take_handler_attributes(
     handler_attributes
 }
 
-fn is_handler_attribute(attribute: &Attribute, ractor: &Path, handler_attribute: &str) -> bool {
+fn is_handler_attribute(
+    attribute: &Attribute,
+    ractor: &Path,
+    handler_attribute: &str,
+    allow_bare: bool,
+) -> bool {
     let path = attribute.path();
-    if path.is_ident(handler_attribute) {
+    if allow_bare && path.is_ident(handler_attribute) {
         return true;
     }
     if path.segments.len() != ractor.segments.len() + 1 {
@@ -358,6 +384,47 @@ fn is_handler_attribute(attribute: &Attribute, ractor: &Path, handler_attribute:
             .segments
             .last()
             .is_some_and(|segment| segment.ident == handler_attribute)
+}
+
+#[cfg(test)]
+mod handler_attribute_tests {
+    use super::*;
+
+    #[test]
+    fn bare_rpc_is_not_consumed() {
+        let ractor: Path = syn::parse_quote!(::renamed_ractor);
+        let bare_rpc: Attribute = syn::parse_quote!(#[rpc(Message::Read(reply))]);
+        let qualified_rpc: Attribute =
+            syn::parse_quote!(#[renamed_ractor::rpc(Message::Read(reply))]);
+        let mut attributes = vec![bare_rpc, qualified_rpc];
+        let rpc_attributes = take_handler_attributes(&mut attributes, &ractor, "rpc", false);
+
+        assert_eq!(rpc_attributes.len(), 1);
+        assert_eq!(attributes.len(), 1);
+        assert_eq!(rpc_attributes[0].path().segments[0].ident, "renamed_ractor");
+        assert!(attributes[0].path().is_ident("rpc"));
+    }
+
+    #[test]
+    fn existing_handler_attributes_keep_bare_compatibility() {
+        let ractor: Path = syn::parse_quote!(::renamed_ractor);
+        let bare_message: Attribute = syn::parse_quote!(#[message(Message::Go)]);
+        let bare_supervision: Attribute =
+            syn::parse_quote!(#[supervision(SupervisionEvent::ActorStarted(child))]);
+
+        assert!(is_handler_attribute(
+            &bare_message,
+            &ractor,
+            "message",
+            true
+        ));
+        assert!(is_handler_attribute(
+            &bare_supervision,
+            &ractor,
+            "supervision",
+            true
+        ));
+    }
 }
 
 fn is_lifecycle_method(ident: &syn::Ident) -> bool {
@@ -392,6 +459,7 @@ enum StateAccess {
 #[derive(Clone, Copy)]
 enum HandlerKind {
     Message,
+    Rpc,
     Supervision,
 }
 
@@ -399,6 +467,7 @@ impl HandlerKind {
     fn method_description(self) -> &'static str {
         match self {
             Self::Message => "message handler methods",
+            Self::Rpc => "RPC handler methods",
             Self::Supervision => "supervision handler methods",
         }
     }
@@ -406,6 +475,7 @@ impl HandlerKind {
     fn parameter_label(self) -> &'static str {
         match self {
             Self::Message => "handler",
+            Self::Rpc => "RPC handler",
             Self::Supervision => "supervision handler",
         }
     }
@@ -413,16 +483,57 @@ impl HandlerKind {
     fn pattern_label(self) -> &'static str {
         match self {
             Self::Message => "message pattern",
+            Self::Rpc => "RPC pattern",
             Self::Supervision => "supervision pattern",
         }
     }
 
     fn event_label(self) -> &'static str {
         match self {
-            Self::Message => "message",
+            Self::Message | Self::Rpc => "message",
             Self::Supervision => "supervision event",
         }
     }
+}
+
+struct RpcHandlerAttribute {
+    pattern: Pat,
+    reply_type: Option<Type>,
+}
+
+impl Parse for RpcHandlerAttribute {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let pattern = Pat::parse_single(input)?;
+        let mut reply_type = None;
+
+        if input.parse::<Option<Token![,]>>()?.is_some() && !input.is_empty() {
+            let option: syn::Ident = input.parse()?;
+            if option != "reply" {
+                return Err(syn::Error::new(
+                    option.span(),
+                    "unknown RPC option; expected `reply = Type`",
+                ));
+            }
+            input.parse::<Token![=]>()?;
+            reply_type = Some(input.parse()?);
+            input.parse::<Option<Token![,]>>()?;
+        }
+
+        if !input.is_empty() {
+            return Err(input.error("unexpected tokens after RPC handler options"));
+        }
+
+        Ok(Self {
+            pattern,
+            reply_type,
+        })
+    }
+}
+
+struct RpcHandler {
+    reply_binding: syn::Ident,
+    reply_type: Type,
+    propagates_processing_error: bool,
 }
 
 struct Handler {
@@ -435,6 +546,7 @@ struct Handler {
     state_access: Option<StateAccess>,
     is_async: bool,
     is_fallible: bool,
+    rpc: Option<RpcHandler>,
     cfg_attributes: Vec<Attribute>,
 }
 
@@ -473,6 +585,112 @@ fn parse_handler(
         state_access,
         is_async: method.sig.asyncness.is_some(),
         is_fallible: !returns_unit(&method.sig.output),
+        rpc: None,
+        cfg_attributes,
+    })
+}
+
+fn parse_rpc_handler(
+    method: &ImplItemFn,
+    pattern: Pat,
+    explicit_reply_type: Option<Type>,
+    ractor: &Path,
+) -> syn::Result<Handler> {
+    validate_method_shape(&method.sig, HandlerKind::Rpc.method_description())?;
+    let (pattern_key, pattern_bindings) = parse_handler_pattern(&pattern, HandlerKind::Rpc)?;
+    let parameters = typed_parameters(&method.sig, HandlerKind::Rpc.parameter_label())?;
+
+    let propagates_processing_error = explicit_reply_type.is_some();
+    let reply_type = match explicit_reply_type {
+        Some(reply_type) => {
+            if returns_unit(&method.sig.output) {
+                return Err(syn::Error::new(
+                    method.sig.output.span(),
+                    "an RPC handler using `reply = Type` must return a fallible value; `Result<Type, ActorProcessingErr>` is the usual form",
+                ));
+            }
+            reply_type
+        }
+        None => return_type(&method.sig.output),
+    };
+    if let Some(span) = impl_trait_span(&reply_type) {
+        return Err(syn::Error::new(
+            span,
+            "RPC reply types must be concrete; `impl Trait` is not supported anywhere in a reply type",
+        ));
+    }
+
+    let mut candidates = Vec::new();
+    for reply_index in 0..pattern_bindings.len() {
+        let payload_bindings = pattern_bindings
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| *index != reply_index)
+            .map(|(_, binding)| binding.clone())
+            .collect::<Vec<_>>();
+        if let Ok((wants_actor_ref, state_access)) = classify_handler_parameters(
+            &parameters,
+            &payload_bindings,
+            method.sig.ident.span(),
+            HandlerKind::Rpc.parameter_label(),
+            HandlerKind::Rpc.pattern_label(),
+        ) {
+            candidates.push((reply_index, payload_bindings, wants_actor_ref, state_access));
+        }
+    }
+
+    let (reply_index, binding_names, wants_actor_ref, state_access) = match candidates.len() {
+        1 => candidates.pop().expect("one RPC reply candidate was found"),
+        0 => {
+            return Err(syn::Error::new(
+                method.sig.ident.span(),
+                "RPC handler parameters must match every RPC pattern binding except exactly one reply-port binding, with an optional leading `ActorRef` and optional trailing state reference",
+            ));
+        }
+        _ => {
+            return Err(syn::Error::new(
+                method.sig.ident.span(),
+                "RPC reply port is ambiguous; exactly one RPC pattern binding must be absent from the method parameters",
+            ));
+        }
+    };
+
+    let payload_start = usize::from(wants_actor_ref);
+    let payload_end = parameters.len() - usize::from(state_access.is_some());
+    let mut payload_types = parameters[payload_start..payload_end]
+        .iter()
+        .map(|parameter| (*parameter.ty).clone());
+    let binding_types = pattern_bindings
+        .iter()
+        .enumerate()
+        .map(|(index, _)| {
+            if index == reply_index {
+                syn::parse_quote!(#ractor::RpcReplyPort<#reply_type>)
+            } else {
+                payload_types
+                    .next()
+                    .expect("validated RPC payload binding is missing its parameter type")
+            }
+        })
+        .collect();
+    debug_assert!(payload_types.next().is_none());
+
+    let cfg_attributes = match_arm_cfg_attributes(&method.attrs)?;
+    Ok(Handler {
+        method_name: method.sig.ident.clone(),
+        pattern,
+        pattern_key,
+        binding_names,
+        binding_types,
+        wants_actor_ref,
+        state_access,
+        is_async: method.sig.asyncness.is_some(),
+        is_fallible: false,
+        rpc: Some(RpcHandler {
+            reply_binding: pattern_bindings[reply_index].clone(),
+            reply_type,
+            propagates_processing_error,
+        }),
         cfg_attributes,
     })
 }
@@ -736,12 +954,27 @@ fn qualify_generated_message_pattern(
     Ok(())
 }
 
+fn inject_unit_rpc_reply(pattern: &mut Pat) -> syn::Result<()> {
+    let Pat::Path(unit_variant) = pattern else {
+        return Ok(());
+    };
+    if unit_variant.qself.is_some() || !unit_variant.attrs.is_empty() {
+        return Ok(());
+    }
+
+    let path = &unit_variant.path;
+    let reply_binding = syn::Ident::new("__ractor_reply_port", Span::mixed_site());
+    *pattern = Pat::parse_single.parse2(quote!(#path(#reply_binding)))?;
+    Ok(())
+}
+
 fn parse_handler_pattern(
     pattern: &Pat,
     handler_kind: HandlerKind,
 ) -> syn::Result<(String, Vec<syn::Ident>)> {
     let pattern_description = match handler_kind {
         HandlerKind::Message => "message patterns",
+        HandlerKind::Rpc => "RPC patterns",
         HandlerKind::Supervision => "supervision patterns",
     };
     let (path, fields): (&Path, Vec<&Pat>) = match pattern {
@@ -927,6 +1160,32 @@ fn returns_unit(output: &ReturnType) -> bool {
     }
 }
 
+fn return_type(output: &ReturnType) -> Type {
+    match output {
+        ReturnType::Default => syn::parse_quote!(()),
+        ReturnType::Type(_, ty) => (**ty).clone(),
+    }
+}
+
+fn impl_trait_span(ty: &Type) -> Option<Span> {
+    #[derive(Default)]
+    struct Finder {
+        span: Option<Span>,
+    }
+
+    impl<'ast> Visit<'ast> for Finder {
+        fn visit_type_impl_trait(&mut self, node: &'ast syn::TypeImplTrait) {
+            if self.span.is_none() {
+                self.span = Some(node.span());
+            }
+        }
+    }
+
+    let mut finder = Finder::default();
+    finder.visit_type(ty);
+    finder.span
+}
+
 fn is_unit_type(ty: &Type) -> bool {
     matches!(unparenthesized_type(ty), Type::Tuple(tuple) if tuple.elems.is_empty())
 }
@@ -1019,6 +1278,21 @@ fn generated_handler_arms(
             }
 
             let await_suffix = handler.is_async.then(|| quote!(.await));
+            if let Some(rpc) = &handler.rpc {
+                let reply_binding = &rpc.reply_binding;
+                let reply_type = &rpc.reply_type;
+                let try_suffix = rpc.propagates_processing_error.then(|| quote!(?));
+                let reply_value = syn::Ident::new("__ractor_reply_value", Span::mixed_site());
+                return quote! {
+                    #(#cfg_attributes)*
+                    #pattern => {
+                        let #reply_value: #reply_type =
+                            self.#method_name(#(#arguments),*) #await_suffix #try_suffix;
+                        let _ = #reply_binding.send(#reply_value);
+                        ::core::result::Result::Ok(())
+                    }
+                };
+            }
             let try_suffix = handler.is_fallible.then(|| quote!(?));
             quote! {
                 #(#cfg_attributes)*

--- a/ractor_macros/src/lib.rs
+++ b/ractor_macros/src/lib.rs
@@ -23,17 +23,26 @@ use crate::config::ActorConfig;
 /// to `()`. Add the `thread_local` flag to implement `ThreadLocalActor` instead
 /// of `Actor`.
 ///
-/// Mark handlers with `#[ractor::message(Message::Variant(...))]`. Flat unit,
-/// tuple, and struct variant patterns are supported, and their named bindings
-/// must appear as method parameters in the same order. A handler may also take
-/// an `ActorRef` first and `&State` or `&mut State` last. Handlers can be sync
-/// or async; any explicit non-unit return must support `?` and is propagated
-/// into the generated `handle` method.
+/// Mark one-way handlers with `#[ractor::message(Message::Variant(...))]` and
+/// request/reply handlers with `#[ractor::rpc(Message::Variant(...))]`. Flat
+/// unit, tuple, and struct variant patterns are supported. Message bindings
+/// must appear as method parameters in the same order. For an RPC, exactly one
+/// binding is omitted from the method parameters and used as its reply port;
+/// the method's return value is sent automatically. A handler may also take an
+/// `ActorRef` first and `&State` or `&mut State` last.
 ///
-/// The generated dispatch is exhaustive, so adding a message variant without
-/// a handler is a compile error. A canonical raw `handle` method remains
-/// supported, but cannot be mixed with generated message handlers. Other
-/// lifecycle methods keep their normal async trait signatures.
+/// Handlers can be sync or async. An explicit non-unit message-handler return
+/// is propagated into the generated `handle` method with `?`. By default, an
+/// RPC handler's full return type is its reply type, including `Result`.
+/// `#[ractor::rpc(Pattern, reply = Type)]` instead treats the method return as
+/// fallible actor processing, applies `?`, and sends the resulting `Type`.
+///
+/// When focused message or RPC handlers are present, the generated dispatch is
+/// exhaustive, so adding a message variant without a handler is a compile
+/// error. A canonical raw `handle` method remains supported, but cannot be
+/// mixed with focused handlers. If neither form is present, the macro emits no
+/// `handle` method and inherits the trait's no-op default. Other lifecycle
+/// methods keep their normal async trait signatures.
 ///
 /// Mark focused supervision handlers with
 /// `#[ractor::supervision(SupervisionEvent::Variant(...))]`. Their parameters


### PR DESCRIPTION
## Summary

- add focused `#[ractor::rpc(...)]` handlers for generated and existing message enums
- infer reply types from handler returns, with `reply = T` for actor-processing error propagation
- support tuple and struct variants with the reply port at any position, plus no-payload shorthand
- keep dropped reply receivers non-fatal and cluster wire metadata explicit
- bump the workspace version to `0.16.2` and require `ractor_macros >= 0.16.2`

## Validation

- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`
- `cargo test`
- actor-macro tests under default/native async, `async-trait`, `cluster`, and async-std configurations
- actor macro example check and library documentation build

## Follow-up regression fix\n\n- allow lifecycle- and supervision-only macro actors to omit `handle` and inherit the trait default