### PR TITLE
fix(docs): repair and enforce Rustdoc links

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,9 +182,11 @@ jobs:
 
       - name: Run cargo doc on release profile
         uses: actions-rs/cargo@v1
+        env:
+          RUSTDOCFLAGS: -D warnings
         with:
           command: doc
-          args: --lib -r
+          args: --workspace --no-deps -r
 
   benches:
     name: benches

--- a/ractor/src/concurrency/async_std_primitives.rs
+++ b/ractor/src/concurrency/async_std_primitives.rs
@@ -6,7 +6,7 @@
 //! Concurrency primitives based on the `async-std` crate
 //!
 //! We still rely on tokio for some core executor-independent parts
-//! such as channels (see: https://github.com/tokio-rs/tokio/issues/4232#issuecomment-968329443).
+//! such as channels (see: <https://github.com/tokio-rs/tokio/issues/4232#issuecomment-968329443>).
 
 use std::fmt::Debug;
 use std::future::Future;

--- a/ractor/src/errors.rs
+++ b/ractor/src/errors.rs
@@ -211,7 +211,7 @@ impl<T> RactorErr<T> {
     /// [RactorErr] instance in order to not have require cloning the message payload.
     /// Should be used in conjunction with `has_message` to not consume the error if not wanted
     ///
-    /// Returns [Some(`T`)] if there is a message payload, [None] otherwise.
+    /// Returns `Some(T)` if there is a message payload, [`None`] otherwise.
     pub fn try_get_message(self) -> Option<T> {
         if let Self::Messaging(MessagingErr::SendErr(msg)) = self {
             Some(msg)

--- a/ractor/src/factory/job.rs
+++ b/ractor/src/factory/job.rs
@@ -205,8 +205,8 @@ where
     /// external threadpools to the Tokio processing pool and prevent
     /// overloading the unbounded channel which fronts all actors.
     ///
-    /// The reply channel return [None] if the job was accepted, or
-    /// [Some(`Job`)] if it was rejected & loadshed, and then the
+    /// The reply channel returns [`None`] if the job was accepted, or
+    /// `Some(Job)` if it was rejected and load-shed, and then the
     /// job may be retried by the caller at a later time (if desired).
     ///
     /// Default = [None]

--- a/ractor/src/factory/queues.rs
+++ b/ractor/src/factory/queues.rs
@@ -133,7 +133,7 @@ where
 
     /// Retrieve the job's priority.
     ///
-    /// Returns [None] if the job does not have a priority, [Some(`TPriority`)] otherwise.
+    /// Returns [`None`] if the job does not have a priority, `Some(TPriority)` otherwise.
     fn get_priority(&self, job: &TKey) -> Option<TPriority>;
 }
 

--- a/ractor/src/rpc.rs
+++ b/ractor/src/rpc.rs
@@ -197,7 +197,7 @@ where
 /// * `timeout_option` - An optional [Duration] which represents the amount of
 ///   time until the operation times out
 ///
-/// Returns [Ok(`Vec<CallResult<TReply>>>`)] upon successful initial sending with the reply from
+/// Returns `Ok(Vec<CallResult<TReply>>)` upon successful initial sending with the reply from
 /// the [crate::Actor]s, [Err(MessagingErr)] if the initial send operation failed
 pub async fn multi_call<TMessage, TReply, TMsgBuilder>(
     actors: &[ActorRef<TMessage>],

--- a/ractor_cluster_integration_tests/src/tests/external_transport.rs
+++ b/ractor_cluster_integration_tests/src/tests/external_transport.rs
@@ -10,7 +10,7 @@
 //! containers. Instead of relying on the built-in TCP listener, the nodes bind
 //! their own TCP socket and inject the accepted stream through
 //! [`NodeServerMessage::ConnectionOpenedExternal`]. The peer dials that socket
-//! and registers the client half via [`client_connect_external`]. Once the
+//! and registers the client half via [`ractor_cluster::client_connect_external`]. Once the
 //! cluster session reports `Ready`, the actors exchange RPCs to prove remote
 //! messaging works over the custom transport wiring.
 


### PR DESCRIPTION
## Summary

- repair four invalid value-shaped Rustdoc links reported by the existing docs job
- fix a feature-gated bare URL and the integration-test external transport link found by the wider scan
- document the full workspace in CI and deny Rustdoc warnings so broken links cannot pass silently
- retain the existing workspace version `0.16.2`

## Validation

- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`
- `cargo test`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps -r`
- strict all-feature docs for `ractor`, `ractor_cluster`, macros, and integration tests