### PR TITLE
feat(factory): improve Factory API ergonomics

### DIFF
--- a/ractor/src/factory.rs
+++ b/ractor/src/factory.rs
@@ -11,6 +11,19 @@
 //! which denotes a key and message payload for each action. Workers are effectively mindless
 //! agents of the factory's will.
 //!
+//! ## Local and remote factory operations
+//!
+//! In a cluster, only [`FactoryMessage::Dispatch`] is serialized for a remote
+//! factory. Job dispatch and [`FactoryRef::call_job`] can therefore target a
+//! remote factory when the job's message supports it. Factory observation and
+//! management operations, such as queue-depth queries, pool resizing, settings
+//! updates, and request draining, are local-factory-only.
+//!
+//! The one-way [`FactoryRef`] helpers return [`FactorySendResult`], which boxes
+//! the large but recoverable [`FactoryMessage`] on failure. Call and query
+//! helpers follow [`crate::ActorRef::call`] and return an unboxed
+//! [`FactoryMessagingErr`].
+//!
 //! ## Worker message routing mode
 //!  
 //! The factory has a series of dispatch modes which are defined in the [routing] module and
@@ -53,7 +66,6 @@
 //! use ractor::factory::*;
 //! use ractor::Actor;
 //! use ractor::ActorProcessingErr;
-//! use ractor::ActorRef;
 //! use ractor::RpcReplyPort;
 //!
 //! #[derive(Debug)]
@@ -77,7 +89,7 @@
 //!     async fn pre_start(
 //!         &self,
 //!         wid: WorkerId,
-//!         factory: &ActorRef<FactoryMessage<(), ExampleMessage>>,
+//!         factory: &FactoryRef<(), ExampleMessage>,
 //!         startup_context: Self::Arguments,
 //!     ) -> Result<Self::State, ActorProcessingErr> {
 //!         Ok(startup_context)
@@ -85,7 +97,7 @@
 //!     async fn handle(
 //!         &self,
 //!         wid: WorkerId,
-//!         factory: &ActorRef<FactoryMessage<(), ExampleMessage>>,
+//!         factory: &FactoryRef<(), ExampleMessage>,
 //!         Job { msg, key, .. }: Job<(), ExampleMessage>,
 //!         _state: &mut Self::State,
 //!     ) -> Result<(), ActorProcessingErr> {
@@ -103,13 +115,6 @@
 //!         Ok(key)
 //!     }
 //! }
-//! /// Used by the factory to build new [ExampleWorker]s.
-//! struct ExampleWorkerBuilder;
-//! impl WorkerBuilder<ExampleWorker, ()> for ExampleWorkerBuilder {
-//!     fn build(&mut self, _wid: usize) -> (ExampleWorker, ()) {
-//!         (ExampleWorker, ())
-//!     }
-//! }
 //! #[tokio::main]
 //! async fn main() {
 //!     let factory_def = Factory::<
@@ -121,7 +126,7 @@
 //!         queues::DefaultQueue<(), ExampleMessage>,
 //!     >::default();
 //!     let factory_args = FactoryArguments::builder()
-//!         .worker_builder(Box::new(ExampleWorkerBuilder))
+//!         .worker_builder(Box::new(worker_builder(|_wid| (ExampleWorker, ()))))
 //!         .queue(Default::default())
 //!         .router(Default::default())
 //!         .num_initial_workers(5)
@@ -132,24 +137,13 @@
 //!         .expect("Failed to startup factory");
 //!     for i in 0..99 {
 //!         factory
-//!             .cast(FactoryMessage::Dispatch(Job {
-//!                 key: (),
-//!                 msg: ExampleMessage::PrintValue(i),
-//!                 options: JobOptions::default(),
-//!                 accepted: None,
-//!             }))
+//!             .dispatch((), ExampleMessage::PrintValue(i))
 //!             .expect("Failed to send to factory");
 //!     }
 //!     let reply = factory
-//!         .call(
-//!             |prt| {
-//!                 FactoryMessage::Dispatch(Job {
-//!                     key: (),
-//!                     msg: ExampleMessage::EchoValue(123, prt),
-//!                     options: JobOptions::default(),
-//!                     accepted: None,
-//!                 })
-//!             },
+//!         .call_job(
+//!             (),
+//!             |reply| ExampleMessage::EchoValue(123, reply),
 //!             None,
 //!         )
 //!         .await
@@ -171,6 +165,7 @@ use crate::Message;
 use crate::RpcReplyPort;
 
 pub mod discard;
+mod factory_ref;
 pub mod factoryimpl;
 pub mod hash;
 pub mod job;
@@ -189,6 +184,9 @@ pub use discard::DiscardMode;
 pub use discard::DiscardReason;
 pub use discard::DiscardSettings;
 pub use discard::DynamicDiscardController;
+pub use factory_ref::FactoryMessagingErr;
+pub use factory_ref::FactoryRef;
+pub use factory_ref::FactorySendResult;
 pub use factoryimpl::Factory;
 pub use factoryimpl::FactoryArguments;
 pub use factoryimpl::FactoryArgumentsBuilder;
@@ -201,8 +199,10 @@ pub use lifecycle::FactoryLifecycleHooks;
 pub use ratelim::LeakyBucketRateLimiter;
 pub use ratelim::RateLimitedRouter;
 pub use ratelim::RateLimiter;
-use stats::FactoryStatsLayer;
+pub use stats::FactoryStatsLayer;
+pub use worker::worker_builder;
 pub use worker::DeadMansSwitchConfiguration;
+pub use worker::FnWorkerBuilder;
 pub use worker::Worker;
 pub use worker::WorkerBuilder;
 pub use worker::WorkerCapacityController;

--- a/ractor/src/factory/factory_ref.rs
+++ b/ractor/src/factory/factory_ref.rs
@@ -1,0 +1,179 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! Typed operations for communicating with a factory.
+//!
+//! Only job dispatch is supported for remote factories. Observation and
+//! management operations are local-factory-only.
+
+use super::{FactoryMessage, Job, JobKey, JobOptions, UpdateSettingsRequest};
+use crate::concurrency::Duration;
+use crate::rpc::CallResult;
+use crate::{ActorRef, Message, MessagingErr, RpcReplyPort};
+
+/// A strongly typed reference to a factory.
+///
+/// This alias exposes factory-specific methods such as [`FactoryRef::dispatch`]
+/// and [`FactoryRef::queue_depth`] while retaining all of the operations on an
+/// [`ActorRef`]. Existing `ActorRef<FactoryMessage<...>>` values can use the
+/// same methods without conversion.
+pub type FactoryRef<TKey, TMsg> = ActorRef<FactoryMessage<TKey, TMsg>>;
+
+/// An error returned while sending an operation to a [`FactoryRef`].
+///
+/// Call and query helpers return this error unboxed, matching
+/// [`ActorRef::call`]. One-way helpers use [`FactorySendResult`] instead.
+pub type FactoryMessagingErr<TKey, TMsg> = MessagingErr<FactoryMessage<TKey, TMsg>>;
+
+/// The result of sending a one-way operation to a [`FactoryRef`].
+///
+/// Factory messages include dynamic configuration values and can therefore be
+/// large. The error is boxed so the uncommon failure path does not inflate the
+/// result returned by every successful operation. If sending fails, the boxed
+/// [`MessagingErr::SendErr`] still owns the recoverable [`FactoryMessage`].
+pub type FactorySendResult<TKey, TMsg> = Result<(), Box<FactoryMessagingErr<TKey, TMsg>>>;
+
+impl<TKey, TMsg> ActorRef<FactoryMessage<TKey, TMsg>>
+where
+    TKey: JobKey,
+    TMsg: Message,
+{
+    /// Dispatch a message to the factory using `key` for routing.
+    ///
+    /// Use [`Self::dispatch_with_options`] when the job needs a TTL or other
+    /// non-default [`JobOptions`], or [`Self::dispatch_job`] for full control
+    /// over the [`Job`].
+    pub fn dispatch(&self, key: TKey, message: TMsg) -> FactorySendResult<TKey, TMsg> {
+        self.dispatch_job(Job::new(key, message))
+    }
+
+    /// Dispatch a message to the factory with explicit [`JobOptions`].
+    pub fn dispatch_with_options(
+        &self,
+        key: TKey,
+        message: TMsg,
+        options: JobOptions,
+    ) -> FactorySendResult<TKey, TMsg> {
+        self.dispatch_job(Job::with_options(key, message, options))
+    }
+
+    /// Dispatch an already configured [`Job`] to the factory.
+    ///
+    /// This is the most flexible dispatch operation. For a local factory, it
+    /// preserves settings configured through [`Job::builder`], including an
+    /// acceptance reply port. When dispatching to a remote factory, the
+    /// cluster wire format does not serialize [`Job::accepted`], so no
+    /// acceptance reply is sent.
+    pub fn dispatch_job(&self, job: Job<TKey, TMsg>) -> FactorySendResult<TKey, TMsg> {
+        Ok(self.cast(FactoryMessage::Dispatch(job))?)
+    }
+
+    /// Call a worker through the factory and await its reply.
+    ///
+    /// `message_builder` receives the reply port used to construct the worker
+    /// message. The factory routes the resulting job like any other dispatch.
+    pub async fn call_job<TReply, TMessageBuilder>(
+        &self,
+        key: TKey,
+        message_builder: TMessageBuilder,
+        timeout: Option<Duration>,
+    ) -> Result<CallResult<TReply>, FactoryMessagingErr<TKey, TMsg>>
+    where
+        TReply: Send + 'static,
+        TMessageBuilder: FnOnce(RpcReplyPort<TReply>) -> TMsg,
+    {
+        self.call(
+            |reply| FactoryMessage::Dispatch(Job::new(key, message_builder(reply))),
+            timeout,
+        )
+        .await
+    }
+
+    /// Call a worker through the factory using explicit [`JobOptions`].
+    pub async fn call_job_with_options<TReply, TMessageBuilder>(
+        &self,
+        key: TKey,
+        message_builder: TMessageBuilder,
+        options: JobOptions,
+        timeout: Option<Duration>,
+    ) -> Result<CallResult<TReply>, FactoryMessagingErr<TKey, TMsg>>
+    where
+        TReply: Send + 'static,
+        TMessageBuilder: FnOnce(RpcReplyPort<TReply>) -> TMsg,
+    {
+        self.call(
+            |reply| {
+                FactoryMessage::Dispatch(Job::with_options(key, message_builder(reply), options))
+            },
+            timeout,
+        )
+        .await
+    }
+
+    /// Retrieve the number of jobs currently held in the factory's queue.
+    ///
+    /// This operation is only supported for local factories.
+    pub async fn queue_depth(
+        &self,
+        timeout: Option<Duration>,
+    ) -> Result<CallResult<usize>, FactoryMessagingErr<TKey, TMsg>> {
+        self.call(FactoryMessage::GetQueueDepth, timeout).await
+    }
+
+    /// Retrieve the factory's currently available worker and queue capacity.
+    ///
+    /// When no queue limit is configured, this reports the number of available
+    /// workers. With a queue limit, it also includes the remaining queue space.
+    ///
+    /// This operation is only supported for local factories.
+    pub async fn available_capacity(
+        &self,
+        timeout: Option<Duration>,
+    ) -> Result<CallResult<usize>, FactoryMessagingErr<TKey, TMsg>> {
+        self.call(FactoryMessage::GetAvailableCapacity, timeout)
+            .await
+    }
+
+    /// Retrieve the number of workers currently processing jobs.
+    ///
+    /// This operation is only supported for local factories.
+    pub async fn active_workers(
+        &self,
+        timeout: Option<Duration>,
+    ) -> Result<CallResult<usize>, FactoryMessagingErr<TKey, TMsg>> {
+        self.call(FactoryMessage::GetNumActiveWorkers, timeout)
+            .await
+    }
+
+    /// Resize the factory's worker pool.
+    ///
+    /// The resize is processed asynchronously by the factory. A subsequent
+    /// request sent through the same reference is processed after this one.
+    ///
+    /// This operation is only supported for local factories.
+    pub fn adjust_worker_pool(&self, worker_count: usize) -> FactorySendResult<TKey, TMsg> {
+        Ok(self.cast(FactoryMessage::AdjustWorkerPool(worker_count))?)
+    }
+
+    /// Drain all queued and active jobs, reject new work, and then stop the factory.
+    ///
+    /// This differs from [`crate::ActorCell::drain`], because a factory owns an
+    /// internal job queue in addition to its actor mailbox.
+    ///
+    /// This operation is only supported for local factories.
+    pub fn drain_requests(&self) -> FactorySendResult<TKey, TMsg> {
+        Ok(self.cast(FactoryMessage::DrainRequests)?)
+    }
+
+    /// Apply settings which can be changed while the factory is running.
+    ///
+    /// This operation is only supported for local factories.
+    pub fn update_settings(
+        &self,
+        settings: UpdateSettingsRequest<TKey, TMsg>,
+    ) -> FactorySendResult<TKey, TMsg> {
+        Ok(self.cast(FactoryMessage::UpdateSettings(settings))?)
+    }
+}

--- a/ractor/src/factory/job.rs
+++ b/ractor/src/factory/job.rs
@@ -349,6 +349,21 @@ where
     TKey: JobKey,
     TMsg: Message,
 {
+    /// Construct a job with default [`JobOptions`].
+    pub fn new(key: TKey, message: TMsg) -> Self {
+        Self::with_options(key, message, JobOptions::default())
+    }
+
+    /// Construct a job with explicit [`JobOptions`].
+    pub fn with_options(key: TKey, message: TMsg, options: JobOptions) -> Self {
+        Self {
+            key,
+            msg: message,
+            options,
+            accepted: None,
+        }
+    }
+
     /// Determine if this job's TTL is expired
     ///
     /// Expiration only takes effect prior to the job being

--- a/ractor/src/factory/stats.rs
+++ b/ractor/src/factory/stats.rs
@@ -13,12 +13,15 @@ use crate::factory::JobOptions;
 
 /// A wrapper over whatever stats collection a user wishes to utilize
 /// in the [super::Factory].
+///
+/// Every callback defaults to a no-op, so implementations only need to
+/// override the metrics they collect.
 pub trait FactoryStatsLayer: Send + Sync + 'static {
     /// Called when a factory ping has been received, marking the duration
     /// between when it was sent and now.
     ///
     /// Measures ping latency on the factory
-    fn factory_ping_received(&self, factory: &str, sent: Instant);
+    fn factory_ping_received(&self, _factory: &str, _sent: Instant) {}
 
     /// Called when a worker replies to a ping request from the factory,
     /// measuring the duration between the time the ping was sent and the
@@ -26,10 +29,10 @@ pub trait FactoryStatsLayer: Send + Sync + 'static {
     ///
     /// Measures worker "free" latency and this metric relates to identification
     /// of "stuck" or slow workers.
-    fn worker_ping_received(&self, factory: &str, elapsed: Duration);
+    fn worker_ping_received(&self, _factory: &str, _elapsed: Duration) {}
 
     /// Called for each new incoming job
-    fn new_job(&self, factory: &str);
+    fn new_job(&self, _factory: &str) {}
 
     /// Called when a job is completed to report factory processing time,
     /// worker processing time, total processing time, and job count
@@ -38,34 +41,32 @@ pub trait FactoryStatsLayer: Send + Sync + 'static {
     /// 1. Time in factory's queue = factory_job_processing_latency_usec - worker_job_processing_latency_usec
     /// 2. Time in worker's queue + being processed by worker = worker_job_processing_latency_usec
     /// 3. Total time since submission = job_processing_latency_usec
-    fn job_completed(&self, factory: &str, options: &JobOptions);
+    fn job_completed(&self, _factory: &str, _options: &JobOptions) {}
 
     /// Called when a job is discarded
-    fn job_discarded(&self, factory: &str);
+    fn job_discarded(&self, _factory: &str) {}
 
     /// Called when a job is rate limited
-    fn job_rate_limited(&self, factory: &str);
+    fn job_rate_limited(&self, _factory: &str) {}
 
     /// Called when jobs TTL timeout in the factory's queue
-    fn job_ttl_expired(&self, factory: &str, num_removed: usize);
+    fn job_ttl_expired(&self, _factory: &str, _num_removed: usize) {}
 
     /// Fixed-period recording of the factory's queue depth
-    fn record_queue_depth(&self, factory: &str, depth: usize);
+    fn record_queue_depth(&self, _factory: &str, _depth: usize) {}
 
     /// Fixed-period recording of the factory's number of processed messages
-    fn record_processing_messages_count(&self, factory: &str, count: usize);
+    fn record_processing_messages_count(&self, _factory: &str, _count: usize) {}
 
     /// Fixed-period recording of the factory's in-flight message count (processing + queued)
     ///
-    /// Default empty implemention for backwards compatibility
-    #[allow(unused_variables)]
-    fn record_in_flight_messages_count(&self, factory: &str, count: usize) {}
+    fn record_in_flight_messages_count(&self, _factory: &str, _count: usize) {}
 
     /// Fixed-period recording of the factory's number of workers
-    fn record_worker_count(&self, factory: &str, count: usize);
+    fn record_worker_count(&self, _factory: &str, _count: usize) {}
 
     /// Fixed-period recording of the factory's maximum allowed queue size
-    fn record_queue_limit(&self, factory: &str, count: usize);
+    fn record_queue_limit(&self, _factory: &str, _count: usize) {}
 }
 
 impl FactoryStatsLayer for Option<Arc<dyn FactoryStatsLayer>> {

--- a/ractor/src/factory/tests.rs
+++ b/ractor/src/factory/tests.rs
@@ -10,6 +10,7 @@ mod draining_requests;
 mod dynamic_discarding;
 mod dynamic_pool;
 mod dynamic_settings;
+mod ergonomics;
 mod lifecycle;
 mod priority_queueing;
 mod processing_messages_accounting;

--- a/ractor/src/factory/tests/ergonomics.rs
+++ b/ractor/src/factory/tests/ergonomics.rs
@@ -1,0 +1,236 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use crate::concurrency::Duration;
+use crate::factory::*;
+use crate::rpc::CallResult;
+use crate::{Actor, ActorProcessingErr, ActorRef, MessagingErr, RpcReplyPort};
+
+#[derive(Debug)]
+enum TestMessage {
+    Increment,
+    Echo(usize, RpcReplyPort<usize>),
+}
+
+#[cfg(feature = "cluster")]
+impl crate::Message for TestMessage {}
+
+struct TestWorker {
+    handled: Arc<AtomicUsize>,
+    generation: usize,
+}
+
+#[cfg_attr(feature = "async-trait", crate::async_trait)]
+impl Worker for TestWorker {
+    type Key = ();
+    type Message = TestMessage;
+    type State = ();
+    type Arguments = ();
+
+    async fn pre_start(
+        &self,
+        _wid: WorkerId,
+        _factory: &FactoryRef<Self::Key, Self::Message>,
+        arguments: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(arguments)
+    }
+
+    async fn handle(
+        &self,
+        _wid: WorkerId,
+        _factory: &ActorRef<FactoryMessage<Self::Key, Self::Message>>,
+        Job { key, msg, .. }: Job<Self::Key, Self::Message>,
+        _state: &mut Self::State,
+    ) -> Result<Self::Key, ActorProcessingErr> {
+        self.handled.fetch_add(self.generation, Ordering::Relaxed);
+        if let TestMessage::Echo(value, reply) = msg {
+            let _ = reply.send(value);
+        }
+        Ok(key)
+    }
+}
+
+#[derive(Default)]
+struct NewJobStats {
+    count: AtomicUsize,
+}
+
+// All callbacks other than the one this test needs use the trait's no-op defaults.
+impl FactoryStatsLayer for NewJobStats {
+    fn new_job(&self, _factory: &str) {
+        self.count.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[crate::concurrency::test]
+async fn factory_ref_and_closure_builder_cover_common_operations() {
+    let handled = Arc::new(AtomicUsize::new(0));
+    let builds = Arc::new(AtomicUsize::new(0));
+    let stats = Arc::new(NewJobStats::default());
+    let worker_handled = handled.clone();
+    let worker_builds = builds.clone();
+    let mut generation = 0;
+    let builder = worker_builder(move |_wid| {
+        generation += 1;
+        worker_builds.store(generation, Ordering::Relaxed);
+        (
+            TestWorker {
+                handled: worker_handled.clone(),
+                generation,
+            },
+            (),
+        )
+    });
+
+    let definition = Factory::<
+        (),
+        TestMessage,
+        (),
+        TestWorker,
+        routing::QueuerRouting<(), TestMessage>,
+        queues::DefaultQueue<(), TestMessage>,
+    >::default();
+    let arguments = FactoryArguments::builder()
+        .worker_builder(Box::new(builder))
+        .num_initial_workers(1)
+        .router(routing::QueuerRouting::default())
+        .queue(queues::DefaultQueue::default())
+        .stats(stats.clone())
+        .build();
+
+    let (factory, handle) = Actor::spawn(None, definition, arguments)
+        .await
+        .expect("factory should start");
+    let factory: FactoryRef<(), TestMessage> = factory;
+    let timeout = Some(Duration::from_secs(1));
+
+    assert_eq!(
+        CallResult::Success(1),
+        factory
+            .available_capacity(timeout)
+            .await
+            .expect("capacity query should be sent")
+    );
+
+    factory
+        .dispatch((), TestMessage::Increment)
+        .expect("message should be dispatched");
+    factory
+        .dispatch_with_options(
+            (),
+            TestMessage::Increment,
+            JobOptions::new(Some(Duration::from_secs(1))),
+        )
+        .expect("message with options should be dispatched");
+    factory
+        .dispatch_job(Job::new((), TestMessage::Increment))
+        .expect("configured job should be dispatched");
+
+    assert_eq!(
+        CallResult::Success(42),
+        factory
+            .call_job((), |reply| TestMessage::Echo(42, reply), timeout)
+            .await
+            .expect("worker call should be sent")
+    );
+    assert_eq!(
+        CallResult::Success(84),
+        factory
+            .call_job_with_options(
+                (),
+                |reply| TestMessage::Echo(84, reply),
+                JobOptions::default(),
+                timeout,
+            )
+            .await
+            .expect("worker call with options should be sent")
+    );
+
+    assert!(factory
+        .queue_depth(timeout)
+        .await
+        .expect("queue depth query should be sent")
+        .is_success());
+    assert!(factory
+        .active_workers(timeout)
+        .await
+        .expect("active worker query should be sent")
+        .is_success());
+
+    factory
+        .adjust_worker_pool(2)
+        .expect("pool adjustment should be sent");
+    assert!(factory
+        .available_capacity(timeout)
+        .await
+        .expect("capacity query should be sent")
+        .is_success());
+    assert_eq!(2, builds.load(Ordering::Relaxed));
+    factory
+        .update_settings(UpdateSettingsRequest::builder().worker_count(1).build())
+        .expect("settings update should be sent");
+
+    factory
+        .drain_requests()
+        .expect("drain request should be sent");
+    crate::concurrency::timeout(Duration::from_secs(1), handle)
+        .await
+        .expect("factory should drain within the timeout")
+        .expect("factory should exit cleanly");
+
+    assert_eq!(5, handled.load(Ordering::Relaxed));
+    // Both the factory and worker layers observe each new job.
+    assert_eq!(10, stats.count.load(Ordering::Relaxed));
+}
+
+#[crate::concurrency::test]
+async fn one_way_helper_recovers_job_when_factory_is_stopped() {
+    let handled = Arc::new(AtomicUsize::new(0));
+    let definition = Factory::<
+        (),
+        TestMessage,
+        (),
+        TestWorker,
+        routing::QueuerRouting<(), TestMessage>,
+        queues::DefaultQueue<(), TestMessage>,
+    >::default();
+    let arguments = FactoryArguments::builder()
+        .worker_builder(Box::new(worker_builder(move |_wid| {
+            (
+                TestWorker {
+                    handled: handled.clone(),
+                    generation: 1,
+                },
+                (),
+            )
+        })))
+        .num_initial_workers(1)
+        .router(routing::QueuerRouting::default())
+        .queue(queues::DefaultQueue::default())
+        .build();
+
+    let (factory, handle) = Actor::spawn(None, definition, arguments)
+        .await
+        .expect("factory should start");
+    factory.stop(None);
+    handle.await.expect("factory should stop cleanly");
+
+    let error = factory
+        .dispatch((), TestMessage::Increment)
+        .expect_err("dispatch to a stopped factory should fail");
+    match *error {
+        MessagingErr::SendErr(FactoryMessage::Dispatch(Job {
+            key: (),
+            msg: TestMessage::Increment,
+            accepted: None,
+            ..
+        })) => {}
+        other => panic!("expected the failed job to be returned, got {other:?}"),
+    }
+}

--- a/ractor/src/factory/worker.rs
+++ b/ractor/src/factory/worker.rs
@@ -415,6 +415,78 @@ where
     fn build(&mut self, wid: WorkerId) -> (TWorker, TWorkerStart);
 }
 
+/// A [`WorkerBuilder`] backed by a closure.
+///
+/// Construct this type with [`worker_builder`]. The closure is [`FnMut`] so it
+/// can maintain state across worker construction, including replacement
+/// workers created after a failure.
+pub struct FnWorkerBuilder<TBuilder> {
+    builder: TBuilder,
+}
+
+impl<TBuilder> Debug for FnWorkerBuilder<TBuilder> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FnWorkerBuilder").finish_non_exhaustive()
+    }
+}
+
+/// Construct a [`WorkerBuilder`] from a closure.
+///
+/// This removes the need to define a one-off type solely to implement
+/// [`WorkerBuilder`]. The closure receives the worker ID and returns the worker
+/// together with its custom startup arguments.
+///
+/// # Examples
+///
+/// ```
+/// use ractor::factory::{worker_builder, FactoryMessage, Worker, WorkerBuilder, WorkerId};
+/// use ractor::{ActorProcessingErr, ActorRef};
+///
+/// struct ExampleWorker;
+///
+/// #[cfg_attr(feature = "async-trait", ractor::async_trait)]
+/// impl Worker for ExampleWorker {
+///     type Key = ();
+///     type Message = ();
+///     type State = ();
+///     type Arguments = ();
+///
+///     async fn pre_start(
+///         &self,
+///         _wid: WorkerId,
+///         _factory: &ActorRef<FactoryMessage<(), ()>>,
+///         arguments: (),
+///     ) -> Result<(), ActorProcessingErr> {
+///         Ok(arguments)
+///     }
+/// }
+///
+/// let builder: Box<dyn WorkerBuilder<ExampleWorker, ()>> =
+///     Box::new(worker_builder(|_wid| (ExampleWorker, ())));
+/// ```
+pub fn worker_builder<TWorker, TWorkerStart, TBuilder>(
+    builder: TBuilder,
+) -> FnWorkerBuilder<TBuilder>
+where
+    TWorker: Actor,
+    TWorkerStart: Message,
+    TBuilder: FnMut(WorkerId) -> (TWorker, TWorkerStart) + Send + Sync,
+{
+    FnWorkerBuilder { builder }
+}
+
+impl<TWorker, TWorkerStart, TBuilder> WorkerBuilder<TWorker, TWorkerStart>
+    for FnWorkerBuilder<TBuilder>
+where
+    TWorker: Actor,
+    TWorkerStart: Message,
+    TBuilder: FnMut(WorkerId) -> (TWorker, TWorkerStart) + Send + Sync,
+{
+    fn build(&mut self, wid: WorkerId) -> (TWorker, TWorkerStart) {
+        (self.builder)(wid)
+    }
+}
+
 /// Controls the size of the worker pool by dynamically growing/shrinking the pool
 /// to requested size
 #[cfg_attr(feature = "async-trait", crate::async_trait)]


### PR DESCRIPTION
## Summary

- add `FactoryRef` operations for dispatching, worker RPCs, status queries, pool resizing, draining, and settings updates
- add `Job::new` and `Job::with_options` constructors
- add an explicit `worker_builder(FnMut)` adapter for closure-backed worker construction
- give `FactoryStatsLayer` callbacks no-op defaults so implementations can select metrics
- document local-only management operations and remote dispatch acceptance-port behavior
- preserve recoverable failed jobs through boxed one-way send errors

## Validation

- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`
- `cargo test`
- focused Factory ergonomics tests under default, `async-trait`, and `cluster` configurations