### PR TITLE
Prepare 0.16.4: compatible safety and reliability fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ resolver = "3"
 
 [workspace.package]
 rust-version = "1.85"
-version = "0.16.3"
+version = "0.16.4"

--- a/ractor/Cargo.toml
+++ b/ractor/Cargo.toml
@@ -45,7 +45,7 @@ strum = { version = "0.28", features = ["derive"] }
 # async-std feature 'unstable' is required for spawn_local: https://docs.rs/async-std/latest/async_std/task/fn.spawn_local.html
 async-std = { version = "1", features = ["attributes", "unstable"], optional = true }
 async-trait = { version = "0.1", optional = true }
-ractor_macros = { path = "../ractor_macros", version = "0.16.3", optional = true }
+ractor_macros = { path = "../ractor_macros", version = "0.16.4", optional = true }
 tokio = { version = "1", features = ["sync"] }
 tracing = { version = "0.1", features = ["attributes"] }
 

--- a/ractor/src/actor.rs
+++ b/ractor/src/actor.rs
@@ -1035,7 +1035,30 @@ where
         #[cfg(feature = "message_span_propogation")]
         let current_span_when_message_was_sent = msg.span.take();
 
-        // An error here will bubble up to terminate the actor
+        #[cfg(feature = "cluster")]
+        let typed_msg = if msg.serialized_msg.is_some() {
+            match std::panic::catch_unwind(AssertUnwindSafe(|| TActor::Msg::from_boxed(msg))) {
+                Ok(Ok(message)) => message,
+                Ok(Err(_)) => {
+                    tracing::debug!(
+                        "Dropping serialized message that actor {:?} could not decode",
+                        myself.get_id()
+                    );
+                    return Ok(());
+                }
+                Err(_) => {
+                    tracing::debug!(
+                        "Dropping serialized message whose decoder panicked for actor {:?}",
+                        myself.get_id()
+                    );
+                    return Ok(());
+                }
+            }
+        } else {
+            TActor::Msg::from_boxed(msg)?
+        };
+
+        #[cfg(not(feature = "cluster"))]
         let typed_msg = TActor::Msg::from_boxed(msg)?;
 
         #[cfg(feature = "message_span_propogation")]

--- a/ractor/src/actor/actor_cell.rs
+++ b/ractor/src/actor/actor_cell.rs
@@ -244,14 +244,16 @@ impl ActorCell {
             inner: Arc::new(props),
         };
 
-        #[cfg(feature = "cluster")]
-        {
-            // registry to the PID registry
-            crate::registry::pid_registry::register_pid(cell.get_id(), cell.clone())?;
+        if let Some(r_name) = &name {
+            crate::registry::register(r_name.clone(), cell.clone())?;
         }
 
-        if let Some(r_name) = name {
-            crate::registry::register(r_name, cell.clone())?;
+        #[cfg(feature = "cluster")]
+        if let Err(err) = crate::registry::pid_registry::register_pid(cell.get_id(), cell.clone()) {
+            if let Some(r_name) = &name {
+                crate::registry::unregister(r_name);
+            }
+            return Err(err.into());
         }
 
         Ok((

--- a/ractor/src/actor/actor_properties.rs
+++ b/ractor/src/actor/actor_properties.rs
@@ -209,9 +209,8 @@ impl ActorProperties {
 
     /// Start draining, and wait for the actor to exit
     pub(crate) async fn drain_and_wait(&self) -> Result<(), MessagingErr<()>> {
-        let rx = self.wait_handler.notified();
         self.drain()?;
-        rx.await;
+        self.wait().await;
         Ok(())
     }
 
@@ -254,16 +253,17 @@ impl ActorProperties {
         &self,
         reason: Option<String>,
     ) -> Result<(), MessagingErr<StopMessage>> {
-        let rx = self.wait_handler.notified();
         self.send_stop(reason)?;
-        rx.await;
+        self.wait().await;
         Ok(())
     }
 
     /// Wait for the actor to exit
     pub(crate) async fn wait(&self) {
-        let rx = self.wait_handler.notified();
-        rx.await;
+        let notified = self.wait_handler.notified();
+        if self.get_status() != ActorStatus::Stopped {
+            notified.await;
+        }
     }
 
     /// Send the kill signal, threading in a OneShot sender which notifies when the shutdown is completed
@@ -271,18 +271,14 @@ impl ActorProperties {
         &self,
         signal: Signal,
     ) -> Result<(), MessagingErr<()>> {
-        // first bind the wait handler
-        let rx = self.wait_handler.notified();
         let _ = self.send_signal(signal);
-        rx.await;
+        self.wait().await;
         Ok(())
     }
 
     pub(crate) fn notify_stop_listener(&self) {
         self.wait_handler.notify_waiters();
-        // make sure that any future caller immediately returns by pre-storing
-        // a notify permit (i.e. the actor stops, but you are only start waiting
-        // after the actor has already notified it's dead.)
+        // Preserve one permit for a waiter created after the actor stopped.
         self.wait_handler.notify_one();
     }
 }

--- a/ractor/src/actor/actor_ref.rs
+++ b/ractor/src/actor/actor_ref.rs
@@ -102,8 +102,7 @@ where
     ///
     /// Returns [Ok(())] on successful message send, [Err(MessagingErr)] otherwise
     pub fn send_message(&self, message: TMessage) -> Result<(), MessagingErr<TMessage>> {
-        // Use unchecked version - ActorRef<TMessage> provides compile-time type safety
-        self.inner.inner.send_message_unchecked::<TMessage>(message)
+        self.inner.send_message::<TMessage>(message)
     }
 
     // ========================== General Actor Operation Aliases ========================== //

--- a/ractor/src/actor/tests.rs
+++ b/ractor/src/actor/tests.rs
@@ -594,6 +594,83 @@ async fn test_serialized_cast() {
 }
 
 #[cfg(feature = "cluster")]
+#[crate::concurrency::test]
+async fn serialized_decode_failures_do_not_terminate_the_actor() {
+    use crate::message::BoxedDowncastErr;
+    use crate::message::SerializedMessage;
+    use crate::Message;
+
+    struct TestActor(Arc<AtomicU8>);
+    struct TestMessage;
+
+    impl Message for TestMessage {
+        fn serializable() -> bool {
+            true
+        }
+
+        fn deserialize(bytes: SerializedMessage) -> Result<Self, BoxedDowncastErr> {
+            match bytes {
+                SerializedMessage::Cast { variant, .. } if variant == "valid" => Ok(Self),
+                SerializedMessage::Cast { variant, .. } if variant == "panic" => {
+                    panic!("malformed decoder input")
+                }
+                _ => Err(BoxedDowncastErr),
+            }
+        }
+    }
+
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    impl Actor for TestActor {
+        type Msg = TestMessage;
+        type State = ();
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _: (),
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+
+        async fn handle(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _message: Self::Msg,
+            _state: &mut Self::State,
+        ) -> Result<(), ActorProcessingErr> {
+            self.0.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    let received = Arc::new(AtomicU8::new(0));
+    let (actor, handle) = Actor::spawn(None, TestActor(received.clone()), ())
+        .await
+        .unwrap();
+
+    for variant in ["error", "panic", "valid"] {
+        actor
+            .send_serialized(SerializedMessage::Cast {
+                variant: variant.to_string(),
+                args: vec![],
+                metadata: None,
+            })
+            .unwrap();
+    }
+
+    periodic_check(
+        || received.load(Ordering::Relaxed) == 1,
+        Duration::from_secs(2),
+    )
+    .await;
+    assert_eq!(actor.get_status(), ActorStatus::Running);
+
+    actor.stop(None);
+    handle.await.unwrap();
+}
+
+#[cfg(feature = "cluster")]
 fn port_forward<Tin, Tout, F>(
     typed_port: crate::RpcReplyPort<Tout>,
     converter: F,
@@ -1041,6 +1118,12 @@ async fn kill_and_wait() {
         .kill_and_wait(None)
         .await
         .expect("Failed to wait for actor death");
+    for _ in 0..2 {
+        actor
+            .kill_and_wait(Some(Duration::from_millis(100)))
+            .await
+            .expect("Repeated kill wait should observe the stopped actor");
+    }
     // the handle should be done and completed (after some brief scheduling delay)
     periodic_check(|| handle.is_finished(), Duration::from_millis(500)).await;
 }
@@ -1392,6 +1475,43 @@ async fn runtime_message_typing() {
 }
 
 #[crate::concurrency::test]
+async fn wrongly_typed_actor_ref_rejects_message_without_killing_actor() {
+    struct TestActor;
+
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    impl Actor for TestActor {
+        type Msg = EmptyMessage;
+        type Arguments = ();
+        type State = ();
+
+        async fn pre_start(
+            &self,
+            _this_actor: ActorRef<Self::Msg>,
+            _: (),
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+    }
+
+    let (actor, handle) = Actor::spawn(None, TestActor, ())
+        .await
+        .expect("Failed to start test actor");
+    let wrongly_typed: ActorRef<i64> = actor.get_cell().into();
+
+    assert!(matches!(
+        wrongly_typed.send_message(42),
+        Err(MessagingErr::InvalidActorType)
+    ));
+    assert!(actor.get_status() < ActorStatus::Stopping);
+    actor
+        .cast(EmptyMessage)
+        .expect("Correctly typed message should still be accepted");
+
+    actor.stop(None);
+    handle.await.unwrap();
+}
+
+#[crate::concurrency::test]
 #[cfg_attr(
     not(all(target_arch = "wasm32", target_os = "unknown")),
     tracing_test::traced_test
@@ -1427,12 +1547,22 @@ async fn wait_for_death() {
         .await
         .expect("Failed to start test actor");
 
-    actor.stop(None);
-    assert!(actor.wait(Some(Duration::from_millis(100))).await.is_ok());
-
-    // cleanup
-    actor.stop(None);
+    let stop_actor = actor.clone();
+    let (first_wait, second_wait, ()) = futures::join!(
+        actor.wait(Some(Duration::from_millis(100))),
+        actor.wait(Some(Duration::from_millis(100))),
+        async move {
+            crate::concurrency::sleep(Duration::from_millis(10)).await;
+            stop_actor.stop(None);
+        }
+    );
+    assert!(first_wait.is_ok());
+    assert!(second_wait.is_ok());
     handle.await.unwrap();
+
+    for _ in 0..3 {
+        assert!(actor.wait(Some(Duration::from_millis(100))).await.is_ok());
+    }
 }
 
 #[crate::concurrency::test]

--- a/ractor/src/factory/factoryimpl.rs
+++ b/ractor/src/factory/factoryimpl.rs
@@ -770,12 +770,20 @@ where
         let worker_availability = self
             .pool
             .values()
-            .filter(|worker| worker.is_available())
+            .filter(|worker| !worker.is_draining && worker.is_available())
             .count();
         match self.discard_settings.get_limit_and_mode() {
             Some((limit, _)) => {
-                // get the queue space and add it to the worker availability
-                let count = std::cmp::max(limit - self.queue.len(), 0) + worker_availability;
+                let queue_capacity = if self.router.is_factory_queueing() {
+                    limit.saturating_sub(self.queue.len())
+                } else {
+                    self.pool
+                        .values()
+                        .filter(|worker| !worker.is_draining)
+                        .map(|worker| limit.saturating_sub(worker.queued_job_count()))
+                        .fold(0usize, usize::saturating_add)
+                };
+                let count = worker_availability.saturating_add(queue_capacity);
                 let _ = reply.send(count);
             }
             None => {

--- a/ractor/src/factory/job.rs
+++ b/ractor/src/factory/job.rs
@@ -321,6 +321,9 @@ where
         maybe_bytes: Option<Vec<u8>>,
     ) -> Result<(TKey, JobOptions), BoxedDowncastErr> {
         if let Some(mut meta_bytes) = maybe_bytes {
+            if meta_bytes.len() < 16 {
+                return Err(BoxedDowncastErr);
+            }
             let key_bytes = meta_bytes.split_off(16);
             Ok((
                 TKey::from_bytes(key_bytes),
@@ -575,6 +578,11 @@ impl<TKey: JobKey, TMessage: Message> Drop for RetriableMessage<TKey, TMessage> 
             // can't do a retry if the factory and options are not available
             return;
         };
+        if factory.is_message_type_of::<FactoryMessage<TKey, Self>>() != Some(true) {
+            // RetriableMessage is local-only. Avoid consuming it in an invalid or remote
+            // send path, where the payload cannot be recovered and Drop would recurse.
+            return;
+        }
         // construct the new retriable message
         let msg = Self {
             key: self.key.clone(),
@@ -589,6 +597,11 @@ impl<TKey: JobKey, TMessage: Message> Drop for RetriableMessage<TKey, TMessage> 
             msg,
             options: options.clone(),
         };
+        if job.is_expired() {
+            let mut expired_job = job;
+            expired_job.msg.completed();
+            return;
+        }
         // Execute the custom retry hook, if provided
         if let Some(handler) = job.msg.retry_hook.as_ref() {
             let key = std::panic::AssertUnwindSafe(&job.key);
@@ -599,10 +612,17 @@ impl<TKey: JobKey, TMessage: Message> Drop for RetriableMessage<TKey, TMessage> 
             "A retriable job is being resubmitted to the factory. Number of retries left {:?}",
             self.strategy
         );
-        // SAFETY: A silent-drop here is OK should the dispatch to the factory fail. This is
-        // because if a worker died, it would be a silent drop anyways so there's no loss
-        // in functionality
-        _ = factory.cast(FactoryMessage::Dispatch(job));
+        let failed_job = match factory.cast(FactoryMessage::Dispatch(job)) {
+            Err(crate::MessagingErr::SendErr(FactoryMessage::Dispatch(failed_job))) => {
+                Some(failed_job)
+            }
+            _ => None,
+        };
+        if let Some(mut failed_job) = failed_job {
+            // The send error owns the job. Disarm it before dropping so a closed factory
+            // cannot recursively retry from this Drop implementation.
+            failed_job.msg.completed();
+        }
     }
 }
 
@@ -702,6 +722,127 @@ impl<TKey: JobKey, TMessage: Message> RetriableMessage<TKey, TMessage> {
     pub fn completed(&mut self) {
         self.strategy = MessageRetryStrategy::NoRetry;
         self.message = None;
+    }
+}
+
+#[cfg(test)]
+mod retry_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{Actor, ActorCell, ActorProcessingErr};
+
+    type RetryMessage = RetriableMessage<(), ()>;
+    type RetryFactoryMessage = FactoryMessage<(), RetryMessage>;
+
+    struct RetrySink;
+
+    struct WrongRetrySink;
+
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    impl Actor for RetrySink {
+        type Msg = RetryFactoryMessage;
+        type State = ();
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _args: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+    }
+
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    impl Actor for WrongRetrySink {
+        type Msg = ();
+        type State = ();
+        type Arguments = ();
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _args: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+    }
+
+    fn closed_factory() -> ActorRef<RetryFactoryMessage> {
+        let (actor, ports) =
+            ActorCell::new::<RetrySink>(None).expect("actor cell should be created");
+        drop(ports);
+        actor.into()
+    }
+
+    #[test]
+    fn failed_retry_send_is_disarmed_before_drop() {
+        let retry_count = Arc::new(AtomicUsize::new(0));
+        let mut job = RetriableMessage::from_job(
+            Job::new((), ()),
+            MessageRetryStrategy::RetryForever,
+            closed_factory(),
+        );
+        job.msg.set_retry_hook({
+            let retry_count = retry_count.clone();
+            move |_| {
+                retry_count.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        drop(job);
+
+        assert_eq!(1, retry_count.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn invalid_retry_target_is_rejected_before_consuming_the_job() {
+        let retry_count = Arc::new(AtomicUsize::new(0));
+        let (actor, _ports) =
+            ActorCell::new::<WrongRetrySink>(None).expect("actor cell should be created");
+        let invalid_factory: ActorRef<RetryFactoryMessage> = actor.into();
+        let mut job = RetriableMessage::from_job(
+            Job::new((), ()),
+            MessageRetryStrategy::RetryForever,
+            invalid_factory,
+        );
+        job.msg.set_retry_hook({
+            let retry_count = retry_count.clone();
+            move |_| {
+                retry_count.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        drop(job);
+
+        assert_eq!(0, retry_count.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn expired_message_is_not_retried() {
+        let retry_count = Arc::new(AtomicUsize::new(0));
+        let mut options = JobOptions::new(Some(Duration::from_secs(1)));
+        options.submit_time = SystemTime::now()
+            .checked_sub(Duration::from_secs(2))
+            .expect("test timestamp should be representable");
+        options.reset_ttl_timer();
+        let mut job = RetriableMessage::from_job(
+            Job::with_options((), (), options),
+            MessageRetryStrategy::RetryForever,
+            closed_factory(),
+        );
+        job.msg.set_retry_hook({
+            let retry_count = retry_count.clone();
+            move |_| {
+                retry_count.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        drop(job);
+
+        assert_eq!(0, retry_count.load(Ordering::Relaxed));
     }
 }
 
@@ -894,6 +1035,17 @@ mod tests {
         } else {
             panic!("Failed to deserialize the message payload");
         }
+    }
+
+    #[test]
+    fn short_job_metadata_is_rejected() {
+        let serialized = SerializedMessage::Cast {
+            variant: "A".to_string(),
+            args: String::new().into_bytes(),
+            metadata: Some(vec![0; 15]),
+        };
+
+        assert!(TheJob::deserialize(serialized).is_err());
     }
 
     #[test]

--- a/ractor/src/factory/ratelim.rs
+++ b/ractor/src/factory/ratelim.rs
@@ -107,7 +107,7 @@ pub struct LeakyBucketRateLimiter {
     /// The "balance" of the rate limiter, i.e. the number of tokens still available
     pub balance: usize,
     /// The deadline to perform another refill
-    deadline: Instant,
+    deadline: Option<Instant>,
 }
 
 #[bon::bon]
@@ -131,34 +131,42 @@ impl LeakyBucketRateLimiter {
             refill,
             interval,
             max,
-            balance: initial.unwrap_or(max),
-            deadline: Instant::now() + interval,
+            balance: initial.unwrap_or(max).min(max),
+            deadline: Instant::now().checked_add(interval),
         }
     }
 
     fn refresh(&mut self, now: Instant) {
-        if now < self.deadline {
+        let Some(deadline) = self.deadline else {
+            return;
+        };
+        if now < deadline {
             return;
         }
 
-        // Time elapsed in milliseconds since the last deadline.
-        let millis = self.interval.as_millis();
-        let since = now.saturating_duration_since(self.deadline).as_millis();
+        let interval_nanos = self.interval.as_nanos();
+        if interval_nanos == 0 {
+            self.balance = self.balance.saturating_add(self.refill).min(self.max);
+            self.deadline = Some(now);
+            return;
+        }
 
-        let periods = usize::try_from(since / millis + 1).unwrap_or(usize::MAX);
+        let since_nanos = now.saturating_duration_since(deadline).as_nanos();
 
-        let tokens = periods
-            .checked_mul(self.refill)
-            .unwrap_or(MAX_LB_BALANCE)
-            .min(MAX_LB_BALANCE);
+        let periods =
+            usize::try_from((since_nanos / interval_nanos).saturating_add(1)).unwrap_or(usize::MAX);
 
-        let remaining_millis_until_next_deadline =
-            u64::try_from(since % millis).unwrap_or(u64::MAX);
-        self.deadline = now
-            + self
-                .interval
-                .saturating_sub(Duration::from_millis(remaining_millis_until_next_deadline));
-        self.balance = (self.balance + tokens).min(self.max);
+        let tokens = periods.saturating_mul(self.refill).min(MAX_LB_BALANCE);
+
+        let nanos_since_last_period = since_nanos % interval_nanos;
+        let seconds = u64::try_from(nanos_since_last_period / 1_000_000_000).unwrap_or(u64::MAX);
+        let subsec_nanos =
+            u32::try_from(nanos_since_last_period % 1_000_000_000).unwrap_or(u32::MAX);
+        self.deadline = now.checked_add(
+            self.interval
+                .saturating_sub(Duration::new(seconds, subsec_nanos)),
+        );
+        self.balance = self.balance.saturating_add(tokens).min(self.max);
     }
 }
 
@@ -219,6 +227,55 @@ mod tests {
 
         assert!(limiter.check());
         limiter.bump();
+        assert!(!limiter.check());
+    }
+
+    #[test]
+    fn test_leaky_bucket_handles_zero_interval_and_saturates() {
+        let mut limiter = LeakyBucketRateLimiter::builder()
+            .refill(usize::MAX)
+            .initial(usize::MAX)
+            .interval(Duration::ZERO)
+            .max(2)
+            .build();
+
+        assert_eq!(2, limiter.balance);
+        limiter.bump();
+        assert!(limiter.check());
+        assert_eq!(2, limiter.balance);
+    }
+
+    #[test]
+    fn test_leaky_bucket_tracks_sub_millisecond_periods() {
+        let mut limiter = LeakyBucketRateLimiter::builder()
+            .refill(1)
+            .initial(0)
+            .interval(Duration::from_micros(500))
+            .max(10)
+            .build();
+        let first_deadline = limiter.deadline.expect("deadline should be representable");
+
+        limiter.refresh(first_deadline + Duration::from_micros(1_250));
+
+        assert_eq!(3, limiter.balance);
+        assert_eq!(
+            first_deadline + Duration::from_micros(1_500),
+            limiter
+                .deadline
+                .expect("deadline should remain representable")
+        );
+    }
+
+    #[test]
+    fn test_leaky_bucket_handles_unrepresentable_interval() {
+        let mut limiter = LeakyBucketRateLimiter::builder()
+            .refill(1)
+            .initial(0)
+            .interval(Duration::MAX)
+            .max(10)
+            .build();
+
+        assert!(limiter.deadline.is_none());
         assert!(!limiter.check());
     }
 }

--- a/ractor/src/factory/tests/basic.rs
+++ b/ractor/src/factory/tests/basic.rs
@@ -212,6 +212,81 @@ async fn test_dispatch_key_persistent() {
 }
 
 #[crate::concurrency::test]
+async fn test_zero_worker_queue_limit_preserves_direct_slot() {
+    struct TestDiscarder {
+        counter: Arc<AtomicU16>,
+    }
+
+    impl DiscardHandler<TestKey, TestMessage> for TestDiscarder {
+        fn discard(&self, reason: DiscardReason, _job: &mut Job<TestKey, TestMessage>) {
+            assert_eq!(DiscardReason::Loadshed, reason);
+            self.counter.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    for mode in [DiscardMode::Newest, DiscardMode::Oldest] {
+        let worker_counters: [_; NUM_TEST_WORKERS] = [
+            Arc::new(AtomicU16::new(0)),
+            Arc::new(AtomicU16::new(0)),
+            Arc::new(AtomicU16::new(0)),
+        ];
+        let discard_counter = Arc::new(AtomicU16::new(0));
+        let factory_definition = Factory::<
+            TestKey,
+            TestMessage,
+            (),
+            TestWorker,
+            routing::KeyPersistentRouting<TestKey, TestMessage>,
+            DefaultQueue,
+        >::default();
+        let (factory, factory_handle) = Actor::spawn(
+            None,
+            factory_definition,
+            FactoryArguments {
+                num_initial_workers: 1,
+                queue: DefaultQueue::default(),
+                router: Default::default(),
+                capacity_controller: None,
+                dead_mans_switch: None,
+                discard_handler: Some(Arc::new(TestDiscarder {
+                    counter: discard_counter.clone(),
+                })),
+                discard_settings: DiscardSettings::Static { limit: 0, mode },
+                lifecycle_hooks: None,
+                worker_builder: Box::new(SlowTestWorkerBuilder {
+                    counters: worker_counters.clone(),
+                }),
+                stats: None,
+            },
+        )
+        .await
+        .expect("Failed to spawn factory");
+
+        for _ in 0..2 {
+            factory
+                .cast(FactoryMessage::Dispatch(Job::new(
+                    TestKey { id: 0 },
+                    TestMessage::Ok,
+                )))
+                .expect("Failed to send to factory");
+        }
+
+        let handled = worker_counters[0].clone();
+        let discarded = discard_counter.clone();
+        periodic_check(
+            move || handled.load(Ordering::Relaxed) == 1 && discarded.load(Ordering::Relaxed) == 1,
+            Duration::from_secs(1),
+        )
+        .await;
+
+        factory.stop(None);
+        factory_handle.await.expect("factory should stop cleanly");
+        assert_eq!(1, worker_counters[0].load(Ordering::Relaxed));
+        assert_eq!(1, discard_counter.load(Ordering::Relaxed));
+    }
+}
+
+#[crate::concurrency::test]
 #[cfg_attr(
     not(all(target_arch = "wasm32", target_os = "unknown")),
     tracing_test::traced_test

--- a/ractor/src/factory/tests/ergonomics.rs
+++ b/ractor/src/factory/tests/ergonomics.rs
@@ -234,3 +234,110 @@ async fn one_way_helper_recovers_job_when_factory_is_stopped() {
         other => panic!("expected the failed job to be returned, got {other:?}"),
     }
 }
+
+#[crate::concurrency::test]
+async fn worker_queue_capacity_includes_each_workers_queue() {
+    let handled = Arc::new(AtomicUsize::new(0));
+    let definition = Factory::<
+        (),
+        TestMessage,
+        (),
+        TestWorker,
+        routing::KeyPersistentRouting<(), TestMessage>,
+        queues::DefaultQueue<(), TestMessage>,
+    >::default();
+    let arguments = FactoryArguments::builder()
+        .worker_builder(Box::new(worker_builder(move |_wid| {
+            (
+                TestWorker {
+                    handled: handled.clone(),
+                    generation: 1,
+                },
+                (),
+            )
+        })))
+        .num_initial_workers(2)
+        .router(routing::KeyPersistentRouting::default())
+        .queue(queues::DefaultQueue::default())
+        .discard_settings(DiscardSettings::Static {
+            limit: 3,
+            mode: DiscardMode::Newest,
+        })
+        .build();
+    let (factory, handle) = Actor::spawn(None, definition, arguments)
+        .await
+        .expect("factory should start");
+    let factory: FactoryRef<(), TestMessage> = factory;
+
+    assert_eq!(
+        CallResult::Success(8),
+        factory
+            .available_capacity(Some(Duration::from_secs(1)))
+            .await
+            .expect("capacity query should be sent")
+    );
+
+    factory.stop(None);
+    handle.await.expect("factory should stop cleanly");
+}
+
+#[crate::concurrency::test]
+async fn shared_queue_capacity_saturates_after_limit_reduction() {
+    let handled = Arc::new(AtomicUsize::new(0));
+    let definition = Factory::<
+        (),
+        TestMessage,
+        (),
+        TestWorker,
+        routing::QueuerRouting<(), TestMessage>,
+        queues::DefaultQueue<(), TestMessage>,
+    >::default();
+    let arguments = FactoryArguments::builder()
+        .worker_builder(Box::new(worker_builder({
+            let handled = handled.clone();
+            move |_wid| {
+                (
+                    TestWorker {
+                        handled: handled.clone(),
+                        generation: 1,
+                    },
+                    (),
+                )
+            }
+        })))
+        .num_initial_workers(1)
+        .router(routing::QueuerRouting::default())
+        .queue(queues::DefaultQueue::default())
+        .build();
+    let (factory, handle) = Actor::spawn(None, definition, arguments)
+        .await
+        .expect("factory should start");
+    let factory: FactoryRef<(), TestMessage> = factory;
+
+    for _ in 0..32 {
+        factory
+            .dispatch((), TestMessage::Increment)
+            .expect("message should be dispatched");
+    }
+    factory
+        .update_settings(
+            UpdateSettingsRequest::builder()
+                .discard_settings(DiscardSettings::Static {
+                    limit: 0,
+                    mode: DiscardMode::Newest,
+                })
+                .build(),
+        )
+        .expect("settings update should be sent");
+
+    assert_eq!(
+        CallResult::Success(0),
+        factory
+            .available_capacity(Some(Duration::from_secs(1)))
+            .await
+            .expect("capacity query should be sent")
+    );
+
+    factory.stop(None);
+    handle.await.expect("factory should stop cleanly");
+}

--- a/ractor/src/factory/worker.rs
+++ b/ractor/src/factory/worker.rs
@@ -700,6 +700,10 @@ where
         !self.is_available()
     }
 
+    pub(crate) fn queued_job_count(&self) -> usize {
+        self.message_queue.len()
+    }
+
     /// Denotes if the worker is stuck (i.e. unable to complete it's current job)
     pub(crate) fn is_stuck(&self, duration: Duration) -> bool {
         if self.heartbeat.is_stuck(duration) {
@@ -726,7 +730,7 @@ where
         self.stats.new_job(&self.factory_name);
 
         if let Some((limit, DiscardMode::Newest)) = self.discard_settings.get_limit_and_mode() {
-            if limit > 0 && self.message_queue.len() >= limit {
+            if !self.is_available() && self.message_queue.len() >= limit {
                 // Discard THIS job as it's the newest one
                 self.stats.job_discarded(&self.factory_name);
                 if let Some(handler) = &self.discard_handler {
@@ -755,7 +759,7 @@ where
 
         if let Some((limit, DiscardMode::Oldest)) = self.discard_settings.get_limit_and_mode() {
             // load-shed the OLDEST jobs
-            while limit > 0 && self.message_queue.len() > limit {
+            while self.message_queue.len() > limit {
                 if let Some(mut discarded) = self.get_next_non_expired_job() {
                     self.stats.job_discarded(&self.factory_name);
                     if let Some(handler) = &self.discard_handler {

--- a/ractor/src/pg.rs
+++ b/ractor/src/pg.rs
@@ -606,12 +606,15 @@ pub fn which_scopes_and_groups() -> Vec<ScopeGroupKey> {
 /// Returns a [`Vec<ScopeName>`] representing all the registered scopes
 pub fn which_scopes() -> Vec<ScopeName> {
     let monitor = get_monitor();
-    monitor
+    let mut scopes = monitor
         .map
         .iter()
         .filter(|kvp| !kvp.value().members.is_empty())
         .map(|kvp| kvp.key().scope.to_owned())
-        .collect::<Vec<_>>()
+        .collect::<Vec<_>>();
+    scopes.sort_unstable();
+    scopes.dedup();
+    scopes
 }
 
 /// Subscribes the provided [crate::Actor] to the group in the default scope
@@ -625,12 +628,19 @@ pub fn monitor(group: GroupName, actor: ActorCell) {
         group,
     };
     let monitor = get_monitor();
-    let relations = get_or_create_actor_relations(monitor, actor.get_id());
+    let actor_id = actor.get_id();
+    let relations = get_or_create_actor_relations(monitor, actor_id);
     let mut entry = monitor.map.entry(key.clone()).or_default();
     let mut relations_guard = lock_relations(&relations);
 
     if actor.get_status() <= ActorStatus::Draining {
-        entry.listeners.push(actor.clone());
+        if !entry
+            .listeners
+            .iter()
+            .any(|listener| listener.get_id() == actor_id)
+        {
+            entry.listeners.push(actor.clone());
+        }
         relations_guard.group_monitors.insert(key.clone());
     }
 
@@ -642,7 +652,7 @@ pub fn monitor(group: GroupName, actor: ActorCell) {
                 entry.remove();
             }
         }
-        remove_empty_actor_relations(monitor, actor.get_id(), &relations);
+        remove_empty_actor_relations(monitor, actor_id, &relations);
     }
 }
 
@@ -656,13 +666,16 @@ pub fn monitor_scope(scope: ScopeName, actor: ActorCell) {
         group: ALL_GROUPS_NOTIFICATION.to_owned(),
     };
     let monitor = get_monitor();
-    let relations = get_or_create_actor_relations(monitor, actor.get_id());
+    let actor_id = actor.get_id();
+    let relations = get_or_create_actor_relations(monitor, actor_id);
     let mut entry = monitor.world_listeners.entry(key.clone()).or_default();
     let mut relations_guard = lock_relations(&relations);
 
     if actor.get_status() <= ActorStatus::Draining {
         // Register ONLY in world_listeners (not per-group) to avoid duplicate notifications
-        entry.push(actor.clone());
+        if !entry.iter().any(|listener| listener.get_id() == actor_id) {
+            entry.push(actor.clone());
+        }
         relations_guard.world_monitors.insert(key.clone());
     }
 
@@ -674,7 +687,7 @@ pub fn monitor_scope(scope: ScopeName, actor: ActorCell) {
                 entry.remove();
             }
         }
-        remove_empty_actor_relations(monitor, actor.get_id(), &relations);
+        remove_empty_actor_relations(monitor, actor_id, &relations);
     }
 }
 

--- a/ractor/src/pg/tests.rs
+++ b/ractor/src/pg/tests.rs
@@ -118,6 +118,9 @@ async fn test_which_scopes_and_groups() {
     let scopes_and_groups = pg::which_scopes_and_groups();
     // println!("Scopes and groups are: {:#?}", scopes_and_groups);
     assert_eq!(4, scopes_and_groups.len());
+    let scopes = pg::which_scopes();
+    assert_eq!(1, scopes.iter().filter(|scope| *scope == &scope_a).count());
+    assert_eq!(1, scopes.iter().filter(|scope| *scope == &scope_b).count());
 
     // Cleanup
     actor.stop(None);
@@ -568,6 +571,7 @@ async fn test_pg_monitoring() {
             myself: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
+            pg::monitor(self.pg_group.clone(), myself.clone().into());
             pg::monitor(self.pg_group.clone(), myself.into());
             Ok(())
         }
@@ -683,6 +687,7 @@ async fn test_scope_monitoring() {
             myself: crate::ActorRef<Self::Msg>,
             _: (),
         ) -> Result<Self::State, ActorProcessingErr> {
+            pg::monitor_scope(self.scope.clone(), myself.clone().into());
             pg::monitor_scope(self.scope.clone(), myself.into());
             Ok(())
         }

--- a/ractor/src/port/output.rs
+++ b/ractor/src/port/output.rs
@@ -147,12 +147,18 @@ mod v1 {
             TReceiverMsg: Message,
         {
             let handle = crate::concurrency::spawn(async move {
-                while let Ok(Some(msg)) = port.recv().await {
-                    if let Some(new_msg) = converter(msg) {
-                        if receiver.cast(new_msg).is_err() {
-                            // kill the subscription process, as the forwarding agent is stopped
-                            return;
+                loop {
+                    match port.recv().await {
+                        Ok(Some(msg)) => {
+                            if let Some(new_msg) = converter(msg) {
+                                if receiver.cast(new_msg).is_err() {
+                                    // kill the subscription process, as the forwarding agent is stopped
+                                    return;
+                                }
+                            }
                         }
+                        Ok(None) | Err(pubsub::error::RecvError::Closed) => return,
+                        Err(pubsub::error::RecvError::Lagged(_)) => continue,
                     }
                 }
             });

--- a/ractor/src/port/output/tests.rs
+++ b/ractor/src/port/output/tests.rs
@@ -84,6 +84,80 @@ async fn test_single_forward() {
 }
 
 #[crate::concurrency::test]
+#[cfg(not(feature = "output-port-v2"))]
+async fn lagged_subscription_continues_forwarding() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Barrier};
+
+    struct TestActor;
+
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    impl Actor for TestActor {
+        type Msg = ();
+        type Arguments = ();
+        type State = ();
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+    }
+
+    let (actor, handle) = Actor::spawn(None, TestActor, ())
+        .await
+        .expect("failed to start test actor");
+    let output = Arc::new(OutputPort::<u32>::default());
+    let entered_converter = Arc::new(Barrier::new(2));
+    let release_converter = Arc::new(Barrier::new(2));
+    let delivered_after_lag = Arc::new(AtomicBool::new(false));
+
+    let converter_entered = entered_converter.clone();
+    let converter_release = release_converter.clone();
+    let converter_delivered = delivered_after_lag.clone();
+    output.subscribe(actor.clone(), move |message| {
+        if message == 0 {
+            converter_entered.wait();
+            converter_release.wait();
+        }
+        if message == u32::MAX {
+            converter_delivered.store(true, Ordering::SeqCst);
+        }
+        None
+    });
+
+    let producer_output = output.clone();
+    let producer_entered = entered_converter.clone();
+    let producer_release = release_converter.clone();
+    let producer = std::thread::spawn(move || {
+        producer_output.send(0);
+        producer_entered.wait();
+        for message in 1..=100 {
+            producer_output.send(message);
+        }
+        producer_output.send(u32::MAX);
+        producer_release.wait();
+    });
+
+    while !producer.is_finished() {
+        crate::concurrency::sleep(Duration::from_millis(1)).await;
+    }
+    producer.join().expect("producer thread should not panic");
+    timeout(Duration::from_secs(1), async {
+        while !delivered_after_lag.load(Ordering::SeqCst) {
+            crate::concurrency::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("subscriber should continue after reporting lag");
+
+    actor.stop(None);
+    handle.await.expect("actor should stop cleanly");
+}
+
+#[crate::concurrency::test]
 #[cfg_attr(
     not(all(target_arch = "wasm32", target_os = "unknown")),
     tracing_test::traced_test

--- a/ractor/src/port/output/tests.rs
+++ b/ractor/src/port/output/tests.rs
@@ -84,7 +84,10 @@ async fn test_single_forward() {
 }
 
 #[crate::concurrency::test]
-#[cfg(not(feature = "output-port-v2"))]
+#[cfg(all(
+    not(feature = "output-port-v2"),
+    not(all(target_arch = "wasm32", target_os = "unknown"))
+))]
 async fn lagged_subscription_continues_forwarding() {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Barrier};
@@ -145,6 +148,65 @@ async fn lagged_subscription_continues_forwarding() {
         crate::concurrency::sleep(Duration::from_millis(1)).await;
     }
     producer.join().expect("producer thread should not panic");
+    timeout(Duration::from_secs(1), async {
+        while !delivered_after_lag.load(Ordering::SeqCst) {
+            crate::concurrency::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("subscriber should continue after reporting lag");
+
+    actor.stop(None);
+    handle.await.expect("actor should stop cleanly");
+}
+
+#[crate::concurrency::test]
+#[cfg(all(
+    not(feature = "output-port-v2"),
+    target_arch = "wasm32",
+    target_os = "unknown"
+))]
+async fn lagged_subscription_continues_forwarding() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    struct TestActor;
+
+    #[cfg_attr(feature = "async-trait", crate::async_trait)]
+    impl Actor for TestActor {
+        type Msg = ();
+        type Arguments = ();
+        type State = ();
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+    }
+
+    let (actor, handle) = Actor::spawn(None, TestActor, ())
+        .await
+        .expect("failed to start test actor");
+    let output = OutputPort::<u32>::default();
+    let delivered_after_lag = Arc::new(AtomicBool::new(false));
+    let converter_delivered = delivered_after_lag.clone();
+    output.subscribe(actor.clone(), move |message| {
+        if message == u32::MAX {
+            converter_delivered.store(true, Ordering::SeqCst);
+        }
+        None
+    });
+
+    // The browser executor is single-threaded, so this burst fills the broadcast
+    // buffer before the subscription task can poll its receiver.
+    for message in 0..=100 {
+        output.send(message);
+    }
+    output.send(u32::MAX);
+
     timeout(Duration::from_secs(1), async {
         while !delivered_after_lag.load(Ordering::SeqCst) {
             crate::concurrency::sleep(Duration::from_millis(1)).await;

--- a/ractor/src/registry/tests.rs
+++ b/ractor/src/registry/tests.rs
@@ -96,6 +96,16 @@ async fn test_duplicate_registration() {
     // make sure the first actor is still registered
     assert!(crate::registry::where_is("my_second_actor".to_string()).is_some());
 
+    #[cfg(feature = "cluster")]
+    assert_eq!(
+        1,
+        crate::registry::get_all_pids()
+            .into_iter()
+            .filter(|cell| cell.get_name().as_deref() == Some("my_second_actor"))
+            .count(),
+        "the rejected actor must not remain in the PID registry"
+    );
+
     actor.stop(None);
     handle.await.expect("Failed to clean stop the actor");
 }

--- a/ractor/src/thread_local/inner.rs
+++ b/ractor/src/thread_local/inner.rs
@@ -57,14 +57,16 @@ impl ActorCell {
             inner: Arc::new(props),
         };
 
-        #[cfg(feature = "cluster")]
-        {
-            // registry to the PID registry
-            crate::registry::pid_registry::register_pid(cell.get_id(), cell.clone())?;
+        if let Some(r_name) = &name {
+            crate::registry::register(r_name.clone(), cell.clone())?;
         }
 
-        if let Some(r_name) = name {
-            crate::registry::register(r_name, cell.clone())?;
+        #[cfg(feature = "cluster")]
+        if let Err(err) = crate::registry::pid_registry::register_pid(cell.get_id(), cell.clone()) {
+            if let Some(r_name) = &name {
+                crate::registry::unregister(r_name);
+            }
+            return Err(err.into());
         }
 
         Ok((

--- a/ractor/src/thread_local/tests.rs
+++ b/ractor/src/thread_local/tests.rs
@@ -34,6 +34,46 @@ fn get_spawner() -> ThreadLocalActorSpawner {
         .clone()
 }
 
+#[test]
+#[cfg(feature = "cluster")]
+fn duplicate_thread_local_name_does_not_leak_pid() {
+    #[derive(Default)]
+    struct TestActor;
+
+    impl Actor for TestActor {
+        type Msg = ();
+        type Arguments = ();
+        type State = ();
+
+        async fn pre_start(
+            &self,
+            _myself: ActorRef<Self::Msg>,
+            _: Self::Arguments,
+        ) -> Result<Self::State, ActorProcessingErr> {
+            Ok(())
+        }
+    }
+
+    let name = "duplicate_thread_local_name_does_not_leak_pid".to_string();
+    let (actor, ports) = ActorCell::new_thread_local::<TestActor>(Some(name.clone()))
+        .expect("first actor should be constructed");
+
+    assert!(matches!(
+        ActorCell::new_thread_local::<TestActor>(Some(name.clone())),
+        Err(SpawnErr::ActorAlreadyRegistered(_))
+    ));
+    assert_eq!(
+        1,
+        crate::registry::get_all_pids()
+            .into_iter()
+            .filter(|cell| cell.get_name().as_deref() == Some(name.as_str()))
+            .count()
+    );
+
+    actor.set_status(ActorStatus::Stopped);
+    drop(ports);
+}
+
 struct EmptyMessage;
 #[cfg(feature = "cluster")]
 impl crate::Message for EmptyMessage {}

--- a/ractor_cluster/Cargo.toml
+++ b/ractor_cluster/Cargo.toml
@@ -30,8 +30,8 @@ prost-build = { version = "0.14" }
 bytes = { version = "1" }
 prost = { version = "0.14" }
 prost-types = { version = "0.14" }
-ractor = { version = "0.16.0", default-features = false, features = ["tokio_runtime", "cluster"], path = "../ractor" }
-ractor_cluster_derive = { version = "0.16.0", path = "../ractor_cluster_derive" }
+ractor = { version = "0.16.4", default-features = false, features = ["tokio_runtime", "cluster"], path = "../ractor" }
+ractor_cluster_derive = { version = "0.16.4", path = "../ractor_cluster_derive" }
 rand = "0.10"
 socket2 = { version = "0.6", features = ["all"] }
 sha2 = "0.11"

--- a/ractor_cluster/src/net/session.rs
+++ b/ractor_cluster/src/net/session.rs
@@ -28,28 +28,23 @@ use tokio::net::TcpStream;
 
 use crate::RactorMessage;
 
-/// Helper method to read exactly `len` bytes from the stream into a pre-allocated buffer
-/// of bytes
+const FRAME_READ_CHUNK_SIZE: usize = 8 * 1024;
+
+/// Helper method to read exactly `len` bytes while growing the payload only as data arrives.
 async fn read_n_bytes(stream: &mut ActorReadHalf, len: usize) -> Result<Vec<u8>, tokio::io::Error> {
     let mut buf = Vec::new();
-    buf.try_reserve_exact(len).map_err(|reserve_err| {
-        tokio::io::Error::new(
-            ErrorKind::InvalidData,
-            format!("cluster frame length {len} could not be allocated: {reserve_err}"),
-        )
-    })?;
-    buf.resize(len, 0);
-    let mut c_len = 0;
+    let mut chunk = [0u8; FRAME_READ_CHUNK_SIZE];
     if let ActorReadHalf::Regular(r) = stream {
         r.readable().await?;
     }
 
-    while c_len < len {
+    while buf.len() < len {
+        let read_len = (len - buf.len()).min(chunk.len());
         let n = match stream {
-            ActorReadHalf::ServerTls(t) => t.read(&mut buf[c_len..]).await?,
-            ActorReadHalf::ClientTls(t) => t.read(&mut buf[c_len..]).await?,
-            ActorReadHalf::Regular(t) => t.read(&mut buf[c_len..]).await?,
-            ActorReadHalf::External(t) => t.read(&mut buf[c_len..]).await?,
+            ActorReadHalf::ServerTls(t) => t.read(&mut chunk[..read_len]).await?,
+            ActorReadHalf::ClientTls(t) => t.read(&mut chunk[..read_len]).await?,
+            ActorReadHalf::Regular(t) => t.read(&mut chunk[..read_len]).await?,
+            ActorReadHalf::External(t) => t.read(&mut chunk[..read_len]).await?,
         };
         if n == 0 {
             // EOF
@@ -58,7 +53,13 @@ async fn read_n_bytes(stream: &mut ActorReadHalf, len: usize) -> Result<Vec<u8>,
                 "EOF",
             ));
         }
-        c_len += n;
+        buf.try_reserve(n).map_err(|reserve_err| {
+            tokio::io::Error::new(
+                ErrorKind::InvalidData,
+                format!("cluster frame payload could not be extended: {reserve_err}"),
+            )
+        })?;
+        buf.extend_from_slice(&chunk[..n]);
     }
     Ok(buf)
 }
@@ -383,6 +384,14 @@ fn checked_frame_length(length: u64, max_frame_size: u64) -> tokio::io::Result<u
         ));
     }
 
+    let max_vec_len = u64::try_from(isize::MAX).expect("isize::MAX always fits in u64");
+    if length > max_vec_len {
+        return Err(tokio::io::Error::new(
+            ErrorKind::InvalidData,
+            format!("cluster frame length {length} could not be allocated by a Vec"),
+        ));
+    }
+
     usize::try_from(length).map_err(|_| {
         tokio::io::Error::new(
             ErrorKind::InvalidData,
@@ -488,6 +497,8 @@ mod tests {
     use std::io::Cursor;
     use std::mem::size_of;
     use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
     use std::task::Context;
     use std::task::Poll;
 
@@ -519,6 +530,43 @@ mod tests {
         frame.extend_from_slice(&payload_len.to_be_bytes());
         frame.extend_from_slice(&payload);
         frame
+    }
+
+    struct IncrementalReader {
+        remaining: usize,
+        max_requested: Arc<AtomicUsize>,
+    }
+
+    impl AsyncRead for IncrementalReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<tokio::io::Result<()>> {
+            self.max_requested
+                .fetch_max(buf.remaining(), Ordering::Relaxed);
+            let count = self.remaining.min(buf.remaining()).min(1024);
+            let bytes = [7u8; 1024];
+            buf.put_slice(&bytes[..count]);
+            self.remaining -= count;
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn frame_payload_is_read_in_bounded_chunks() {
+        let len = FRAME_READ_CHUNK_SIZE * 3 + 1;
+        let max_requested = Arc::new(AtomicUsize::new(0));
+        let mut reader = ActorReadHalf::External(Box::new(IncrementalReader {
+            remaining: len,
+            max_requested: max_requested.clone(),
+        }));
+
+        let payload = read_n_bytes(&mut reader, len).await.unwrap();
+
+        assert_eq!(payload.len(), len);
+        assert!(payload.iter().all(|byte| *byte == 7));
+        assert!(max_requested.load(Ordering::Relaxed) <= FRAME_READ_CHUNK_SIZE);
     }
 
     #[test]

--- a/ractor_cluster/src/node.rs
+++ b/ractor_cluster/src/node.rs
@@ -746,8 +746,10 @@ impl Actor for NodeServer {
             }
             Self::Msg::GetSessions(reply) => {
                 let mut map = HashMap::new();
-                for value in state.node_sessions.values() {
-                    map.insert(value.node_id, value.clone());
+                for (actor_id, value) in &state.node_sessions {
+                    if state.authenticated_sessions.contains(actor_id) {
+                        map.insert(value.node_id, value.clone());
+                    }
                 }
                 let _ = reply.send(map);
             }
@@ -1295,6 +1297,29 @@ mod tests {
             is_server: connection.b_is_server,
         })
         .expect("node B connection should enqueue");
+    }
+
+    #[ractor::concurrency::test]
+    async fn unauthenticated_sessions_are_not_externally_visible() {
+        let nodes = TestNodes::spawn().await;
+        let stalled = connection("stalled", true);
+
+        nodes
+            .a
+            .cast(NodeServerMessage::ConnectionOpenedExternal {
+                stream: Box::new(stalled.a),
+                is_server: stalled.a_is_server,
+            })
+            .expect("stalled session should enqueue");
+
+        // This RPC is a mailbox barrier after the session was opened. Its peer
+        // remains connected but sends no authentication message.
+        let visible = ractor::call_t!(nodes.a, NodeServerMessage::GetSessions, 1_000)
+            .expect("session topology should be available");
+        assert!(visible.is_empty());
+
+        drop(stalled.b);
+        nodes.stop().await;
     }
 
     #[ractor::concurrency::test]

--- a/ractor_cluster/src/node/node_session.rs
+++ b/ractor_cluster/src/node/node_session.rs
@@ -41,6 +41,9 @@ use crate::NodeServerMessage;
 
 const MIN_PING_LATENCY_MS: u64 = 1000;
 const MAX_PING_LATENCY_MS: u64 = 5000;
+const MIN_PROTOBUF_TIMESTAMP_SECONDS: i64 = -62_135_596_800;
+const MAX_PROTOBUF_TIMESTAMP_SECONDS: i64 = 253_402_300_799;
+const NANOSECONDS_PER_SECOND: i32 = 1_000_000_000;
 
 #[cfg(test)]
 mod tests;
@@ -416,9 +419,7 @@ impl NodeSession {
         if let Some(msg) = message.msg {
             match msg {
                 node_protocol::node_message::Msg::Cast(cast_args) => {
-                    if let Some(actor) =
-                        ractor::registry::where_is_pid(ActorId::Local(cast_args.to))
-                    {
+                    if let Some(actor) = state.authorized_local_actor(cast_args.to) {
                         let _ = actor.send_serialized(SerializedMessage::Cast {
                             variant: cast_args.variant,
                             args: cast_args.what,
@@ -429,9 +430,7 @@ impl NodeSession {
                 node_protocol::node_message::Msg::Call(call_args) => {
                     let to = call_args.to;
                     let tag = call_args.tag;
-                    if let Some(actor) =
-                        ractor::registry::where_is_pid(ActorId::Local(call_args.to))
-                    {
+                    if let Some(actor) = state.authorized_local_actor(call_args.to) {
                         let (tx, rx) = ractor::concurrency::oneshot();
 
                         // send off the transmission in the serialized format, letting the message's own deserialization handle
@@ -573,25 +572,7 @@ impl NodeSession {
                     });
                 }
                 control_protocol::control_message::Msg::Pong(pong) => {
-                    let ts: std::time::SystemTime = pong
-                        .timestamp
-                        .expect("Timestamp missing in Pong")
-                        .try_into()
-                        .expect("Failed to convert Pong(Timestamp) to SystemTime");
-                    let inst = ts
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .expect("Time went backwards");
-                    let delta_ms = (state.epoch.elapsed() - inst).as_millis();
-                    tracing::debug!("Ping -> Pong took {delta_ms}ms");
-                    if delta_ms > 50 {
-                        tracing::warn!(
-                            "Super long ping detected {} - {} ({delta_ms}ms)",
-                            state.local_addr,
-                            state.peer_addr,
-                        );
-                    }
-                    // schedule next ping
-                    state.schedule_tcp_ping();
+                    state.handle_pong(pong);
                 }
                 control_protocol::control_message::Msg::PgJoin(join) => {
                     let mut cells = vec![];
@@ -728,7 +709,7 @@ impl NodeSession {
         );
 
         // startup the ping healthcheck activity
-        state.schedule_tcp_ping();
+        state.start_ping_loop();
 
         // trigger enumeration of the remote peer's node sessions for transitive connections
         if let NodeConnectionMode::Transitive = self.connection_mode {
@@ -753,6 +734,9 @@ impl NodeSession {
                 pid: a.get_id().pid(),
             })
             .collect::<Vec<_>>();
+        state
+            .advertised_local_pids
+            .extend(pids.iter().map(|actor| actor.pid));
         if !pids.is_empty() {
             let msg = control_protocol::ControlMessage {
                 msg: Some(control_protocol::control_message::Msg::Spawn(
@@ -840,21 +824,74 @@ impl NodeSession {
     }
 }
 
+#[derive(Debug)]
+struct AbortOnDropTask {
+    handle: Option<ractor::concurrency::JoinHandle<()>>,
+}
+
+impl AbortOnDropTask {
+    fn new(handle: ractor::concurrency::JoinHandle<()>) -> Self {
+        Self {
+            handle: Some(handle),
+        }
+    }
+
+    fn abort(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+impl Drop for AbortOnDropTask {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}
+
+#[derive(Debug, Default)]
+struct PongWarnings {
+    invalid: bool,
+    slow: bool,
+}
+
 /// The state of the node session
 #[derive(Debug)]
 pub struct NodeSessionState {
     tcp: Option<ActorRef<SessionMessage>>,
+    ping_task: Option<AbortOnDropTask>,
     peer_addr: SocketAddr,
     local_addr: SocketAddr,
     epoch: Instant,
+    pong_warnings: PongWarnings,
     name: Option<auth_protocol::NameMessage>,
     connection_id: u64,
     auth: AuthenticationState,
     ready: ReadyState,
     remote_actors: HashMap<u64, ActorRef<RemoteActorMessage>>,
+    advertised_local_pids: HashSet<u64>,
 }
 
 impl NodeSessionState {
+    fn authorized_local_actor(&mut self, pid: u64) -> Option<ractor::ActorCell> {
+        if !self.advertised_local_pids.contains(&pid) {
+            tracing::debug!("Rejected cluster message for unadvertised local PID {pid}");
+            return None;
+        }
+
+        let actor = ractor::registry::where_is_pid(ActorId::Local(pid));
+        if actor
+            .as_ref()
+            .is_some_and(ractor::ActorCell::supports_remoting)
+        {
+            actor
+        } else {
+            self.advertised_local_pids.remove(&pid);
+            tracing::debug!("Rejected cluster message for non-remotable local PID {pid}");
+            None
+        }
+    }
+
     fn is_tcp_actor(&self, actor: ActorId) -> bool {
         self.tcp
             .as_ref()
@@ -891,28 +928,96 @@ impl NodeSessionState {
         }
     }
 
-    fn schedule_tcp_ping(&self) {
-        let epoch = self.epoch;
-        if let Some(tcp) = &self.tcp {
-            #[allow(clippy::let_underscore_future)]
-            let _ = tcp.send_after(Self::get_send_delay(), move || {
-                let ping = control_protocol::ControlMessage {
-                    msg: Some(control_protocol::control_message::Msg::Ping(
-                        control_protocol::Ping {
-                            timestamp: Some(prost_types::Timestamp::from(
-                                SystemTime::UNIX_EPOCH + epoch.elapsed(),
-                            )),
-                        },
-                    )),
-                };
-                let net_msg = crate::protocol::NetworkMessage {
-                    message: Some(crate::protocol::meta::network_message::Message::Control(
-                        ping,
-                    )),
-                };
-                SessionMessage::Send(net_msg)
-            });
+    fn start_ping_loop(&mut self) {
+        self.start_ping_loop_with_delay(Self::get_send_delay);
+    }
+
+    fn start_ping_loop_with_delay<F>(&mut self, next_delay: F) -> bool
+    where
+        F: Fn() -> Duration + Send + 'static,
+    {
+        if self.ping_task.is_some() {
+            return false;
         }
+        let Some(tcp) = self.tcp.clone() else {
+            return false;
+        };
+
+        let epoch = self.epoch;
+        self.ping_task = Some(AbortOnDropTask::new(ractor::concurrency::spawn(
+            async move {
+                loop {
+                    ractor::concurrency::sleep(next_delay()).await;
+                    let ping = control_protocol::ControlMessage {
+                        msg: Some(control_protocol::control_message::Msg::Ping(
+                            control_protocol::Ping {
+                                timestamp: Some(prost_types::Timestamp::from(
+                                    SystemTime::UNIX_EPOCH + epoch.elapsed(),
+                                )),
+                            },
+                        )),
+                    };
+                    let net_msg = crate::protocol::NetworkMessage {
+                        message: Some(crate::protocol::meta::network_message::Message::Control(
+                            ping,
+                        )),
+                    };
+                    if tcp.cast(SessionMessage::Send(net_msg)).is_err() {
+                        break;
+                    }
+                }
+            },
+        )));
+        true
+    }
+
+    fn handle_pong(&mut self, pong: control_protocol::Pong) {
+        match self.pong_latency(pong.timestamp) {
+            Ok(delta) => {
+                let delta_ms = delta.as_millis();
+                tracing::debug!("Ping -> Pong took {delta_ms}ms");
+                if delta_ms > 50 && !self.pong_warnings.slow {
+                    tracing::warn!(
+                        "Slow ping detected {} - {} ({delta_ms}ms); further slow Pongs will only be logged at debug level",
+                        self.local_addr,
+                        self.peer_addr,
+                    );
+                    self.pong_warnings.slow = true;
+                }
+            }
+            Err(reason) if !self.pong_warnings.invalid => {
+                tracing::warn!(
+                    "Ignoring invalid Pong from {} to {}: {reason}; further invalid Pongs will be ignored",
+                    self.peer_addr,
+                    self.local_addr,
+                );
+                self.pong_warnings.invalid = true;
+            }
+            Err(_) => {}
+        }
+    }
+
+    fn pong_latency(
+        &self,
+        timestamp: Option<prost_types::Timestamp>,
+    ) -> Result<Duration, &'static str> {
+        let timestamp = timestamp.ok_or("timestamp is missing")?;
+        if !(MIN_PROTOBUF_TIMESTAMP_SECONDS..=MAX_PROTOBUF_TIMESTAMP_SECONDS)
+            .contains(&timestamp.seconds)
+            || !(0..NANOSECONDS_PER_SECOND).contains(&timestamp.nanos)
+        {
+            return Err("timestamp is outside the protobuf Timestamp range");
+        }
+        let timestamp: SystemTime = timestamp
+            .try_into()
+            .map_err(|_| "timestamp is out of range")?;
+        let sent_at = timestamp
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|_| "timestamp predates the Unix epoch")?;
+        self.epoch
+            .elapsed()
+            .checked_sub(sent_at)
+            .ok_or("timestamp is ahead of this session's clock")
     }
 
     fn get_send_delay() -> Duration {
@@ -946,6 +1051,7 @@ impl Actor for NodeSession {
 
         let state = Self::State {
             tcp: Some(actor),
+            ping_task: None,
             name: None,
             connection_id: self.connection_id,
             auth: if self.is_server {
@@ -955,9 +1061,11 @@ impl Actor for NodeSession {
             },
             ready: ReadyState::Open,
             remote_actors: HashMap::new(),
+            advertised_local_pids: HashSet::new(),
             peer_addr,
             local_addr,
             epoch: Instant::now(),
+            pong_warnings: PongWarnings::default(),
         };
 
         // If a client-connection, startup the handshake
@@ -975,8 +1083,11 @@ impl Actor for NodeSession {
     async fn post_stop(
         &self,
         myself: ActorRef<Self::Msg>,
-        _state: &mut Self::State,
+        state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
+        if let Some(mut ping_task) = state.ping_task.take() {
+            ping_task.abort();
+        }
         // unhook monitoring sessions
         ractor::pg::demonitor_scope(
             ractor::pg::ALL_SCOPES_NOTIFICATION.to_string(),
@@ -1188,6 +1299,7 @@ impl Actor for NodeSession {
             SupervisionEvent::PidLifecycleEvent(pid) => match pid {
                 PidLifecycleEvent::Spawn(who) => {
                     if who.supports_remoting() {
+                        state.advertised_local_pids.insert(who.get_id().pid());
                         let msg = control_protocol::ControlMessage {
                             msg: Some(control_protocol::control_message::Msg::Spawn(
                                 control_protocol::Spawn {
@@ -1203,6 +1315,7 @@ impl Actor for NodeSession {
                 }
                 PidLifecycleEvent::Terminate(who) => {
                     if who.supports_remoting() {
+                        state.advertised_local_pids.remove(&who.get_id().pid());
                         let msg = control_protocol::ControlMessage {
                             msg: Some(control_protocol::control_message::Msg::Terminate(
                                 control_protocol::Terminate {

--- a/ractor_cluster/src/node/node_session/tests.rs
+++ b/ractor_cluster/src/node/node_session/tests.rs
@@ -5,10 +5,12 @@
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Instant;
+use std::time::SystemTime;
 
 use ractor::concurrency::sleep;
 
@@ -82,6 +84,279 @@ impl Actor for DummyNodeSession {
     }
 }
 
+struct PingCounter {
+    pings: Arc<AtomicU8>,
+}
+
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+impl Actor for PingCounter {
+    type Msg = SessionMessage;
+    type State = ();
+    type Arguments = ();
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(())
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        if matches!(
+            message,
+            SessionMessage::Send(crate::protocol::NetworkMessage {
+                message: Some(crate::protocol::meta::network_message::Message::Control(
+                    control_protocol::ControlMessage {
+                        msg: Some(control_protocol::control_message::Msg::Ping(_)),
+                    },
+                )),
+            })
+        ) {
+            self.pings.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(())
+    }
+}
+
+fn authenticated_state(tcp: Option<ActorRef<SessionMessage>>) -> NodeSessionState {
+    NodeSessionState {
+        auth: AuthenticationState::AsClient(auth::ClientAuthenticationProcess::Ok),
+        ready: ReadyState::Open,
+        local_addr: SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0),
+        peer_addr: SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0),
+        name: None,
+        connection_id: 0,
+        remote_actors: HashMap::new(),
+        advertised_local_pids: HashSet::new(),
+        tcp,
+        ping_task: None,
+        epoch: Instant::now(),
+        pong_warnings: PongWarnings::default(),
+    }
+}
+
+#[test]
+fn malformed_pongs_are_ignored() {
+    let mut state = authenticated_state(None);
+    let future_timestamp = prost_types::Timestamp::from(
+        SystemTime::UNIX_EPOCH + state.epoch.elapsed() + Duration::from_secs(60),
+    );
+
+    for timestamp in [
+        None,
+        Some(prost_types::Timestamp {
+            seconds: 0,
+            nanos: 1_000_000_000,
+        }),
+        Some(prost_types::Timestamp {
+            seconds: -1,
+            nanos: 0,
+        }),
+        Some(future_timestamp),
+    ] {
+        assert!(state.pong_latency(timestamp.clone()).is_err());
+        state.handle_pong(control_protocol::Pong { timestamp });
+    }
+
+    assert!(state.pong_warnings.invalid);
+    assert!(state.ping_task.is_none());
+}
+
+#[ractor::concurrency::test]
+async fn ping_loop_is_single_and_aborted_with_session_state() {
+    let pings = Arc::new(AtomicU8::new(0));
+    let (tcp, tcp_handle) = Actor::spawn(
+        None,
+        PingCounter {
+            pings: pings.clone(),
+        },
+        (),
+    )
+    .await
+    .unwrap();
+    let mut state = authenticated_state(Some(tcp.clone()));
+    let task_capture = Arc::new(AtomicBool::new(false));
+    let weak_task_capture = Arc::downgrade(&task_capture);
+
+    assert!(state.start_ping_loop_with_delay(move || {
+        task_capture.store(true, Ordering::Relaxed);
+        Duration::from_millis(5)
+    }));
+    assert!(!state.start_ping_loop_with_delay(|| Duration::from_millis(1)));
+
+    ractor::concurrency::timeout(Duration::from_millis(250), async {
+        while pings.load(Ordering::Relaxed) < 2 {
+            sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .unwrap();
+
+    drop(state);
+    ractor::concurrency::timeout(Duration::from_millis(250), async {
+        while weak_task_capture.upgrade().is_some() {
+            sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .unwrap();
+
+    let final_count = pings.load(Ordering::Relaxed);
+    sleep(Duration::from_millis(20)).await;
+    assert_eq!(final_count, pings.load(Ordering::Relaxed));
+
+    tcp.stop(None);
+    tcp_handle.await.unwrap();
+}
+
+struct RemotableMessage;
+
+impl ractor::Message for RemotableMessage {
+    fn serializable() -> bool {
+        true
+    }
+
+    fn deserialize(message: SerializedMessage) -> Result<Self, ractor::message::BoxedDowncastErr> {
+        match message {
+            SerializedMessage::Cast { .. } | SerializedMessage::Call { .. } => Ok(Self),
+            SerializedMessage::CallReply(_, _) => Err(ractor::message::BoxedDowncastErr),
+        }
+    }
+}
+
+struct RemotableCounter {
+    received: Arc<AtomicU8>,
+}
+
+#[cfg_attr(feature = "async-trait", ractor::async_trait)]
+impl Actor for RemotableCounter {
+    type Msg = RemotableMessage;
+    type State = ();
+    type Arguments = ();
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _: (),
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(())
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _message: Self::Msg,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        self.received.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+#[ractor::concurrency::test]
+async fn inbound_messages_require_an_advertised_remotable_pid() {
+    let (server, server_handle) = Actor::spawn(None, DummyNodeServer, ()).await.unwrap();
+    let (session_actor, session_handle) = Actor::spawn(None, DummyNodeSession, ()).await.unwrap();
+    let received = Arc::new(AtomicU8::new(0));
+    let (target, target_handle) = Actor::spawn(
+        None,
+        RemotableCounter {
+            received: received.clone(),
+        },
+        (),
+    )
+    .await
+    .unwrap();
+    assert!(target.supports_remoting());
+
+    let session = NodeSession {
+        cookie: "cookie".to_string(),
+        is_server: true,
+        node_id: 1,
+        this_node_name: auth_protocol::NameMessage {
+            name: "myself".to_string(),
+            flags: Some(auth_protocol::NodeFlags { version: 1 }),
+            connection_string: "localhost:123".to_string(),
+            connection_id: 0,
+        },
+        node_server: server.get_cell().into(),
+        connection_mode: NodeConnectionMode::Isolated,
+        max_inbound_frame_size: super::super::DEFAULT_MAX_INBOUND_FRAME_SIZE,
+        connection_id: 0,
+    };
+    let mut state = authenticated_state(None);
+    let pid = target.get_id().pid();
+    let session_ref: ActorRef<NodeSessionMessage> = session_actor.get_cell().into();
+
+    session.handle_node(
+        &mut state,
+        node_protocol::NodeMessage {
+            msg: Some(node_protocol::node_message::Msg::Cast(
+                node_protocol::Cast {
+                    to: pid,
+                    what: vec![],
+                    variant: "Cast".to_string(),
+                    metadata: None,
+                },
+            )),
+        },
+        session_ref.clone(),
+    );
+    sleep(Duration::from_millis(20)).await;
+    assert_eq!(received.load(Ordering::Relaxed), 0);
+
+    state.advertised_local_pids.insert(pid);
+    session.handle_node(
+        &mut state,
+        node_protocol::NodeMessage {
+            msg: Some(node_protocol::node_message::Msg::Cast(
+                node_protocol::Cast {
+                    to: pid,
+                    what: vec![],
+                    variant: "Cast".to_string(),
+                    metadata: None,
+                },
+            )),
+        },
+        session_ref.clone(),
+    );
+    sleep(Duration::from_millis(20)).await;
+    assert_eq!(received.load(Ordering::Relaxed), 1);
+
+    state.advertised_local_pids.remove(&pid);
+    session.handle_node(
+        &mut state,
+        node_protocol::NodeMessage {
+            msg: Some(node_protocol::node_message::Msg::Call(
+                node_protocol::Call {
+                    to: pid,
+                    tag: 1,
+                    what: vec![],
+                    timeout_ms: Some(10),
+                    variant: "Call".to_string(),
+                    metadata: None,
+                },
+            )),
+        },
+        session_ref.clone(),
+    );
+    sleep(Duration::from_millis(20)).await;
+    assert_eq!(received.load(Ordering::Relaxed), 1);
+
+    target.stop(None);
+    server.stop(None);
+    session_actor.stop(None);
+    target_handle.await.unwrap();
+    server_handle.await.unwrap();
+    session_handle.await.unwrap();
+}
+
 #[ractor::concurrency::test]
 async fn node_sesison_client_auth_success() {
     let (dummy_server, dummy_shandle) = Actor::spawn(None, DummyNodeServer, ())
@@ -120,8 +395,11 @@ async fn node_sesison_client_auth_success() {
         name: None,
         connection_id: 0,
         remote_actors: HashMap::new(),
+        advertised_local_pids: HashSet::new(),
         tcp: None,
+        ping_task: None,
         epoch: Instant::now(),
+        pong_warnings: PongWarnings::default(),
     };
 
     // Client sends their name, Server responds with Ok
@@ -270,8 +548,11 @@ async fn node_session_client_auth_session_state_failures() {
         name: None,
         connection_id: 0,
         remote_actors: HashMap::new(),
+        advertised_local_pids: HashSet::new(),
         tcp: None,
+        ping_task: None,
         epoch: Instant::now(),
+        pong_warnings: PongWarnings::default(),
     };
 
     // Client sends their name, Server responds with Ok
@@ -405,8 +686,11 @@ async fn node_session_server_auth_success() {
         name: None,
         connection_id: 0,
         remote_actors: HashMap::new(),
+        advertised_local_pids: HashSet::new(),
         tcp: None,
+        ping_task: None,
         epoch: Instant::now(),
+        pong_warnings: PongWarnings::default(),
     };
 
     // Client sends their name
@@ -505,8 +789,11 @@ async fn node_session_server_auth_session_state_failures() {
         name: None,
         connection_id: 0,
         remote_actors: HashMap::new(),
+        advertised_local_pids: HashSet::new(),
         tcp: None,
+        ping_task: None,
         epoch: Instant::now(),
+        pong_warnings: PongWarnings::default(),
     };
 
     // Other session continues, this one dies
@@ -661,8 +948,11 @@ async fn node_session_handle_node_msg() {
         name: None,
         connection_id: 0,
         remote_actors: HashMap::new(),
+        advertised_local_pids: HashSet::new(),
         tcp: None,
+        ping_task: None,
         epoch: Instant::now(),
+        pong_warnings: PongWarnings::default(),
     };
     // add the "remote" actor
     state
@@ -763,8 +1053,11 @@ async fn node_session_handle_control() {
         name: None,
         connection_id: 0,
         remote_actors: HashMap::new(),
+        advertised_local_pids: HashSet::new(),
         tcp: None,
+        ping_task: None,
         epoch: Instant::now(),
+        pong_warnings: PongWarnings::default(),
     };
 
     // check spawn creates a remote actor

--- a/ractor_cluster/src/remote_actor.rs
+++ b/ractor_cluster/src/remote_actor.rs
@@ -7,7 +7,8 @@
 //! running on a remote `node()` server. See [crate::node::NodeServer] for more on inter-node
 //! protocols
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
+use std::ops::Bound::{Excluded, Unbounded};
 
 use ractor::cast;
 use ractor::concurrency::JoinHandle;
@@ -27,6 +28,9 @@ use crate::NodeId;
 
 #[cfg(test)]
 mod tests;
+
+/// Maximum number of pending requests inspected when handling a message.
+const PENDING_REQUEST_CLEANUP_BUDGET: usize = 16;
 
 /// A [RemoteActor] is an actor which represents an actor on another node
 ///
@@ -66,17 +70,83 @@ pub(crate) struct RemoteActorState {
     message_tag: u64,
     /// The map of <message_tag, serialized_rpc_reply> port for network
     /// handling of [SerializedMessage::CallReply]s
-    pending_requests: HashMap<u64, RpcReplyPort<Vec<u8>>>,
+    pending_requests: BTreeMap<u64, RpcReplyPort<Vec<u8>>>,
+    /// Last request inspected for cancellation.
+    pending_request_cleanup_cursor: Option<u64>,
 
     /// Owning session
     session: ActorRef<crate::node::NodeSessionMessage>,
 }
 
 impl RemoteActorState {
+    fn new(session: ActorRef<crate::node::NodeSessionMessage>) -> Self {
+        Self {
+            session,
+            message_tag: 0,
+            pending_requests: BTreeMap::new(),
+            pending_request_cleanup_cursor: None,
+        }
+    }
+
     /// Increment the message tag and return the "next" value
     fn get_and_increment_mtag(&mut self) -> u64 {
         self.message_tag += 1;
         self.message_tag
+    }
+
+    /// Incrementally reclaim reply ports whose receivers were cancelled or timed out.
+    fn cleanup_closed_pending_requests(&mut self) {
+        let cleanup_count = self
+            .pending_requests
+            .len()
+            .min(PENDING_REQUEST_CLEANUP_BUDGET);
+        if cleanup_count == 0 {
+            self.pending_request_cleanup_cursor = None;
+            return;
+        }
+
+        let mut tags = [0; PENDING_REQUEST_CLEANUP_BUDGET];
+        let mut tag_count = 0;
+
+        if let Some(cursor) = self.pending_request_cleanup_cursor {
+            for (&tag, _) in self
+                .pending_requests
+                .range((Excluded(cursor), Unbounded))
+                .take(cleanup_count)
+            {
+                tags[tag_count] = tag;
+                tag_count += 1;
+            }
+        }
+
+        for (&tag, _) in self.pending_requests.iter().take(cleanup_count - tag_count) {
+            tags[tag_count] = tag;
+            tag_count += 1;
+        }
+
+        for tag in &tags[..tag_count] {
+            if self
+                .pending_requests
+                .get(tag)
+                .is_some_and(RpcReplyPort::is_closed)
+            {
+                self.pending_requests.remove(tag);
+            }
+        }
+
+        self.pending_request_cleanup_cursor = if self.pending_requests.is_empty() {
+            None
+        } else {
+            tags[..tag_count].last().copied()
+        };
+    }
+
+    fn remove_pending_request(&mut self, message_tag: u64) -> Option<RpcReplyPort<Vec<u8>>> {
+        let port = self.pending_requests.remove(&message_tag);
+        if self.pending_requests.is_empty() {
+            self.pending_request_cleanup_cursor = None;
+        }
+        port
     }
 }
 
@@ -95,11 +165,7 @@ impl Actor for RemoteActor {
         _myself: ActorRef<Self::Msg>,
         session: ActorRef<crate::node::NodeSessionMessage>,
     ) -> Result<Self::State, ActorProcessingErr> {
-        Ok(Self::State {
-            session,
-            message_tag: 0,
-            pending_requests: HashMap::new(),
-        })
+        Ok(Self::State::new(session))
     }
 
     async fn handle(
@@ -117,6 +183,8 @@ impl Actor for RemoteActor {
         message: SerializedMessage,
         state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
+        state.cleanup_closed_pending_requests();
+
         // get the local pid on the remote system
         let to = myself.get_id().pid();
         // messages should be forwarded over the network link (i.e. sent through the node session) to the intended
@@ -144,7 +212,9 @@ impl Actor for RemoteActor {
                     )),
                 };
                 state.pending_requests.insert(tag, reply);
-                let _ = cast!(state.session, NodeSessionMessage::SendMessage(node_msg));
+                if cast!(state.session, NodeSessionMessage::SendMessage(node_msg)).is_err() {
+                    state.remove_pending_request(tag);
+                }
             }
             SerializedMessage::Cast {
                 args,
@@ -166,7 +236,7 @@ impl Actor for RemoteActor {
             }
             SerializedMessage::CallReply(message_tag, reply_data) => {
                 // Handle the reply to a "Call" message
-                if let Some(port) = state.pending_requests.remove(&message_tag) {
+                if let Some(port) = state.remove_pending_request(message_tag) {
                     let _ = port.send(reply_data);
                 }
             }

--- a/ractor_cluster/src/remote_actor/tests.rs
+++ b/ractor_cluster/src/remote_actor/tests.rs
@@ -40,11 +40,7 @@ async fn remote_actor_serialized_message_handling() {
         .expect("Failed to spawn remote actor");
 
     let remote_actor_instance = RemoteActor;
-    let mut remote_actor_state = RemoteActorState {
-        message_tag: 0,
-        pending_requests: HashMap::new(),
-        session: actor.clone(),
-    };
+    let mut remote_actor_state = RemoteActorState::new(actor.clone());
 
     // act & verify
     let bad_handler = remote_actor_instance
@@ -94,4 +90,82 @@ async fn remote_actor_serialized_message_handling() {
     actor.stop(None);
     remote_actor_handle.await.unwrap();
     handle.await.unwrap();
+}
+
+#[ractor::concurrency::test]
+async fn abandoned_requests_are_reclaimed_incrementally() {
+    let (session, session_handle) = FakeNodeSession::get_node_session().await;
+    let (remote_actor, remote_actor_handle) = Actor::spawn(None, RemoteActor, session.clone())
+        .await
+        .unwrap();
+    let mut state = RemoteActorState::new(session.clone());
+    let (reply, receiver) = ractor::concurrency::oneshot::<Vec<u8>>();
+    drop(receiver);
+
+    RemoteActor
+        .handle_serialized(
+            remote_actor.clone(),
+            SerializedMessage::Call {
+                variant: "Call".to_string(),
+                args: vec![],
+                reply: reply.into(),
+                metadata: None,
+            },
+            &mut state,
+        )
+        .await
+        .unwrap();
+    assert_eq!(state.pending_requests.len(), 1);
+
+    RemoteActor
+        .handle_serialized(
+            remote_actor.clone(),
+            SerializedMessage::Cast {
+                variant: "Cast".to_string(),
+                args: vec![],
+                metadata: None,
+            },
+            &mut state,
+        )
+        .await
+        .unwrap();
+    assert!(state.pending_requests.is_empty());
+
+    remote_actor.stop(None);
+    session.stop(None);
+    remote_actor_handle.await.unwrap();
+    session_handle.await.unwrap();
+}
+
+#[ractor::concurrency::test]
+async fn forwarding_failure_releases_the_reply_port() {
+    let (session, session_handle) = FakeNodeSession::get_node_session().await;
+    session.stop(None);
+    session_handle.await.unwrap();
+
+    let (remote_actor, remote_actor_handle) = Actor::spawn(None, RemoteActor, session.clone())
+        .await
+        .unwrap();
+    let mut state = RemoteActorState::new(session);
+    let (reply, receiver) = ractor::concurrency::oneshot::<Vec<u8>>();
+
+    RemoteActor
+        .handle_serialized(
+            remote_actor.clone(),
+            SerializedMessage::Call {
+                variant: "Call".to_string(),
+                args: vec![],
+                reply: reply.into(),
+                metadata: None,
+            },
+            &mut state,
+        )
+        .await
+        .unwrap();
+
+    assert!(state.pending_requests.is_empty());
+    assert!(receiver.await.is_err());
+
+    remote_actor.stop(None);
+    remote_actor_handle.await.unwrap();
 }

--- a/ractor_cluster_derive/src/codegen.rs
+++ b/ractor_cluster_derive/src/codegen.rs
@@ -207,7 +207,11 @@ fn gen_cast_deserialize_arm(variant: &ParsedVariant) -> impl ToTokens {
         };
         quote! {
             #variant_name => {
-                Ok(#construct)
+                if __args.is_empty() {
+                    Ok(#construct)
+                } else {
+                    Err(ractor::message::BoxedDowncastErr)
+                }
             }
         }
     } else {
@@ -221,7 +225,11 @@ fn gen_cast_deserialize_arm(variant: &ParsedVariant) -> impl ToTokens {
             #variant_name => {
                 let mut __ptr = 0usize;
                 #(#unpacked;)*
-                Ok(#construct)
+                if __ptr == __args.len() {
+                    Ok(#construct)
+                } else {
+                    Err(ractor::message::BoxedDowncastErr)
+                }
             }
         }
     }
@@ -264,8 +272,12 @@ fn gen_call_deserialize_arm(variant: &ParsedVariant) -> impl ToTokens {
     if fields.is_empty() {
         quote! {
             #variant_name => {
-                let __target_port = #target_port;
-                Ok(#construct)
+                if __args.is_empty() {
+                    let __target_port = #target_port;
+                    Ok(#construct)
+                } else {
+                    Err(ractor::message::BoxedDowncastErr)
+                }
             }
         }
     } else {
@@ -274,8 +286,12 @@ fn gen_call_deserialize_arm(variant: &ParsedVariant) -> impl ToTokens {
             #variant_name => {
                 let mut __ptr = 0usize;
                 #(#unpacked;)*
-                let __target_port = #target_port;
-                Ok(#construct)
+                if __ptr == __args.len() {
+                    let __target_port = #target_port;
+                    Ok(#construct)
+                } else {
+                    Err(ractor::message::BoxedDowncastErr)
+                }
             }
         }
     }
@@ -286,8 +302,15 @@ fn pack_args(field: &Ident, target_type: &syn::Type) -> impl ToTokens {
     quote! {
         {
             let __arg_data = <#target_type as ractor::BytesConvertable>::into_bytes(#field);
-            let __arg_len = (__arg_data.len() as u64).to_be_bytes();
-            __data.reserve(8 + __arg_data.len());
+            let __arg_len = <u64 as ::core::convert::TryFrom<usize>>::try_from(__arg_data.len())
+                .map_err(|_| ractor::message::BoxedDowncastErr)?
+                .to_be_bytes();
+            let __additional = ::core::mem::size_of::<u64>()
+                .checked_add(__arg_data.len())
+                .ok_or(ractor::message::BoxedDowncastErr)?;
+            __data
+                .try_reserve(__additional)
+                .map_err(|_| ractor::message::BoxedDowncastErr)?;
             __data.extend(__arg_len);
             __data.extend(__arg_data);
         }
@@ -298,14 +321,31 @@ fn pack_args(field: &Ident, target_type: &syn::Type) -> impl ToTokens {
 fn unpack_arg(field: &Ident, target_type: &syn::Type) -> impl ToTokens {
     quote! {
         let #field = {
+            let __len_end = __ptr
+                .checked_add(::core::mem::size_of::<u64>())
+                .ok_or(ractor::message::BoxedDowncastErr)?;
             let mut __len_bytes = [0u8; 8];
-            __len_bytes.copy_from_slice(&__args[__ptr..__ptr+8]);
-            let __len = u64::from_be_bytes(__len_bytes) as usize;
+            let __encoded_len = __args
+                .get(__ptr..__len_end)
+                .ok_or(ractor::message::BoxedDowncastErr)?;
+            __len_bytes.copy_from_slice(__encoded_len);
+            let __len = <usize as ::core::convert::TryFrom<u64>>::try_from(
+                u64::from_be_bytes(__len_bytes)
+            )
+                .map_err(|_| ractor::message::BoxedDowncastErr)?;
 
-            __ptr += 8;
-            let __data_bytes = __args[__ptr..__ptr+__len].to_vec();
-            let __t_result = <#target_type as ractor::BytesConvertable>::from_bytes(__data_bytes);
-            __ptr += __len;
+            let __data_end = __len_end
+                .checked_add(__len)
+                .ok_or(ractor::message::BoxedDowncastErr)?;
+            let __data_bytes = __args
+                .get(__len_end..__data_end)
+                .ok_or(ractor::message::BoxedDowncastErr)?
+                .to_vec();
+            let __t_result = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+                <#target_type as ractor::BytesConvertable>::from_bytes(__data_bytes)
+            }))
+                .map_err(|_| ractor::message::BoxedDowncastErr)?;
+            __ptr = __data_end;
             __t_result
         };
     }
@@ -316,7 +356,6 @@ fn gen_serialize_port(
     the_port: &Ident,
     target_type: &AngleBracketedGenericArguments,
 ) -> impl ToTokens {
-    // TODO: catch unwind for the conversion? returning Err(BoxedDowncastErr)
     let generic_args = &target_type.args;
     quote! {
         {
@@ -325,13 +364,23 @@ fn gen_serialize_port(
             ractor::concurrency::spawn(async move {
                 if let Some(timeout) = o_timeout {
                     if let Ok(Ok(result)) = ractor::concurrency::timeout(timeout, rx).await {
-                        let typed_result = <#generic_args as ractor::BytesConvertable>::from_bytes(result);
-                        let _ = #the_port.send(typed_result);
+                        if let Ok(typed_result) = ::std::panic::catch_unwind(
+                            ::std::panic::AssertUnwindSafe(|| {
+                                <#generic_args as ractor::BytesConvertable>::from_bytes(result)
+                            })
+                        ) {
+                            let _ = #the_port.send(typed_result);
+                        }
                     }
                 } else {
                     if let Ok(result) = rx.await {
-                        let typed_result = <#generic_args as ractor::BytesConvertable>::from_bytes(result);
-                        let _ = #the_port.send(typed_result);
+                        if let Ok(typed_result) = ::std::panic::catch_unwind(
+                            ::std::panic::AssertUnwindSafe(|| {
+                                <#generic_args as ractor::BytesConvertable>::from_bytes(result)
+                            })
+                        ) {
+                            let _ = #the_port.send(typed_result);
+                        }
                     }
                 }
             });
@@ -350,7 +399,6 @@ fn gen_deserialize_port(
     port_type: &AngleBracketedGenericArguments,
 ) -> impl ToTokens {
     let generic_args = &port_type.args;
-    // TODO: catch unwind for the conversion? returning Err(BoxedDowncastErr)
     quote! {
         {
             let (tx, rx) = ractor::concurrency::oneshot::#port_type();
@@ -358,11 +406,23 @@ fn gen_deserialize_port(
             ractor::concurrency::spawn(async move {
                 if let Some(timeout) = o_timeout {
                     if let Ok(Ok(result)) = ractor::concurrency::timeout(timeout, rx).await {
-                        let _ = #the_port.send(<#generic_args as BytesConvertable>::into_bytes(result));
+                        if let Ok(bytes) = ::std::panic::catch_unwind(
+                            ::std::panic::AssertUnwindSafe(|| {
+                                <#generic_args as BytesConvertable>::into_bytes(result)
+                            })
+                        ) {
+                            let _ = #the_port.send(bytes);
+                        }
                     }
                 } else {
                     if let Ok(result) = rx.await {
-                        let _ = #the_port.send(<#generic_args as BytesConvertable>::into_bytes(result));
+                        if let Ok(bytes) = ::std::panic::catch_unwind(
+                            ::std::panic::AssertUnwindSafe(|| {
+                                <#generic_args as BytesConvertable>::into_bytes(result)
+                            })
+                        ) {
+                            let _ = #the_port.send(bytes);
+                        }
                     }
                 }
             });

--- a/ractor_cluster_integration_tests/src/derive_macro_tests.rs
+++ b/ractor_cluster_integration_tests/src/derive_macro_tests.rs
@@ -56,6 +56,64 @@ fn test_serializable_generation() {
     assert!(matches!(TheMessage::deserialize(data), Ok(TheMessage::A)));
 }
 
+#[test]
+fn malformed_derived_framing_returns_an_error() {
+    #[derive(RactorClusterMessage)]
+    enum FramedMessage {
+        Empty,
+        Value(u32),
+    }
+
+    let cast = |variant: &str, args: Vec<u8>| SerializedMessage::Cast {
+        variant: variant.to_string(),
+        args,
+        metadata: None,
+    };
+
+    assert!(FramedMessage::deserialize(cast("Empty", vec![1])).is_err());
+    assert!(FramedMessage::deserialize(cast("Value", vec![0; 7])).is_err());
+    assert!(FramedMessage::deserialize(cast("Value", u64::MAX.to_be_bytes().to_vec())).is_err());
+
+    let mut truncated_value = 4u64.to_be_bytes().to_vec();
+    truncated_value.extend_from_slice(&[1, 2, 3]);
+    assert!(FramedMessage::deserialize(cast("Value", truncated_value)).is_err());
+
+    let mut decoder_panic = 0u64.to_be_bytes().to_vec();
+    assert!(FramedMessage::deserialize(cast("Value", decoder_panic.clone())).is_err());
+
+    decoder_panic.extend_from_slice(&[9]);
+    assert!(FramedMessage::deserialize(cast("Value", decoder_panic)).is_err());
+
+    let mut trailing_data = FramedMessage::Value(42).serialize().unwrap();
+    if let SerializedMessage::Cast { args, .. } = &mut trailing_data {
+        args.push(0);
+    }
+    assert!(FramedMessage::deserialize(trailing_data).is_err());
+}
+
+#[ractor::concurrency::test]
+async fn malformed_rpc_reply_closes_the_typed_reply_port() {
+    #[derive(RactorClusterMessage)]
+    enum RpcMessage {
+        #[rpc]
+        Request(RpcReplyPort<String>),
+    }
+
+    let (typed_tx, typed_rx) = ractor::concurrency::oneshot();
+    let serialized = RpcMessage::Request(typed_tx.into())
+        .serialize()
+        .expect("RPC message should serialize");
+    let SerializedMessage::Call { reply, .. } = serialized else {
+        panic!("RPC variant should serialize as a call");
+    };
+
+    reply
+        .send(vec![0xff])
+        .expect("malformed reply should reach the conversion bridge");
+
+    assert!(typed_rx.await.is_err());
+}
+
 #[ractor::concurrency::test]
 async fn test_complex_serializable_generation() {
     #[derive(RactorClusterMessage, Debug)]


### PR DESCRIPTION
## Summary

Prepares the four published crates for `0.16.4` with the next source- and wire-compatible safety/reliability fixes from the adversarial audit.

This is a separate follow-up to the merged #467. It contains no public trait methods, public enum changes, protocol schema changes, or cluster wire-format changes.

Audit source and remaining ranked backlog: [#466 review comment](https://github.com/slawlor/ractor/pull/466#issuecomment-5167735569).

## Changes

### Actor core

- Roll back named registration if cluster PID registration fails, for sendable and thread-local actors.
- Make actor waits repeatable and race-safe before, during, and after shutdown.
- Reject messages sent through a safely constructed but wrongly typed `ActorRef<T>` instead of terminating the target actor.
- Keep output-port-v1 subscriptions alive after broadcast lag.
- Return unique process-group scopes and make monitor registration idempotent.

### Factory correctness

- Prevent `RetriableMessage::drop` from recursively retrying expired jobs, closed factories, invalid actor types, or remote/non-serializable targets.
- Reject clustered job metadata shorter than the existing 16-byte options prefix.
- Enforce the documented zero worker-queue limit while preserving the idle worker's direct slot.
- Use saturating, router-aware available-capacity accounting.
- Make leaky-bucket refill arithmetic safe for zero, sub-millisecond, overflowing, and unrepresentable intervals.

### Cluster hardening

- Accept inbound Cast/Call traffic only for remotable local PIDs advertised to that authenticated session.
- Exclude unauthenticated sessions from topology enumeration.
- Grow inbound frame payloads incrementally instead of committing the advertised allocation before progress.
- Bounds-check derived field framing, reject trailing data, and contain panicking converters where unwinding is available.
- Drop malformed serialized messages without terminating the target actor, and contain malformed RPC reply conversion.
- Reclaim abandoned outbound RPC reply ports incrementally and immediately on forwarding failure.
- Replace Pong-driven timer multiplication with one session-owned periodic ping task and checked timestamp handling.

### Release metadata

- Bump the workspace crates and optional actor-macro dependency to `0.16.4`.
- Require `ractor` and `ractor_cluster_derive 0.16.4` from `ractor_cluster` so the security fixes cannot resolve partially.

## Compatibility

- Public signatures, traits, exhaustive enums, and valid cluster/job wire encodings are unchanged.
- Existing `0.16` peers continue to exchange valid messages.
- Inputs that previously panicked, killed an actor, targeted an unadvertised PID, or relied on malformed/trailing framing are now rejected or dropped.
- Typed local sends regain a runtime `TypeId` check to make the existing safe `ActorCell -> ActorRef<T>` conversion safe in practice; CI benchmarks should be reviewed for measurable impact.

Complete protection from arbitrary `BytesConvertable::from_bytes` implementations under `panic = "abort"` still requires the fallible public decode API planned for `0.17`.

## Validation

- `cargo test --workspace`
- Tokio default/no-default, async-trait, monitors, output-port-v2, and blanket-Serde configurations
- Async-std with span propagation and async-trait configurations
- Cluster native and async-trait configurations plus integration tests
- `cargo fmt --all`
- `cargo clippy --all -- -D clippy::all -D warnings`
