### PR TITLE
Prepare 0.16.3: compatible lifecycle, TTL, and macro fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ resolver = "3"
 
 [workspace.package]
 rust-version = "1.85"
-version = "0.16.2"
+version = "0.16.3"

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -45,7 +45,7 @@ strum = { version = "0.28", features = ["derive"] }
 # async-std feature 'unstable' is required for spawn_local: https://docs.rs/async-std/latest/async_std/task/fn.spawn_local.html
 async-std = { version = "1", features = ["attributes", "unstable"], optional = true }
 async-trait = { version = "0.1", optional = true }
-ractor_macros = { path = "../ractor_macros", version = "0.16.2", optional = true }
+ractor_macros = { path = "../ractor_macros", version = "0.16.3", optional = true }
 tokio = { version = "1", features = ["sync"] }
 tracing = { version = "0.1", features = ["attributes"] }
 

--- a/ractor/src/actor.rs
+++ b/ractor/src/actor.rs
@@ -476,6 +476,71 @@ impl ActorLoopResult {
     }
 }
 
+/// Owns synchronous actor cleanup so executor cancellation cannot strand
+/// lifecycle state, registry entries, spawn-time supervision links, children, or waiters.
+pub(crate) struct ActorLifecycleGuard {
+    actor: ActorCell,
+    supervisor: Option<ActorCell>,
+    notify_on_cancel: bool,
+    armed: bool,
+}
+
+impl ActorLifecycleGuard {
+    pub(crate) fn new(actor: ActorCell) -> Self {
+        Self {
+            actor,
+            supervisor: None,
+            notify_on_cancel: false,
+            armed: true,
+        }
+    }
+
+    pub(crate) fn set_supervisor(&mut self, supervisor: Option<ActorCell>) {
+        self.supervisor = supervisor;
+    }
+
+    pub(crate) fn mark_running(&mut self) {
+        self.notify_on_cancel = true;
+    }
+
+    pub(crate) fn finish(mut self, event: SupervisionEvent) {
+        self.cleanup(Some(event));
+    }
+
+    fn cleanup(&mut self, event: Option<SupervisionEvent>) {
+        if !self.armed {
+            return;
+        }
+
+        self.actor.set_status(ActorStatus::Stopping);
+        self.actor.terminate();
+
+        if let Some(event) = event {
+            self.actor.notify_supervisor(event);
+        }
+
+        if let Some(supervisor) = self.supervisor.take() {
+            self.actor.unlink(supervisor);
+        }
+
+        self.actor.set_status(ActorStatus::Stopped);
+        self.armed = false;
+    }
+}
+
+impl Drop for ActorLifecycleGuard {
+    fn drop(&mut self) {
+        let event = self.notify_on_cancel.then(|| {
+            SupervisionEvent::ActorTerminated(
+                self.actor.clone(),
+                None,
+                Some("actor_task_cancelled".to_string()),
+            )
+        });
+        self.cleanup(event);
+    }
+}
+
 /// [ActorRuntime] is a struct which represents the processing actor.
 ///
 ///  This struct is consumed by the `start` operation, but results in an
@@ -486,6 +551,7 @@ where
     TActor: Actor,
 {
     actor_ref: ActorRef<TActor::Msg>,
+    lifecycle: ActorLifecycleGuard,
     handler: TActor,
     id: ActorId,
     name: Option<String>,
@@ -656,9 +722,11 @@ where
             let id = actor_cell.get_id();
             let name = actor_cell.get_name();
             let actor_cell2 = actor_cell.clone();
+            let lifecycle = ActorLifecycleGuard::new(actor_cell.clone());
             let (actor, ports) = (
                 Self {
                     actor_ref: actor_cell.into(),
+                    lifecycle,
                     handler,
                     id,
                     name,
@@ -683,9 +751,11 @@ where
         let (actor_cell, ports) = actor_cell::ActorCell::new::<TActor>(name)?;
         let id = actor_cell.get_id();
         let name = actor_cell.get_name();
+        let lifecycle = ActorLifecycleGuard::new(actor_cell.clone());
         Ok((
             Self {
                 actor_ref: actor_cell.into(),
+                lifecycle,
                 handler,
                 id,
                 name,
@@ -721,6 +791,7 @@ where
         let Self {
             handler,
             actor_ref,
+            mut lifecycle,
             id,
             name,
         } = self;
@@ -730,22 +801,16 @@ where
         // Perform the pre-start routine, crashing immediately if we fail to start
         let mut state = match Self::do_pre_start(actor_ref.clone(), &handler, startup_args).await {
             Ok(Ok(state)) => state,
-            Ok(Err(e)) => {
-                // Set status to stopped on error before returning
-                actor_ref.set_status(ActorStatus::Stopped);
-                return Err(SpawnErr::StartupFailed(e));
-            }
-            Err(e) => {
-                // Set status to stopped on error before returning
-                actor_ref.set_status(ActorStatus::Stopped);
-                return Err(e);
-            }
+            Ok(Err(e)) => return Err(SpawnErr::StartupFailed(e)),
+            Err(e) => return Err(e),
         };
 
         // setup supervision
         if let Some(sup) = &supervisor {
             actor_ref.link(sup.clone());
         }
+        lifecycle.set_supervisor(supervisor);
+        lifecycle.mark_running();
 
         // Generate the ActorRef which will be returned
         let myself_ret = actor_ref.clone();
@@ -771,19 +836,7 @@ where
                 },
             };
 
-            // terminate children
-            myself.terminate();
-
-            // notify supervisors of the actor's death
-            myself.notify_supervisor_and_monitors(evt);
-
-            // unlink superisors
-            if let Some(sup) = supervisor {
-                myself.unlink(sup);
-            }
-
-            // set status to stopped
-            myself.set_status(ActorStatus::Stopped);
+            lifecycle.finish(evt);
         });
 
         Ok((myself_ret, handle))

--- a/ractor/src/actor/tests.rs
+++ b/ractor/src/actor/tests.rs
@@ -1045,6 +1045,82 @@ async fn kill_and_wait() {
     periodic_check(|| handle.is_finished(), Duration::from_millis(500)).await;
 }
 
+#[crate::concurrency::test]
+async fn aborting_actor_task_runs_lifecycle_cleanup() {
+    struct WaitingActor;
+
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    impl Actor for WaitingActor {
+        type Msg = ();
+        type State = ();
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _: ActorRef<Self::Msg>,
+            _: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+    }
+
+    let actor_name = "aborting_actor_task_runs_lifecycle_cleanup".to_string();
+    let (actor, handle) = Actor::spawn(Some(actor_name.clone()), WaitingActor, ())
+        .await
+        .expect("actor should start");
+
+    #[cfg(feature = "async-std")]
+    let mut handle = handle;
+    handle.abort();
+    assert!(handle.await.is_err());
+    assert_eq!(ActorStatus::Stopped, actor.get_status());
+    assert!(crate::registry::where_is(actor_name).is_none());
+}
+
+#[crate::concurrency::test]
+async fn cancelling_spawn_future_runs_lifecycle_cleanup() {
+    struct NeverStarts;
+
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    impl Actor for NeverStarts {
+        type Msg = ();
+        type State = ();
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _: ActorRef<Self::Msg>,
+            _: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            std::future::pending().await
+        }
+    }
+
+    let actor_name = "cancelling_spawn_future_runs_lifecycle_cleanup".to_string();
+    let result = crate::concurrency::timeout(
+        Duration::from_millis(10),
+        Actor::spawn(Some(actor_name.clone()), NeverStarts, ()),
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert!(crate::registry::where_is(actor_name).is_none());
+}
+
+#[test]
+fn dropping_unpolled_start_future_runs_lifecycle_cleanup() {
+    let actor_name = "dropping_unpolled_start_future_runs_lifecycle_cleanup".to_string();
+    let (runtime, ports) = super::ActorRuntime::new(Some(actor_name.clone()), StatusTestActor)
+        .expect("actor runtime should be created");
+    let actor = runtime.actor_ref.clone();
+
+    let start = runtime.start(ports, (), None);
+    drop(start);
+
+    assert_eq!(ActorStatus::Stopped, actor.get_status());
+    assert!(crate::registry::where_is(actor_name).is_none());
+}
+
 #[test]
 #[cfg_attr(
     not(all(target_arch = "wasm32", target_os = "unknown")),

--- a/ractor/src/concurrency/async_std_primitives.rs
+++ b/ractor/src/concurrency/async_std_primitives.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 
-use futures::future::BoxFuture;
+use futures::future::{AbortHandle, Abortable, Aborted, BoxFuture};
 use futures::stream::FuturesUnordered;
 use futures::FutureExt;
 use futures::StreamExt;
@@ -26,7 +26,8 @@ use futures::StreamExt;
 /// Adds some syntactic wrapping to support a JoinHandle
 /// similar to `tokio`'s.
 pub struct JoinHandle<T> {
-    handle: Option<async_std::task::JoinHandle<T>>,
+    handle: Option<async_std::task::JoinHandle<Result<T, Aborted>>>,
+    abort_handle: AbortHandle,
     is_done: Arc<AtomicBool>,
 }
 
@@ -35,6 +36,7 @@ impl<T> Debug for JoinHandle<T> {
         f.debug_struct("JoinHandle")
             .field("name", &self.is_done.load(Ordering::Relaxed))
             .field("handle", &self.handle.is_some())
+            .field("aborted", &self.abort_handle.is_aborted())
             .finish()
     }
 }
@@ -42,15 +44,14 @@ impl<T> Debug for JoinHandle<T> {
 impl<T> JoinHandle<T> {
     /// Determine if the handle is currently finished
     pub fn is_finished(&self) -> bool {
-        self.handle.is_none() || self.is_done.load(Ordering::Relaxed)
+        self.handle.is_none()
+            || self.abort_handle.is_aborted()
+            || self.is_done.load(Ordering::Relaxed)
     }
 
     /// Abort the handle
     pub fn abort(&mut self) {
-        if let Some(handle) = self.handle.take() {
-            let f = handle.cancel();
-            drop(f);
-        }
+        self.abort_handle.abort();
     }
 }
 
@@ -68,9 +69,13 @@ impl<T> async_std::future::Future for JoinHandle<T> {
 
         match inner_polled_value {
             Poll::Pending => Poll::Pending,
-            Poll::Ready(v) => {
+            Poll::Ready(Ok(v)) => {
                 mutself.handle = None;
                 Poll::Ready(Ok(v))
+            }
+            Poll::Ready(Err(_)) => {
+                mutself.handle = None;
+                Poll::Ready(Err(()))
             }
         }
     }
@@ -180,15 +185,17 @@ where
 {
     let signal = Arc::new(AtomicBool::new(false));
     let inner_signal = signal.clone();
+    let (abort_handle, abort_registration) = AbortHandle::new_pair();
 
     let jh = async_std::task::spawn_local(async move {
-        let r = future.await;
+        let r = Abortable::new(future, abort_registration).await;
         inner_signal.fetch_or(true, Ordering::Relaxed);
         r
     });
 
     JoinHandle {
         handle: Some(jh),
+        abort_handle,
         is_done: signal,
     }
 }
@@ -199,6 +206,7 @@ where
     F: Future + Send + 'static,
     F::Output: Send + 'static,
 {
+    let (abort_handle, abort_registration) = AbortHandle::new_pair();
     if let Some(name) = name {
         let signal = Arc::new(AtomicBool::new(false));
         let inner_signal = signal.clone();
@@ -206,7 +214,7 @@ where
         let jh = async_std::task::Builder::new()
             .name(name.to_string())
             .spawn(async move {
-                let r = future.await;
+                let r = Abortable::new(future, abort_registration).await;
                 inner_signal.fetch_or(true, Ordering::Relaxed);
                 r
             })
@@ -214,6 +222,7 @@ where
 
         JoinHandle {
             handle: Some(jh),
+            abort_handle,
             is_done: signal,
         }
     } else {
@@ -221,13 +230,14 @@ where
         let inner_signal = signal.clone();
 
         let jh = async_std::task::spawn(async move {
-            let r = future.await;
+            let r = Abortable::new(future, abort_registration).await;
             inner_signal.fetch_or(true, Ordering::Relaxed);
             r
         });
 
         JoinHandle {
             handle: Some(jh),
+            abort_handle,
             is_done: signal,
         }
     }
@@ -260,11 +270,17 @@ mod async_std_primitive_tests {
 
     #[super::test]
     async fn join_handle_aborts() {
-        let mut jh = spawn(async {
+        let completed = Arc::new(AtomicBool::new(false));
+        let completed_task = completed.clone();
+        let mut jh = spawn(async move {
             sleep(Duration::from_millis(1000)).await;
+            completed_task.store(true, Ordering::Relaxed);
         });
         jh.abort();
         assert!(jh.is_finished());
+        assert!(jh.await.is_err());
+        sleep(Duration::from_millis(10)).await;
+        assert!(!completed.load(Ordering::Relaxed));
     }
 
     #[super::test]

--- a/ractor/src/factory/job.rs
+++ b/ractor/src/factory/job.rs
@@ -15,6 +15,7 @@ use tracing::Span;
 
 use super::FactoryMessage;
 use crate::concurrency::Duration;
+use crate::concurrency::Instant;
 use crate::concurrency::SystemTime;
 #[cfg(feature = "cluster")]
 use crate::message::BoxedDowncastErr;
@@ -23,6 +24,41 @@ use crate::ActorRef;
 use crate::BytesConvertable;
 use crate::Message;
 use crate::RpcReplyPort;
+
+#[derive(Debug, Clone)]
+struct TtlTimer {
+    started_at: Instant,
+    remaining: Duration,
+    already_expired: bool,
+}
+
+impl TtlTimer {
+    fn new(remaining: Duration) -> Self {
+        Self {
+            started_at: Instant::now(),
+            remaining,
+            already_expired: false,
+        }
+    }
+
+    fn from_submit_time(submit_time: SystemTime, ttl: Duration) -> Self {
+        // A submit timestamp from another host may be ahead of our wall clock. In that
+        // case, start with the full TTL rather than panicking or extending it by the skew.
+        let elapsed = SystemTime::now()
+            .duration_since(submit_time)
+            .unwrap_or_default();
+        Self {
+            started_at: Instant::now(),
+            remaining: ttl.saturating_sub(elapsed),
+            already_expired: elapsed > ttl,
+        }
+    }
+
+    fn is_expired(&self) -> bool {
+        self.already_expired
+            || Instant::now().saturating_duration_since(self.started_at) > self.remaining
+    }
+}
 
 /// Represents a key to a job. Needs to be hashable for routing properties. Additionally needs
 /// to be serializable for remote factories
@@ -44,7 +80,7 @@ pub trait JobKey: Debug + Hash + Send + Sync + Clone + Eq + PartialEq + 'static 
 impl<T: Debug + Hash + Send + Sync + Clone + Eq + PartialEq + 'static> JobKey for T {}
 
 /// Represents options for the specified job
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone)]
 pub struct JobOptions {
     /// Time job was submitted from the client
     submit_time: SystemTime,
@@ -54,6 +90,8 @@ pub struct JobOptions {
     worker_time: SystemTime,
     /// Time-to-live for the job
     ttl: Option<Duration>,
+    /// Monotonic timer used for TTL checks after the job enters this process.
+    ttl_timer: Option<TtlTimer>,
     /// The parent span we want to propagate to the worker.
     /// Spans don't propagate over the wire in networks
     span: Option<Span>,
@@ -78,11 +116,13 @@ impl JobOptions {
                 None
             }
         };
+        let submit_time = SystemTime::now();
         Self {
-            submit_time: SystemTime::now(),
+            submit_time,
             factory_time: SystemTime::now(),
             worker_time: SystemTime::now(),
             ttl,
+            ttl_timer: ttl.map(TtlTimer::new),
             span,
         }
     }
@@ -95,6 +135,7 @@ impl JobOptions {
     /// Set the TTL for this job
     pub fn set_ttl(&mut self, ttl: Option<Duration>) {
         self.ttl = ttl;
+        self.reset_ttl_timer();
     }
 
     /// Time the job was submitted to the factory
@@ -122,6 +163,34 @@ impl JobOptions {
 
     pub(crate) fn take_span(&mut self) -> Option<Span> {
         self.span.take()
+    }
+
+    fn reset_ttl_timer(&mut self) {
+        self.ttl_timer = self
+            .ttl
+            .map(|ttl| TtlTimer::from_submit_time(self.submit_time, ttl));
+    }
+}
+
+impl Debug for JobOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JobOptions")
+            .field("submit_time", &self.submit_time)
+            .field("factory_time", &self.factory_time)
+            .field("worker_time", &self.worker_time)
+            .field("ttl", &self.ttl)
+            .field("span", &self.span)
+            .finish()
+    }
+}
+
+impl PartialEq for JobOptions {
+    fn eq(&self, other: &Self) -> bool {
+        self.submit_time == other.submit_time
+            && self.factory_time == other.factory_time
+            && self.worker_time == other.worker_time
+            && self.ttl == other.ttl
+            && self.span == other.span
     }
 }
 
@@ -161,19 +230,23 @@ impl BytesConvertable for JobOptions {
         } else {
             let ttl_bytes = data.split_off(8);
 
-            let submit_time = u64::from_be_bytes(data.try_into().unwrap()); //Unwrap should be safe since we checked length earlier
+            let submit_time = u64::from_be_bytes(data.try_into().unwrap());
             let ttl = u64::from_be_bytes(ttl_bytes.try_into().unwrap());
 
-            Self {
+            let ttl = if ttl > 0 {
+                Some(Duration::from_nanos(ttl))
+            } else {
+                None
+            };
+            let mut options = Self {
                 submit_time: std::time::UNIX_EPOCH + Duration::from_nanos(submit_time),
-                ttl: if ttl > 0 {
-                    Some(Duration::from_nanos(ttl))
-                } else {
-                    None
-                },
+                ttl,
+                ttl_timer: None,
                 span: None,
                 ..Default::default()
-            }
+            };
+            options.reset_ttl_timer();
+            options
         }
     }
 }
@@ -369,11 +442,10 @@ where
     /// Expiration only takes effect prior to the job being
     /// started execution on a worker.
     pub fn is_expired(&self) -> bool {
-        if let Some(ttl) = self.options.ttl {
-            self.options.submit_time.elapsed().unwrap() > ttl
-        } else {
-            false
-        }
+        self.options
+            .ttl_timer
+            .as_ref()
+            .is_some_and(TtlTimer::is_expired)
     }
 
     /// Set the time the factory received the job
@@ -633,8 +705,42 @@ impl<TKey: JobKey, TMessage: Message> RetriableMessage<TKey, TMessage> {
     }
 }
 
-#[cfg(feature = "cluster")]
 #[cfg(test)]
+mod ttl_tests {
+    use super::*;
+
+    #[test]
+    fn future_submit_time_does_not_panic_or_extend_ttl_by_clock_skew() {
+        let mut options = JobOptions::new(Some(Duration::from_secs(1)));
+        options.submit_time = SystemTime::now()
+            .checked_add(Duration::from_secs(60))
+            .expect("test timestamp should be representable");
+        options.reset_ttl_timer();
+
+        let job = Job::with_options((), (), options);
+        assert!(!job.is_expired());
+
+        let timer = job
+            .options
+            .ttl_timer
+            .as_ref()
+            .expect("a configured TTL should have a monotonic timer");
+        assert_eq!(Duration::from_secs(1), timer.remaining);
+    }
+
+    #[test]
+    fn already_expired_wall_clock_ttl_stays_expired() {
+        let mut options = JobOptions::new(Some(Duration::from_secs(1)));
+        options.submit_time = SystemTime::now()
+            .checked_sub(Duration::from_secs(2))
+            .expect("test timestamp should be representable");
+        options.reset_ttl_timer();
+
+        assert!(Job::with_options((), (), options).is_expired());
+    }
+}
+
+#[cfg(all(feature = "cluster", test))]
 mod tests {
     use super::super::FactoryMessage;
     use super::Job;

--- a/ractor/src/thread_local.rs
+++ b/ractor/src/thread_local.rs
@@ -343,6 +343,14 @@ where
         <Self as SendActor>::post_start(self, myself, state).await
     }
 
+    async fn post_stop(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        <Self as SendActor>::post_stop(self, myself, state).await
+    }
+
     async fn handle(
         &self,
         myself: ActorRef<Self::Msg>,
@@ -378,8 +386,36 @@ struct SpawnArgs {
         dyn FnOnce() -> std::pin::Pin<Box<dyn Future<Output = Result<JoinHandle<()>, SpawnErr>>>>
             + Send,
     >,
-    reply: RpcReplyPort<JoinHandle<Result<JoinHandle<()>, SpawnErr>>>,
+    reply: RpcReplyPort<AbortOnDropHandle<Result<JoinHandle<()>, SpawnErr>>>,
     name: Option<String>,
+}
+
+struct AbortOnDropHandle<T> {
+    handle: Option<JoinHandle<T>>,
+}
+
+impl<T> AbortOnDropHandle<T> {
+    fn new(handle: JoinHandle<T>) -> Self {
+        Self {
+            handle: Some(handle),
+        }
+    }
+
+    fn handle_mut(&mut self) -> &mut JoinHandle<T> {
+        self.handle.as_mut().expect("task handle should be present")
+    }
+
+    fn disarm(&mut self) {
+        self.handle.take();
+    }
+}
+
+impl<T> Drop for AbortOnDropHandle<T> {
+    fn drop(&mut self) {
+        if let Some(handle) = &mut self.handle {
+            handle.abort();
+        }
+    }
 }
 
 /// The [ThreadLocalActorSpawner] is responsible for spawning [ThreadLocalActor] instances
@@ -434,13 +470,13 @@ impl ThreadLocalActorSpawner {
                             .name(name.unwrap_or_default().as_str())
                             .spawn_local(fut)
                             .expect("Tokio task spawn failed");
-                        _ = reply.send(handle);
+                        _ = reply.send(AbortOnDropHandle::new(handle));
                     }
                     #[cfg(not(tokio_unstable))]
                     {
                         _ = name;
                         let handle = crate::concurrency::spawn_local(fut);
-                        _ = reply.send(handle);
+                        _ = reply.send(AbortOnDropHandle::new(handle));
                     }
                 }
                 // If the while loop returns, then all the LocalSpawner
@@ -472,7 +508,7 @@ impl ThreadLocalActorSpawner {
                     let fut = builder();
                     _ = name;
                     let handle = crate::concurrency::spawn_local(fut);
-                    _ = reply.send(handle);
+                    _ = reply.send(AbortOnDropHandle::new(handle));
                 }
             }));
         });
@@ -494,7 +530,7 @@ impl ThreadLocalActorSpawner {
             {
                 let fut = builder();
                 let handle = crate::concurrency::spawn_local(fut);
-                _ = reply.send(handle);
+                _ = reply.send(AbortOnDropHandle::new(handle));
             }
         });
 
@@ -521,10 +557,11 @@ impl ThreadLocalActorSpawner {
         if self.send.send(args).is_err() {
             return Err(SpawnErr::StartupFailed("Spawner dead".into()));
         }
-        let rx_result = rx
+        let mut task = rx
             .await
-            .map_err(|inner| SpawnErr::StartupFailed(inner.into()))?
-            .await;
+            .map_err(|inner| SpawnErr::StartupFailed(inner.into()))?;
+        let rx_result = task.handle_mut().await;
+        task.disarm();
 
         #[cfg(not(feature = "async-std"))]
         {

--- a/ractor/src/thread_local/inner.rs
+++ b/ractor/src/thread_local/inner.rs
@@ -24,6 +24,7 @@ use crate::actor::actor_properties::ActorProperties;
 use crate::actor::actor_properties::MuxedMessage;
 use crate::actor::get_panic_string;
 use crate::actor::messages::StopMessage;
+use crate::actor::ActorLifecycleGuard;
 use crate::actor::ActorLoopResult;
 use crate::concurrency as mpsc;
 use crate::concurrency::JoinHandle;
@@ -126,6 +127,7 @@ where
     TActor: ThreadLocalActor,
 {
     actor_ref: ActorRef<TActor::Msg>,
+    lifecycle: ActorLifecycleGuard,
     id: ActorId,
     name: Option<String>,
 }
@@ -153,9 +155,11 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
             crate::actor::actor_cell::ActorCell::new_thread_local::<TActor>(name)?;
         let id = actor_cell.get_id();
         let name = actor_cell.get_name();
+        let lifecycle = ActorLifecycleGuard::new(actor_cell.clone());
         Ok((
             Self {
                 actor_ref: actor_cell.into(),
+                lifecycle,
                 id,
                 name,
             },
@@ -285,6 +289,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
 
         let Self {
             actor_ref,
+            mut lifecycle,
             id,
             name,
         } = self;
@@ -295,6 +300,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
         if let Some(sup) = &supervisor {
             actor_ref.link(sup.clone());
         }
+        lifecycle.set_supervisor(supervisor);
 
         // Generate the ActorRef which will be returned
         let spawn_name = name.clone();
@@ -308,21 +314,10 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
                 let result = Self::do_pre_start(actor_ref.clone(), &handler, startup_args).await;
                 let mut state = match result {
                     Ok(Ok(state)) => state,
-                    Ok(Err(e)) => {
-                        // cleanup supervision on pre_start failure
-                        if let Some(sup) = &supervisor {
-                            actor_ref.unlink(sup.clone());
-                        }
-                        return Err(SpawnErr::StartupFailed(e));
-                    }
-                    Err(e) => {
-                        // cleanup supervision on panic
-                        if let Some(sup) = &supervisor {
-                            actor_ref.unlink(sup.clone());
-                        }
-                        return Err(e);
-                    }
+                    Ok(Err(e)) => return Err(SpawnErr::StartupFailed(e)),
+                    Err(e) => return Err(e),
                 };
+                lifecycle.mark_running();
 
                 // run the processing loop, backgrounding the work
                 let handle = crate::concurrency::spawn_local(async move {
@@ -349,19 +344,7 @@ impl<TActor: ThreadLocalActor> ThreadLocalActorRuntime<TActor> {
                         },
                     };
 
-                    // terminate children
-                    myself.terminate();
-
-                    // notify supervisors of the actor's death
-                    myself.notify_supervisor_and_monitors(evt);
-
-                    // unlink superisors
-                    if let Some(sup) = supervisor {
-                        myself.unlink(sup);
-                    }
-
-                    // set status to stopped
-                    myself.set_status(ActorStatus::Stopped);
+                    lifecycle.finish(evt);
                 });
                 Ok(handle)
             }

--- a/ractor/src/thread_local/tests.rs
+++ b/ractor/src/thread_local/tests.rs
@@ -94,6 +94,40 @@ async fn test_error_on_start_captured() {
 }
 
 #[crate::concurrency::test]
+async fn cancelling_spawn_cleans_up_queued_thread_local_start() {
+    #[derive(Default)]
+    struct PendingActor;
+
+    impl Actor for PendingActor {
+        type Msg = EmptyMessage;
+        type Arguments = ();
+        type State = ();
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            std::future::pending().await
+        }
+    }
+
+    let actor_name = "cancelling_spawn_cleans_up_queued_thread_local_start".to_string();
+    let result = crate::concurrency::timeout(
+        Duration::from_millis(10),
+        PendingActor::spawn(Some(actor_name.clone()), (), get_spawner()),
+    )
+    .await;
+
+    assert!(result.is_err());
+    periodic_check(
+        || crate::registry::where_is(actor_name.clone()).is_none(),
+        Duration::from_secs(1),
+    )
+    .await;
+}
+
+#[crate::concurrency::test]
 #[cfg_attr(
     not(all(target_arch = "wasm32", target_os = "unknown")),
     tracing_test::traced_test
@@ -538,6 +572,53 @@ async fn actor_post_stop_executed_before_stop_and_wait_returns() {
 
     assert_eq!(1, signal.load(Ordering::SeqCst));
 
+    handle.await.unwrap();
+}
+
+#[crate::concurrency::test]
+#[cfg_attr(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    tracing_test::traced_test
+)]
+async fn send_actor_adapter_delegates_post_stop() {
+    #[derive(Default)]
+    struct TestActor;
+
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    impl crate::Actor for TestActor {
+        type Msg = EmptyMessage;
+        type Arguments = Arc<AtomicU8>;
+        type State = Arc<AtomicU8>;
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            args: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(args)
+        }
+
+        async fn post_stop(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            state: &mut Self::State,
+        ) -> Result<(), ActorProcessingErr> {
+            state.store(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    let signal = Arc::new(AtomicU8::new(0));
+    let (actor, handle) = crate::spawn_local::<TestActor>(signal.clone(), get_spawner())
+        .await
+        .expect("Failed to spawn adapted send actor");
+
+    actor
+        .stop_and_wait(None, None)
+        .await
+        .expect("Failed to stop adapted send actor");
+
+    assert_eq!(1, signal.load(Ordering::SeqCst));
     handle.await.unwrap();
 }
 

--- a/ractor/tests/actor_macros.rs
+++ b/ractor/tests/actor_macros.rs
@@ -427,6 +427,57 @@ where
     }
 }
 
+trait SelfQualifiedTypes {
+    type Payload;
+    type Reply;
+}
+
+#[derive(Clone, Copy)]
+struct SelfQualifiedActor;
+
+impl SelfQualifiedTypes for SelfQualifiedActor {
+    type Payload = u64;
+    type Reply = usize;
+}
+
+#[ractor::actor(
+    message = enum SelfQualifiedMessage,
+    state = u64,
+    crate_path = ::ractor,
+)]
+impl SelfQualifiedActor {
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<SelfQualifiedMessage>,
+        _arguments: (),
+    ) -> Result<u64, ActorProcessingErr> {
+        Ok(0)
+    }
+
+    #[ractor::message(Set(value))]
+    fn set(&self, value: Option<<Self as SelfQualifiedTypes>::Payload>, state: &mut u64) {
+        *state = value.unwrap_or_default();
+    }
+
+    #[ractor::message(ReplaceActor(replacement))]
+    fn replace_actor(&self, replacement: Self) {
+        let _ = replacement;
+    }
+
+    #[ractor::rpc(Read(reply))]
+    fn read(&self, state: &u64) -> Vec<<Self as SelfQualifiedTypes>::Reply> {
+        vec![*state as usize]
+    }
+
+    #[ractor::message(Stop)]
+    fn stop(&self, myself: ActorRef<SelfQualifiedMessage>) {
+        myself.stop(None);
+    }
+}
+
+#[cfg(feature = "cluster")]
+impl ractor::Message for SelfQualifiedMessage {}
+
 mod shadowed_prelude_names {
     use super::Actor;
 
@@ -754,6 +805,30 @@ fn generic_actor_impls_preserve_bounds() {
         value: String::new(),
         reply: reply.into(),
     };
+}
+
+#[ractor::concurrency::test]
+async fn generated_messages_rewrite_impl_self_types() {
+    let (actor, handle) = Actor::spawn(None, SelfQualifiedActor, ())
+        .await
+        .expect("self-qualified actor failed to start");
+
+    actor
+        .send_message(SelfQualifiedMessage::ReplaceActor(SelfQualifiedActor))
+        .expect("plain Self message failed");
+    actor
+        .send_message(SelfQualifiedMessage::Set(Some(42)))
+        .expect("qualified Self message failed");
+    let value =
+        ractor::call_t!(actor, SelfQualifiedMessage::Read, 100).expect("self-qualified RPC failed");
+    assert_eq!(value, vec![42]);
+
+    actor
+        .send_message(SelfQualifiedMessage::Stop)
+        .expect("self-qualified actor stop failed");
+    handle
+        .await
+        .expect("self-qualified actor failed to stop cleanly");
 }
 
 #[test]

--- a/ractor_macros/Cargo.toml
+++ b/ractor_macros/Cargo.toml
@@ -21,4 +21,4 @@ async-trait = []
 proc-macro-crate = "3"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2", features = ["full", "visit"] }
+syn = { version = "2", features = ["full", "visit", "visit-mut"] }

--- a/ractor_macros/src/expand.rs
+++ b/ractor_macros/src/expand.rs
@@ -11,6 +11,7 @@ use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream, Parser};
 use syn::spanned::Spanned;
 use syn::visit::Visit;
+use syn::visit_mut::VisitMut;
 use syn::{
     punctuated::Punctuated, Attribute, FieldPat, FnArg, ImplItem, ImplItemFn, ItemImpl, Member,
     Meta, Pat, PatIdent, Path, ReturnType, Signature, Token, Type, TypeReference, Visibility,
@@ -153,6 +154,9 @@ pub(crate) fn expand_actor(
 
     validate_unique_patterns(&dispatch_handlers, HandlerKind::Message)?;
     validate_unique_patterns(&supervision_handlers, HandlerKind::Supervision)?;
+    if matches!(&config.message, MessageConfig::Generated(_)) {
+        rewrite_impl_self_types(&mut dispatch_handlers, &actor_impl.self_ty)?;
+    }
 
     let has_pre_start = trait_methods
         .iter()
@@ -548,6 +552,182 @@ struct Handler {
     is_fallible: bool,
     rpc: Option<RpcHandler>,
     cfg_attributes: Vec<Attribute>,
+}
+
+fn rewrite_impl_self_types(handlers: &mut [Handler], self_ty: &Type) -> syn::Result<()> {
+    for handler in handlers {
+        for field_type in &mut handler.binding_types {
+            rewrite_impl_self_type(field_type, self_ty)?;
+        }
+        if let Some(rpc) = &mut handler.rpc {
+            rewrite_impl_self_type(&mut rpc.reply_type, self_ty)?;
+        }
+    }
+    Ok(())
+}
+
+fn rewrite_impl_self_type(ty: &mut Type, self_ty: &Type) -> syn::Result<()> {
+    fn self_token_span(tokens: TokenStream) -> Option<Span> {
+        tokens.into_iter().find_map(|token| match token {
+            proc_macro2::TokenTree::Ident(ident) if ident == "Self" => Some(ident.span()),
+            proc_macro2::TokenTree::Group(group) => self_token_span(group.stream()),
+            _ => None,
+        })
+    }
+
+    struct Rewriter<'a> {
+        self_ty: &'a Type,
+        error: Option<syn::Error>,
+    }
+
+    impl VisitMut for Rewriter<'_> {
+        fn visit_type_mut(&mut self, ty: &mut Type) {
+            if let Type::Verbatim(tokens) = ty {
+                if let Some(span) = self_token_span(tokens.clone()) {
+                    self.error = Some(syn::Error::new(
+                        span,
+                        "cannot rewrite `Self` inside opaque type syntax for a generated message; use the concrete actor type explicitly",
+                    ));
+                }
+                return;
+            }
+            let Type::Path(path) = ty else {
+                syn::visit_mut::visit_type_mut(self, ty);
+                return;
+            };
+            if path.qself.is_none()
+                && path.path.leading_colon.is_none()
+                && path.path.segments.len() == 1
+                && path.path.segments[0].ident == "Self"
+            {
+                *ty = self.self_ty.clone();
+                return;
+            }
+            syn::visit_mut::visit_type_mut(self, ty);
+        }
+
+        fn visit_path_mut(&mut self, path: &mut Path) {
+            if path.leading_colon.is_none()
+                && !path.segments.is_empty()
+                && path.segments[0].ident == "Self"
+            {
+                let Type::Path(concrete) = unparenthesized_type(self.self_ty) else {
+                    self.error = Some(syn::Error::new(
+                        path.segments[0].ident.span(),
+                        "cannot rewrite `Self::...` in a generated message type because the actor self type is not a path; use the concrete actor type explicitly",
+                    ));
+                    return;
+                };
+                if concrete.qself.is_some() {
+                    self.error = Some(syn::Error::new(
+                        path.segments[0].ident.span(),
+                        "cannot rewrite `Self::...` in a generated message type because the actor self type is qualified; use the concrete actor type explicitly",
+                    ));
+                    return;
+                }
+
+                let suffix = path.segments.iter().skip(1).cloned().collect::<Vec<_>>();
+                *path = concrete.path.clone();
+                for segment in &mut path.segments {
+                    if let syn::PathArguments::AngleBracketed(arguments) = &mut segment.arguments {
+                        arguments.colon2_token.get_or_insert_default();
+                    }
+                }
+                path.segments.extend(suffix);
+            }
+            syn::visit_mut::visit_path_mut(self, path);
+        }
+
+        fn visit_macro_mut(&mut self, node: &mut syn::Macro) {
+            syn::visit_mut::visit_macro_mut(self, node);
+            if let Some(span) = self_token_span(node.tokens.clone()) {
+                self.error = Some(syn::Error::new(
+                    span,
+                    "cannot rewrite `Self` inside a type macro for a generated message; use the concrete actor type explicitly",
+                ));
+            }
+        }
+    }
+
+    let mut rewriter = Rewriter {
+        self_ty,
+        error: None,
+    };
+    rewriter.visit_type_mut(ty);
+    rewriter.error.map_or(Ok(()), Err)
+}
+
+#[cfg(test)]
+mod impl_self_rewrite_tests {
+    use super::*;
+
+    fn assert_rewrite(input: Type, expected: Type) {
+        let mut actual = input;
+        let self_ty: Type = syn::parse_quote!(crate::ConcreteActor);
+        rewrite_impl_self_type(&mut actual, &self_ty).expect("Self type should be rewritable");
+        assert_eq!(
+            actual.to_token_stream().to_string(),
+            expected.to_token_stream().to_string()
+        );
+    }
+
+    #[test]
+    fn rewrites_nested_bare_and_qualified_self_types() {
+        assert_rewrite(
+            syn::parse_quote!(Option<(Self, <Self as Associated>::Value)>),
+            syn::parse_quote!(
+                Option<(
+                    crate::ConcreteActor,
+                    <crate::ConcreteActor as Associated>::Value
+                )>
+            ),
+        );
+    }
+
+    #[test]
+    fn rewrites_self_associated_paths() {
+        assert_rewrite(
+            syn::parse_quote!(Self::Associated),
+            syn::parse_quote!(crate::ConcreteActor::Associated),
+        );
+        assert_rewrite(
+            syn::parse_quote!([Self; Self::CAPACITY]),
+            syn::parse_quote!([crate::ConcreteActor; crate::ConcreteActor::CAPACITY]),
+        );
+    }
+
+    #[test]
+    fn uses_turbofish_for_generic_self_paths_in_const_expressions() {
+        let mut actual: Type = syn::parse_quote!([u8; Self::CAPACITY]);
+        let self_ty: Type = syn::parse_quote!(crate::GenericActor<T>);
+        rewrite_impl_self_type(&mut actual, &self_ty).expect("Self path should be rewritable");
+
+        let expected: Type = syn::parse_quote!([u8; crate::GenericActor::<T>::CAPACITY]);
+        assert_eq!(
+            actual.to_token_stream().to_string(),
+            expected.to_token_stream().to_string()
+        );
+    }
+
+    #[test]
+    fn rejects_self_associated_paths_for_non_path_actor_types() {
+        let mut ty: Type = syn::parse_quote!(Self::Associated);
+        let self_ty: Type = syn::parse_quote!((Actor,));
+        let error = rewrite_impl_self_type(&mut ty, &self_ty)
+            .expect_err("a non-path actor type cannot qualify an associated type");
+
+        assert!(error.to_string().contains("actor self type is not a path"));
+    }
+
+    #[test]
+    fn rejects_self_inside_type_macros() {
+        let mut ty: Type = syn::parse_quote!(wrapped!(Self));
+        let self_ty: Type = syn::parse_quote!(Actor);
+        let error = rewrite_impl_self_type(&mut ty, &self_ty)
+            .expect_err("Self tokens inside type macros cannot be rewritten safely");
+
+        assert!(error.to_string().contains("inside a type macro"));
+    }
 }
 
 fn parse_handler(


### PR DESCRIPTION
## Summary

Prepares the four published crates for `0.16.3` with the source-compatible fixes selected from the adversarial project audit.

This PR intentionally excludes every change that removes an impl, adds a public trait method, tightens a macro diagnostic into an error, or requires lockstep core/derive upgrades. Those changes remain in the stacked `0.17.0` PR, #466.

## Changes

### Cancellation-safe actor lifecycle

- Own lifecycle cleanup from actor-runtime construction so dropping even an unpolled start future unregisters the actor.
- Clean up status, registries, process groups, children, spawn-time supervision links, and waiters when a running task is cancelled.
- Make async-std task abortion effective while preserving the existing `abort(&mut self)` signature.
- Abort queued thread-local startup work when the requesting spawn future is cancelled.
- Clean up thread-local startup failures consistently.

### Factory TTL correctness

- Track TTL expiry with a local monotonic timer.
- Handle future remote timestamps and wall-clock rollback without panicking or extending TTL beyond its declared duration.
- Preserve the existing 16-byte job-options wire format and public API behavior.

### Thread-local adapter

- Forward `Actor::post_stop` through the blanket `ThreadLocalActor` adapter.

### Actor macros

- Rewrite impl-scoped `Self`, qualified `Self`, nested generic, and const-expression types to the concrete actor type in generated messages and RPC replies.
- Preserve existing accepted handler patterns; alias-equivalent duplicate-handler rejection remains in `0.17.0`.

### Release metadata

- Bump the published workspace crates to `0.16.3`.
- Require `ractor_macros 0.16.3` when the actor macro feature is enabled.

## Compatibility

- No public item is removed.
- No public method signature changes.
- No public trait gains a method.
- Existing cluster framing and job metadata remain wire-compatible.
- Existing macro handler patterns continue to compile.

## Validation

- `cargo test --workspace`
- Full async-std test suite
- Tokio and async-std cancellation regressions
- Actor macro native integration tests
- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`

Breaking follow-up and complete adversarial-audit backlog: #466.
